### PR TITLE
Fix cw40 and serial

### DIFF
--- a/software/chipwhisperer/capture/targets/SimpleSerial.py
+++ b/software/chipwhisperer/capture/targets/SimpleSerial.py
@@ -366,17 +366,17 @@ class SimpleSerial(TargetTemplate, util.DisableNewAttr):
         Setter: Set a new baud rate. Valid baud rates are any integer in the
                 range [500, 2000000].
         """
-        if isinstance(self.ser, SimpleSerial_ChipWhispererLite):
+        if hasattr(self.ser, 'baud') and callable(self.ser.baud):
             return self.ser.baud()
         else:
-            raise AttributeError("Can't access baud rate unless using CW-Lite serial port")
+            raise AttributeError("Can't access baud rate")
 
     @baud.setter
     def baud(self, new_baud):
         if isinstance(self.ser, SimpleSerial_ChipWhispererLite):
             self.ser.setBaud(new_baud)
         else:
-            raise AttributeError("Can't access baud rate unless using CW-Lite serial port")
+            raise AttributeError("Can't access baud rate")
 
     @setupSetParam("Key Length (Bytes)")
     def setKeyLen(self, klen):

--- a/software/chipwhisperer/capture/targets/SimpleSerial.py
+++ b/software/chipwhisperer/capture/targets/SimpleSerial.py
@@ -373,7 +373,7 @@ class SimpleSerial(TargetTemplate, util.DisableNewAttr):
 
     @baud.setter
     def baud(self, new_baud):
-        if isinstance(self.ser, SimpleSerial_ChipWhispererLite):
+        if hasattr(self.ser, 'baud') and callable(self.ser.baud):
             self.ser.setBaud(new_baud)
         else:
             raise AttributeError("Can't access baud rate")


### PR DESCRIPTION
This set of commits implements the required methods to get/set baudrate and mimic the interface with CWLite. This way, we don't break the API v4 and we can display a target when using a sys_serial port instead of CWLite UART.