### PR TITLE
no langid fix

### DIFF
--- a/software/chipwhisperer/hardware/naeusb/naeusb.py
+++ b/software/chipwhisperer/hardware/naeusb/naeusb.py
@@ -427,6 +427,8 @@ class NAEUSB_Backend(NAEUSB_Serializer_base):
                                 else:
                                     raise
             if dictonly:
+                for d in devlist:
+                    d._langids = (1033,)
                 devlist = [{'sn': d.serial_number, 'product': d.product, 'pid': d.idProduct, 'vid': d.idVendor} for d in devlist]
 
             return devlist


### PR DESCRIPTION
When using ChipWhisperer on Debian (vm inside Win10), cw.scope() fails because in naeusb.py it can't get the device's langid.

This change sets langid to 1033 if it's otherwise unavailable