### PR TITLE
Change path from ISE 14.6 to ISE 14.7 in python scripts.

### DIFF
--- a/hardware/capture/chipwhisperer-cw1200/hdl/generate_reconfig_dicts.py
+++ b/hardware/capture/chipwhisperer-cw1200/hdl/generate_reconfig_dicts.py
@@ -12,7 +12,7 @@ import pickle
 
 
 #Linux Path
-XILINX_DIR = "/opt/Xilinx/14.6/ISE_DS/ISE/bin/lin64/"
+XILINX_DIR = "/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/"
 DESIGN_BASE = "cw1200_ise/cw1200_interface"
 
 def cleanup():

--- a/hardware/capture/chipwhisperer-cw1200/hdl/validate_dcm_locations.py
+++ b/hardware/capture/chipwhisperer-cw1200/hdl/validate_dcm_locations.py
@@ -16,7 +16,7 @@ import sys
 #DESIGN_BASE = "cwlite_ise\\cwlite_interface"
 
 #Linux Path
-XILINX_DIR = "/opt/Xilinx/14.6/ISE_DS/ISE/bin/lin64/"
+XILINX_DIR = "/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/"
 DESIGN_BASE = "cw1200_ise/cw1200_interface"
 
 def decodeFARMIN(data, indx):

--- a/hardware/capture/chipwhisperer-lite/hdl/generate_reconfig_dicts.py
+++ b/hardware/capture/chipwhisperer-lite/hdl/generate_reconfig_dicts.py
@@ -16,7 +16,7 @@ import pickle
 #DESIGN_BASE = "cwlite_ise\\cwlite_interface"
 
 #Linux Path
-XILINX_DIR = "/opt/Xilinx/14.6/ISE_DS/ISE/bin/lin64/"
+XILINX_DIR = "/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/"
 DESIGN_BASE = "cwlite_ise/cwlite_interface"
 
 def cleanup():

--- a/hardware/capture/chipwhisperer-lite/hdl/old_long_reconfig_dicts.py
+++ b/hardware/capture/chipwhisperer-lite/hdl/old_long_reconfig_dicts.py
@@ -20,7 +20,7 @@ import sys
 #DESIGN_BASE = "cwlite_ise\\cwlite_interface"
 
 #Linux Path
-XILINX_DIR = "/opt/Xilinx/14.6/ISE_DS/ISE/bin/lin64/"
+XILINX_DIR = "/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/"
 #DESIGN_BASE = "cwlite_ise/cwlite_interface"
 
 def cleanup():

--- a/hardware/capture/chipwhisperer-lite/hdl/validate_dcm_locations.py
+++ b/hardware/capture/chipwhisperer-lite/hdl/validate_dcm_locations.py
@@ -16,7 +16,7 @@ import sys
 #DESIGN_BASE = "cwlite_ise\\cwlite_interface"
 
 #Linux Path
-XILINX_DIR = "/opt/Xilinx/14.6/ISE_DS/ISE/bin/lin64/"
+XILINX_DIR = "/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/"
 DESIGN_BASE = "cwlite_ise/cwlite_interface"
 
 def decodeFARMIN(data, indx):


### PR DESCRIPTION
The most recent (and most probably last) version of ISE is version 14.7 we
should therefore expect that version to be used. This commit changes the path
to point to the new location and was tested (to build) using the
chipwhisperer-lite.

I also found some .in file (also in the openadc repository that contained this version but decided against trying to change them