### PR TITLE
Project Create/Load behavior

### DIFF
--- a/software/chipwhisperer/__init__.py
+++ b/software/chipwhisperer/__init__.py
@@ -63,8 +63,6 @@ def open_project(filename):
        OSError: filename does not exist.
     """
     from chipwhisperer.common.api import ProjectFormat as project
-    if not os.path.isfile(filename):
-        raise OSError("File " + filename + " does not exist or is not a file")
     proj = project.Project()
     proj.load(filename)
     return proj

--- a/software/chipwhisperer/__init__.py
+++ b/software/chipwhisperer/__init__.py
@@ -94,6 +94,9 @@ def create_project(filename, overwrite=False):
     if os.path.isfile(filename) and (overwrite == False):
         raise OSError("File " + filename + " already exists")
 
+    # If the user gives a relative path including ~, expand to the absolute path
+    filename = os.path.expanduser(filename)
+
     if not os.path.isabs(filename):
         filename = os.path.join(PROJECT_DIR, filename)
 

--- a/software/chipwhisperer/common/api/ProjectFormat.py
+++ b/software/chipwhisperer/common/api/ProjectFormat.py
@@ -296,7 +296,10 @@ class Project(Parameterized):
 
     def load(self, f = None):
         if f is not None:
-            self.setFilename(f)
+            self.setFilename(os.path.expanduser(f))
+
+        if not os.path.isabs(self.filename):
+            self.setFilename(os.path.join(PROJECT_DIR, self.filename))
 
         if not os.path.isfile(self.filename):
             raise IOError("File " + self.filename + " does not exist or is not a file")


### PR DESCRIPTION
Hello again,

I noticed that the project creation/load behavior changed over the last few days to automatically use the PROJECT_DIR location for the project if the path isn't an absolute path. However, this has some non-intuitive behavior when the user-specified path has `~` as a component. Typically, the user would expect this to expand to their home directory, however, this is just treated as a relative path and results in paths like `/home/nausicaa/chipwhisperer/projects/~/Documents/Chipwhisperer/jupyter/projects/tvla_avr_project.cwp`. This pull request fixes this by calling `os.path.expanduser` on the filename before checking if it is an absolute path. This expands the `~` into an absolute path, thus allowing it to behave as an absolute path.

Also, the default project location was not added to the corresponding `project.load()` method, so this pull request adds that, along with similar path expansion for user home directories.