### PR TITLE
Add ANSSI masked AES for Cortex-M4 devices implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tutorials"]
 	path = tutorials
 	url = https://github.com/newaetech/chipwhisperer-tutorials.git
+[submodule "hardware/victims/firmware/crypto/SecAESSTM32"]
+	path = hardware/victims/firmware/crypto/SecAESSTM32
+	url = https://github.com/ANSSI-FR/SecAESSTM32.git

--- a/hardware/victims/firmware/crypto/Makefile.maskedaes
+++ b/hardware/victims/firmware/crypto/Makefile.maskedaes
@@ -29,6 +29,9 @@ ifeq ($(implementation),ANSSI)
     ASFLAGS += -mthumb-interwork -fno-builtin
     LDFLAGS += -mthumb-interwork -fno-builtin
     CDEFS += -DUSE_KEIL_PLATFORM
+	ifneq ($(words $(filter-out UNROLLED KEYSCHEDULE,$(options))),0)
+      $(error Unsupported options for this target: $(options).)
+	endif
     ifeq ($(findstring UNROLLED,$(options)),UNROLLED)
       CDEFS += -DUSE_FULL_UNROLLING
     endif

--- a/hardware/victims/firmware/crypto/Makefile.maskedaes
+++ b/hardware/victims/firmware/crypto/Makefile.maskedaes
@@ -14,7 +14,7 @@ $(info Options=$(options))
 
 ifeq ($(implementation),ANSSI)
   # ARM Cortex-M4 targets
-  ifeq ($(HAL),$(filter $(HAL),sam4l stm32f3 stm32f4 cc2538 k24f k82f nrf52840 saml11 efm32tg11b lpc55s6x psoc62))
+  ifeq ($(HAL),$(filter $(HAL),sam4l stm32f3 stm32f4 stm32l4 stm32l5 cc2538 k24f k82f nrf52840 efm32tg11b lpc55s6x psoc62))
     CDEFS += -DANSSI_CM4
     CRYPTO_LIB = SecAESSTM32/src
     SRC += platform.c aes.c

--- a/hardware/victims/firmware/crypto/Makefile.maskedaes
+++ b/hardware/victims/firmware/crypto/Makefile.maskedaes
@@ -1,21 +1,66 @@
-
-CRYPTO_LIB = secAES-ATmega8515/src
 SRC += aes-independant.c
-ASRC += maskedAES128enc.S
-EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
 CDEFS += -DMASKEDAES
 
-ifeq ($(CRYPTO_OPTIONS),VERSION1)
- VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
- EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
+# CRYPTO_OPTIONS is used here to select the underlying implementation
+# and their options.
+# For example, CRYPTO_OPTIONS=ANSSI+UNROLLED+KEYSCHEDULE will compile
+# a firmware using ANSSI's implementation of masked AES for Cortex-M4 devices
+# with unrolled loops and the keyschedule will be part of the capture.
 
-else ifeq ($(CRYPTO_OPTIONS),VERSION2)
- VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
- EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
+implementation=$(firstword $(subst +, ,$(CRYPTO_OPTIONS)))
+options=$(wordlist 2,$(words $(subst +, ,$(CRYPTO_OPTIONS))),$(subst +, ,$(CRYPTO_OPTIONS)))
+$(info Impletementation=$(implementation))
+$(info Options=$(options))
+
+ifeq ($(implementation),ANSSI)
+  # ARM Cortex-M4 targets
+  ifeq ($(HAL),$(filter $(HAL),sam4l stm32f3 stm32f4 cc2538 k24f k82f nrf52840 saml11 efm32tg11b lpc55s6x psoc62))
+    CDEFS += -DANSSI_CM4
+    CRYPTO_LIB = SecAESSTM32/src
+    SRC += platform.c aes.c
+    ASRC += affine_aes.S
+    EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
+    EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/aes
+    EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/printf
+    VPATH += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
+    VPATH += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/aes
+    CFLAGS += -mthumb-interwork -fno-builtin
+    CPPFLAGS += -mthumb-interwork -fno-builtin
+    ASFLAGS += -mthumb-interwork -fno-builtin
+    LDFLAGS += -mthumb-interwork -fno-builtin
+    CDEFS += -DUSE_KEIL_PLATFORM
+    ifeq ($(findstring UNROLLED,$(options)),UNROLLED)
+      CDEFS += -DUSE_FULL_UNROLLING
+    endif
+    ifeq ($(findstring KEYSCHEDULE,$(options)),KEYSCHEDULE)
+      CDEFS += -DTRIG_BEFORE_KS
+    endif
+
+  else ifeq ($(HAL),avr)
+    CDEFS += -DANSSI_AVR
+    CRYPTO_LIB = secAES-ATmega8515/src
+    ASRC += maskedAES128enc.S
+    EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
+
+    ifeq ($(options),VERSION1)
+      VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
+      EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version1
+
+    else ifeq ($(options),VERSION2)
+      VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
+      EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)/Version2
+
+    else
+      $(error Unknown version for AVR masked AES: $(options).)
+
+    endif  # version
+
+  else
+    $(error Unsupported platform/hal for ANSSI masked AES crypto)
+
+  endif  # ANSSI
 
 else
+  $(error Unsupported implementation for masked AES crypto: $(implementation))
 
- $(error: Unknown or blank CRYPTO_OPTIONS: $(CRYPTO_OPTIONS). CRYPTO_OPTIONS is required for this CRYPTO_TARGET)
-endif #MASKEDAES
-
-
+endif # implementation

--- a/hardware/victims/firmware/crypto/aes-independant.c
+++ b/hardware/victims/firmware/crypto/aes-independant.c
@@ -238,6 +238,8 @@ void aes_indep_mask(uint8_t * m, uint8_t len)
 
 #elif defined(MASKEDAES)
 
+#if defined(ANSSI_AVR)
+
 #include "aesTables.h"
 #include "maskedAES128enc.h"
 
@@ -278,7 +280,93 @@ void aes_indep_mask(uint8_t * m, uint8_t len)
     mask[i] = m[i];
 }
 
+#elif defined(ANSSI_CM4)
 
+#include "platform.h"
+#include "string.h"
+#include "aes.h"
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#define AESKeySize 16
+#define AESMaskSize 19
+#define AESBlockSize 16
+
+STRUCT_AES aes_ctx;
+uint8_t key_mask[AESMaskSize];
+uint8_t aes_mask[AESMaskSize];
+uint8_t temp_key[AESKeySize];
+uint8_t mask_modes;
+
+void aes_indep_init(void)
+{
+  local_memset(&aes_ctx, 0, sizeof(aes_ctx));
+  mask_modes = 0;
+}
+
+void aes_indep_key(uint8_t* key)
+{
+#ifdef TRIG_BEFORE_KS
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    temp_key[i] = key[i];
+#else
+  aes(MODE_KEYINIT | mask_modes, &aes_ctx, key,
+      NULL /* plaintext */, NULL /* encrypted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t* pt)
+{
+#ifdef TRIG_BEFORE_KS
+  aes(MODE_KEYINIT | MODE_AESINIT_ENC | MODE_ENC | mask_modes,
+      &aes_ctx, temp_key,
+      pt /* plaintext */, pt /* encrypted text */,
+      aes_mask, key_mask);
+#else
+  aes(MODE_AESINIT_ENC | MODE_ENC | mask_modes, &aes_ctx, NULL /* key */,
+      pt /* plaintext */, pt /* encryted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_mask(uint8_t* m, uint8_t len)
+{
+  int i;
+  if (len >= AESMaskSize) {
+    for (i = 0; i < AESMaskSize; i++)
+      key_mask[i] = m[i];
+    mask_modes |= MODE_RANDOM_KEY_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_KEY_EXT;
+  }
+
+  if (len == (2 * AESMaskSize)) {
+    for (i = 0; i < AESMaskSize; i++)
+      aes_mask[i] = m[i + AESMaskSize];
+    mask_modes |= MODE_RANDOM_AES_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_AES_EXT;
+  }
+}
+
+
+#else
+
+#error "Unsupported MASKEDAES implementation"
+
+#endif // MASKEDAES
 
 #else
 

--- a/hardware/victims/firmware/simpleserial-aes/simpleserial-aes.c
+++ b/hardware/victims/firmware/simpleserial-aes/simpleserial-aes.c
@@ -73,6 +73,7 @@ uint8_t enc_multi_getpt(uint8_t* pt, uint8_t len)
 
     aes_indep_enc_posttrigger(pt);
 	simpleserial_put('r', 16, pt);
+    return 0;
 }
 
 uint8_t enc_multi_setnum(uint8_t* t, uint8_t len)
@@ -81,6 +82,7 @@ uint8_t enc_multi_setnum(uint8_t* t, uint8_t len)
     //which is most sane looking for humans I think
     num_encryption_rounds = t[1];
     num_encryption_rounds |= t[0] << 8;
+    return 0;
 }
 
 #if SS_VER == SS_VER_2_0

--- a/hardware/victims/firmware/simpleserial/simpleserial.c
+++ b/hardware/victims/firmware/simpleserial/simpleserial.c
@@ -264,7 +264,7 @@ void simpleserial_init()
 
 int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t))
 {
-	simpleserial_addcmd_flags(c, len, fp, CMD_FLAG_NONE);
+	return simpleserial_addcmd_flags(c, len, fp, CMD_FLAG_NONE);
 }
 
 int simpleserial_addcmd_flags(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t), uint8_t fl)

--- a/hardware/victims/firmware/simpleserial/simpleserial.c
+++ b/hardware/victims/firmware/simpleserial/simpleserial.c
@@ -214,7 +214,7 @@ typedef struct ss_cmd
 static ss_cmd commands[MAX_SS_CMDS];
 // Callback function for "v" command.
 // This can exist in v1.0 as long as we don't actually send back an ack ("z")
-uint8_t check_version(uint8_t *v)
+uint8_t check_version(uint8_t *v, uint8_t len)
 {
 	return SS_VER;
 }


### PR DESCRIPTION
This PR adds the masked AES for Cortex-M4 devices written and published by ANSSI.

This implementation is a bit special compared to the AVR one:
* the mask can be 19 or 38 bytes long. The first 19 bytes are used to mask the key, the other half, when set, protects the AES128 operations. If only the first half is given, the AES mask will be randomly generated by the implementation
* it allows at compile time to include the schedule and/or unroll the loops. These options can be activated by using `CRYPTO_OPTIONS` environment variable and `+` as an option separator (e.g. `CRYPTO_OPTIONS=ANSSI+UNROLLED+KEYSCHEDULE` will activate both options.

In order to compile a masked AES firmware (and allow more than one implementation of masked AES), one must set `CRYPTO_TARGET=MASKEDAES` and select the implementation using `CRYPTO_OPTIONS=ANSSI`