### PR TITLE
added prefix to traces filename to match default expectations.

### DIFF
--- a/software/chipwhisperer/common/api/TraceManager.py
+++ b/software/chipwhisperer/common/api/TraceManager.py
@@ -73,7 +73,7 @@ class TraceManager(TraceSource):
             config[self.name]['enabled%d' % indx] = str(t.enabled)
 
             # did that actually save anything? ^^^
-            t.saveAllTraces(os.path.dirname(t.config.configFilename())) #actually saving stuff now?
+            t.saveAllTraces(os.path.dirname(t.config.configFilename()), prefix) #actually saving stuff now?
         self.dirty.setValue(False)
         self.saved = True
 


### PR DESCRIPTION
hi.

this change fixes some tutorials which capture samples for DPA like attacks. please review the change - it looks like a typo originally.

-- 