### PR TITLE
Add callback to allow GUIs to setup exit actions.

### DIFF
--- a/software/chipwhisperer/capture/ui/CWCaptureGUI.py
+++ b/software/chipwhisperer/capture/ui/CWCaptureGUI.py
@@ -242,6 +242,13 @@ class CWCaptureGUI(CWMainGUI):
             self.stopCaptureMAct.setEnabled(False)
         return ret
 
+    def beforeExit(self):
+        # Disconnected whatever is still connected before exiting
+        if self.targetStatus.defaultAction() == self.targetStatusActionCon:
+            self.api.disconnectTarget()
+        if self.scopeStatus.defaultAction() == self.scopeStatusActionCon:
+            self.api.disconnectScope()
+
     # Helpful properties for the Python console
     @property
     def scope(self):

--- a/software/chipwhisperer/common/ui/CWMainGUI.py
+++ b/software/chipwhisperer/common/ui/CWMainGUI.py
@@ -220,12 +220,21 @@ class CWMainGUI(QMainWindow):
         QSettings().setValue("geometry", self.saveGeometry())
         QSettings().setValue("windowState", self.saveState())
 
+    def beforeExit(self):
+        """Hook that can be inherited to do actions before the UI got closed."""
+        pass
+
     def closeEvent(self, event):
         """Called when window is closed, attempts to save state/geometry"""
         if not (hasattr(self, "dontSaveGeometry") and self.dontSaveGeometry):
             self.saveSettings()
 
         if self.okToContinue():
+            try:
+                self.beforeExit()
+            except:
+                # We don't want this callback to prevent us from exiting.
+                pass
             sys.excepthook = sys.__excepthook__  # Restore exception handlers
             sys.stdout = sys.__stdout__          # Restore print statements
             sys.stderr = sys.__stderr__


### PR DESCRIPTION
This patch provides a way for subclasses of CWMainGUI to be notified
that the GUI is about to close and let them do some cleaning before.
First use is for the Capture GUI to properly disconnect the scope and the
target.