### PR TITLE
Remove window title does not contain '[*]' warning.

### DIFF
--- a/software/chipwhisperer/analyzer/ui/CWAnalyzerGUI.py
+++ b/software/chipwhisperer/analyzer/ui/CWAnalyzerGUI.py
@@ -143,7 +143,7 @@ class CWAnalyzerGUI(CWMainGUI):
         self._attackSettings = AttackSettings()
         self._preprocessSettings = PreprocessingSettings(api)
 
-        super(CWAnalyzerGUI, self).__init__(api, name="ChipWhisperer" + u"\u2122" + " Analyzer " + CWCoreAPI.__version__, icon="cwiconA")
+        super(CWAnalyzerGUI, self).__init__(api, name="ChipWhisperer" + u"\u2122" + " Analyzer " + CWCoreAPI.__version__ + "[*]", icon="cwiconA")
         #self.addExampleScripts(pluginmanager.getPluginsInDictFromPackage("chipwhisperer.analyzer.scripts", False, False, self))
         CWAnalyzerGUI.instance = self
 

--- a/software/chipwhisperer/capture/ui/CWCaptureGUI.py
+++ b/software/chipwhisperer/capture/ui/CWCaptureGUI.py
@@ -39,7 +39,7 @@ from chipwhisperer.common.utils.tracesource import ActiveTraceObserver
 
 class CWCaptureGUI(CWMainGUI):
     def __init__(self, api):
-        super(CWCaptureGUI, self).__init__(api, name=("ChipWhisperer" + u"\u2122" + " Capture " + CWCoreAPI.__version__), icon="cwiconC")
+        super(CWCaptureGUI, self).__init__(api, name=("ChipWhisperer" + u"\u2122" + " Capture " + CWCoreAPI.__version__ + "[*]"), icon="cwiconC")
         # TODO: replace scripts with an info box about the new script system
         #self.addExampleScripts(pluginmanager.getPluginsInDictFromPackage("chipwhisperer.capture.scripts", False, False, self))
 


### PR DESCRIPTION
During startup of chipwhisperer-ana and chipwhisperer-cap the warning
QWidget::setWindowModified: The window title does not contain a '[*]' placeholder
warning is shown.

This patch adds [*] to the end of the window title and removes the
warning. Tested under Linux