### PR TITLE
FW: Fix `sizeafter` target for AVR

### DIFF
--- a/hardware/victims/firmware/hal/avr/Makefile.avr
+++ b/hardware/victims/firmware/hal/avr/Makefile.avr
@@ -11,6 +11,3 @@ OBJDUMP = avr-objdump
 SIZE = avr-size
 AR = avr-ar rcs
 NM = avr-nm
-
-#Fancy AVR Size formatting
-ELFSIZE = --mcu=$(MCU) --format=avr


### PR DESCRIPTION
The ELFSIZE definition in Makefile.avr breaks Makefile.inc's sizeafter target, which expects this to either be empty or fully defined.