### PR TITLE
Add support for masked AES implementations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "openadc"]
 	path = openadc
 	url = git://git.assembla.com/openadc.git
+[submodule "hardware/victims/firmware/crypto/secAES-ATmega8515"]
+	path = hardware/victims/firmware/crypto/secAES-ATmega8515
+	url = https://github.com/jmichelp/secAES-ATmega8515.git

--- a/hardware/victims/firmware/crypto/Makefile.crypto
+++ b/hardware/victims/firmware/crypto/Makefile.crypto
@@ -51,6 +51,9 @@ else ifeq ($(CRYPTO_TARGET),MBEDTLS)
 #
   include $(FIRMWAREPATH)/crypto/Makefile.mbedtls
 
+else ifeq ($(CRYPTO_TARGET),MASKEDAES)
+  include $(FIRMWAREPATH)/crypto/Makefile.maskedaes
+
 else ifeq ($(CRYPTO_TARGET),NONE)
   #Nothing to do :)
 

--- a/hardware/victims/firmware/crypto/Makefile.maskedaes
+++ b/hardware/victims/firmware/crypto/Makefile.maskedaes
@@ -1,0 +1,21 @@
+
+CRYPTO_LIB = secAES-ATmega8515/src
+SRC += aes-independant.c
+ASRC += maskedAES128enc.S
+EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
+CDEFS += -DMASKEDAES
+
+ifeq ($(CRYPTO_OPTIONS),VERSION1)
+ VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
+ EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
+
+else ifeq ($(CRYPTO_OPTIONS),VERSION2)
+ VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
+ EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
+
+else
+
+ $(error: Unknown or blank CRYPTO_OPTIONS: $(CRYPTO_OPTIONS). CRYPTO_OPTIONS is required for this CRYPTO_TARGET)
+endif #MASKEDAES
+
+

--- a/hardware/victims/firmware/crypto/aes-independant.c
+++ b/hardware/victims/firmware/crypto/aes-independant.c
@@ -37,6 +37,10 @@ void aes_indep_enc(uint8_t * pt)
     HW_AES128_Enc(pt);
 }
 
+void aes_indep_mask(uint8_t * m)
+{
+}
+
 #elif defined(AVRCRYPTOLIB)
 #include "aes128_enc.h"
 #include "aes_keyschedule.h"
@@ -56,6 +60,10 @@ void aes_indep_key(uint8_t * key)
 void aes_indep_enc(uint8_t * pt)
 {
 	aes128_enc(pt, &ctx); /* encrypting the data block */
+}
+
+void aes_indep_mask(uint8_t * m)
+{
 }
 
 #elif defined(SIMPLEAES)
@@ -80,6 +88,10 @@ void aes_indep_enc(uint8_t * pt)
 	for(uint8_t i=0; i < 16; i++){
 		pt[i] = result[i];
 	}
+}
+
+void aes_indep_mask(uint8_t * m)
+{
 }
 
 #elif defined(DPAV4)
@@ -112,6 +124,10 @@ void aes_indep_enc(uint8_t * pt)
 	aes256_enc(j, pt, &ctx, 1);
 }
 
+void aes_indep_mask(uint8_t * m)
+{
+}
+
 #elif defined(TINYAES128C)
 
 #include "aes.h"
@@ -133,6 +149,10 @@ void aes_indep_enc(uint8_t * pt)
 	AES128_ECB_indp_crypto(pt);
 }
 
+void aes_indep_mask(uint8_t * m)
+{
+}
+
 #elif defined(MBEDTLS)
 #include "mbedtls/aes.h"
 
@@ -152,6 +172,44 @@ void aes_indep_enc(uint8_t * pt)
 {
 	mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_ENCRYPT, pt, pt); /* encrypting the data block */
 }
+
+void aes_indep_mask(uint8_t * m)
+{
+}
+
+#elif defined(MASKEDAES)
+
+#include "aesTables.h"
+#include "maskedAES128enc.h"
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    secret[i] = key[i];
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  int i;
+  for (i = 0; i < AESInputSize; i++)
+    input[i] = pt[i];
+  asm_maskedAES128enc();
+  for (i = 0; i < AESOutputSize; i++)
+    pt[i] = input[i];
+}
+
+void aes_indep_mask(uint8_t * m)
+{
+  int i;
+  for (i = 0; i < AESMaskSize; i++)
+    mask[i] = m[i];
+}
+
 
 
 #else

--- a/hardware/victims/firmware/crypto/aes-independant.h
+++ b/hardware/victims/firmware/crypto/aes-independant.h
@@ -44,5 +44,6 @@
 void aes_indep_init(void);
 void aes_indep_key(uint8_t * key);
 void aes_indep_enc(uint8_t * pt);
+void aes_indep_mask(uint8_t * m);
 
 #endif

--- a/hardware/victims/firmware/simpleserial-aes/simpleserial-aes.c
+++ b/hardware/victims/firmware/simpleserial-aes/simpleserial-aes.c
@@ -22,6 +22,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+uint8_t get_mask(uint8_t* m)
+{
+  aes_indep_mask(m);
+  return 0x00;
+}
+
 uint8_t get_key(uint8_t* k)
 {
 	aes_indep_key(k);
@@ -67,6 +73,7 @@ int main(void)
     simpleserial_addcmd('k', 16, get_key);
     simpleserial_addcmd('p', 16,  get_pt);
     simpleserial_addcmd('x',  0,   reset);
+    simpleserial_addcmd('m', 18, get_mask);
     while(1)
         simpleserial_get();
 }

--- a/software/chipwhisperer/capture/targets/SimpleSerial.py
+++ b/software/chipwhisperer/capture/targets/SimpleSerial.py
@@ -92,7 +92,7 @@ class SimpleSerial(TargetTemplate, util.DisableNewAttr):
                 {'name':'Mask Supported', 'key':'maskenabled', 'type':'bool', 'get':self.getMaskEnabled, 'set':self.setMaskEnabled, 'linked':self._linkedmaskgroup, 'action':self.changeMaskEnabled},
                 {'name':'Mask Length (Bytes)', 'key':'masklen', 'type':'list', 'values':[18], 'default':18, 'get':self.maskLen, 'set':self.setMaskLen, 'visible':self.getMaskEnabled()},
                 {'name':'Load Mask Command', 'key':'cmdmask', 'type':'str', 'value':'m$MASK$\\n', 'visible':self.getMaskEnabled()},
-                {'name':'Mask', 'key':'masktype', 'type':'list', 'values':{'Random': False, 'Fixed': True}, 'get':self.getMaskType, 'set':self.setMaskType, 'visible':self.getMaskEnabled(), 'action':self.changeMaskType},
+                {'name':'Mask Type', 'key':'masktype', 'type':'list', 'values':{'Random': False, 'Fixed': True}, 'get':self.getMaskType, 'set':self.setMaskType, 'visible':self.getMaskEnabled(), 'action':self.changeMaskType},
                 {'name':'Fixed Mask', 'key':'initmask', 'type':'str', 'get':self.getInitialMask, 'set':self.setInitialMask, 'visible':self.getMaskEnabled() and self.getMaskType()},
                 {'name':'New Random Mask', 'key':'newmask', 'type':'action', 'action':self.newRandMask, 'visible':self.getMaskEnabled() and self.getMaskType()},
             ]},
@@ -499,8 +499,8 @@ class SimpleSerial(TargetTemplate, util.DisableNewAttr):
             self.runCommand(cmdmask)
 
     def newRandMask(self, _=None):
-        new_mask = ["%02X" % random.randint(0, 255) for _ in range(0, self.maskLen())]
-        self.setInitialMask(" ".join(new_mask))
+        new_mask = [random.randint(0, 255) for _ in range(self.maskLen())]
+        self._mask = bytearray(new_mask)
 
     def reinit(self):
         cmdmask = self.findParam(('maskgroup', 'cmdmask')).getValue()


### PR DESCRIPTION
Add support on the GUI, SimpleSerial target as well as firmware for NOTDUINO.
The AES implementation comes from ANSSI and exists in 2 flavors (version 1 and 2).
By default mask support is disabled so that standard targets works the same (tested on xmega, stm32f and notduino).
To compile the firmware:
```
make PLATFORM=CW304 CRYPTO_TARGET=MASKEDAES CRYPTO_OPTIONS=VERSION2
```