### PR TITLE
Fix some issues with documentation build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,10 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line.
-SPHINXOPTS    = html
-SPHINXBUILD   = python -m sphinx
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 


### PR DESCRIPTION
This fixes an issue with `docs/conf.py` preventing documentation from being built correctly when a parent directory contains a `-`, and removes an improper use of `os.path.join`. Also cleans up the code around this area a bit.

This also replaces `docs/Makefile` with the default Sphinx Makefile, allowing `make html` to work.