### PR TITLE
Add missing entries in docs index

### DIFF
--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -38,6 +38,12 @@ Full Table of Contents:
     background
     installing
 
+    theory
+    newaedocs
+    tutorialsbasic
+    tutorialsadvanced
+    hardware
+
     fpgamain
     chipwhisperer
 


### PR DESCRIPTION
To get the same TOC for offline usage as in https://chipwhisperer.readthedocs.io/en/latest/index.html