### PR TITLE
Use vertical layout to split console and script runner.

### DIFF
--- a/software/chipwhisperer/common/ui/PythonConsole.py
+++ b/software/chipwhisperer/common/ui/PythonConsole.py
@@ -723,13 +723,11 @@ class QPythonScriptRunner(QtGui.QWidget):
 class QSplitConsole(QtGui.QSplitter):
     def __init__(self, parent=None, locals=None):
         super(QSplitConsole,self).__init__(parent)
+        self.setOrientation(QtCore.Qt.Vertical)
         self.console = QPythonConsole(parent, locals)
-        self.addWidget(self.console)
-
         self.script_runner = QPythonScriptRunner(self.console, parent)
         self.addWidget(self.script_runner)
-
-#        self.setLayout(QtGui.QHBoxLayout(self))
+        self.addWidget(self.console)
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
This change sets the orientation of the QSplitConsole to vertical
to give the console more horizontal screen estate.

![chipwhisperer capture v4 0 0 - default cwp_037](https://user-images.githubusercontent.com/22741063/33175264-7895e61e-d05b-11e7-9709-ab977d103998.png)
