### PR TITLE
Add /dev/ttyACM* to serial port detection for bootloader mode

### DIFF
--- a/software/chipwhisperer/common/utils/serialport.py
+++ b/software/chipwhisperer/common/utils/serialport.py
@@ -29,7 +29,7 @@ def scan(max_range=256):
               pass
       return available
     else:
-      return glob.glob('/dev/ttyS*') + glob.glob('/dev/ttyUSB*')
+      return glob.glob('/dev/ttyS*') + glob.glob('/dev/ttyUSB*') + glob.glob('/dev/ttyACM*')
 
 if __name__=='__main__':
     print ("Found ports:")


### PR DESCRIPTION
Otherwise the serial port doesn't get listed in the widget once in bootloader mode.

E.g. on some Linux setups, SAMBA bootloader is seen as
kernel: usb 1-2.2: New USB device found, idVendor=03eb, idProduct=6124
kernel: usb 1-2.2: New USB device strings: Mfr=0, Product=0, SerialNumber=0
kernel: cdc_acm 1-2.2:1.0: ttyACM0: USB ACM device