### PR TITLE
Fix exception because of missing attribute.

### DIFF
--- a/software/chipwhisperer/capture/auxiliary/FrequencyMeasure.py
+++ b/software/chipwhisperer/capture/auxiliary/FrequencyMeasure.py
@@ -97,6 +97,7 @@ class FrequencyMeasure(AuxiliaryTemplate):
     _name = "Frequency Counter"
 
     def __init__(self):
+        self.fm = None
         if ps5000a is not None:
             scope = ps5000a.PS5000a(connect=False)
             self.fm = FreqMeasure(scope)


### PR DESCRIPTION
When loading the plugin, there was an exception because of missing attribute. Simply fixed by creating the attribute in any case.