### PR TITLE
Added ttyASM* to serial device filter for SAM3U

### DIFF
--- a/software/chipwhisperer/common/utils/serialport.py
+++ b/software/chipwhisperer/common/utils/serialport.py
@@ -29,7 +29,7 @@ def scan():
               pass
       return available
     else:
-      return glob.glob('/dev/ttyS*') + glob.glob('/dev/ttyUSB*')
+      return glob.glob('/dev/ttyS*') + glob.glob('/dev/ttyACM*') + glob.glob('/dev/ttyUSB*')
 
 if __name__=='__main__':
     print ("Found ports:")


### PR DESCRIPTION
The SAM3U bootloader was assigned a device name of ttyASM0 when updating firmware using the supplied VMware machine.  This change allows this device to be listed among the other serial device options in the SAM3U Update Widget.
