### PR TITLE
Add 2 more implementations for masked AES128

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,9 @@
 [submodule "hardware/victims/firmware/crypto/SecAESSTM32"]
 	path = hardware/victims/firmware/crypto/SecAESSTM32
 	url = https://github.com/ANSSI-FR/SecAESSTM32.git
+[submodule "hardware/victims/firmware/crypto/masked-bit-sliced-aes-128"]
+	path = hardware/victims/firmware/crypto/masked-bit-sliced-aes-128
+	url = https://github.com/sebastien-riou/masked-bit-sliced-aes-128
+[submodule "hardware/victims/firmware/crypto/Higher-Order-Masked-AES-128"]
+	path = hardware/victims/firmware/crypto/Higher-Order-Masked-AES-128
+	url = https://github.com/knarfrank/Higher-Order-Masked-AES-128

--- a/hardware/victims/firmware/crypto/Makefile.maskedaes
+++ b/hardware/victims/firmware/crypto/Makefile.maskedaes
@@ -63,6 +63,20 @@ ifeq ($(implementation),ANSSI)
 
   endif  # ANSSI
 
+else ifeq ($(implementation),RIOUBSAES)
+  CDEFS += -DRIOUBSAES
+  CRYPTOLIB = masked-bit-sliced-aes-128
+  VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTOLIB)/source
+  SRC += bitslice.c secure_aes_pbs.c
+  EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTOLIB)/include
+
+else ifeq ($(implementation),KNARFRANK)
+  CDEFS += -DKNARFRANKBSAES
+  CRYPTOLIB = Higher-Order-Masked-AES-128
+  VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTOLIB)
+  SRC += maths.c masked_combined.c
+  EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTOLIB)
+
 else
   $(error Unsupported implementation for masked AES crypto: $(implementation))
 

--- a/hardware/victims/firmware/crypto/aes-independant.c
+++ b/hardware/victims/firmware/crypto/aes-independant.c
@@ -361,6 +361,87 @@ void aes_indep_mask(uint8_t* m, uint8_t len)
   }
 }
 
+#elif defined(RIOUBSAES)
+
+#include "secure_aes_pbs.h"
+
+uint8_t encKey[16];
+
+bitslice_t get_random_bitslice(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  sec_aes128_enc_packed_bitslice_wrapper(pt, pt, encKey);
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(KNARFRANKBSAES)
+
+#include "masked_combined.h"
+
+uint8_t encKey[16];
+
+uint32_t rand(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  uint8_t result[16];
+  Encrypt(result, pt, encKey);
+  for (uint8_t i = 0; i < 16; i++) {
+    pt[i] = result[i];
+  }
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
 
 #else
 

--- a/hardware/victims/firmware/crypto/aes-independant.c
+++ b/hardware/victims/firmware/crypto/aes-independant.c
@@ -406,7 +406,7 @@ void aes_indep_mask(uint8_t * m, uint8_t len)
 
 uint8_t encKey[16];
 
-uint32_t rand(void)
+int rand(void)
 {
   return get_rand();
 }

--- a/hardware/victims/firmware/hal/k24f/fsl_common.h
+++ b/hardware/victims/firmware/hal/k24f/fsl_common.h
@@ -40,9 +40,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#if defined(__ICCARM__)
+//#if defined(__ICCARM__)
 #include <stddef.h>
-#endif
+//#endif
 
 #include "fsl_device_registers.h"
 

--- a/hardware/victims/firmware/hal/k24f/k24f_hal.c
+++ b/hardware/victims/firmware/hal/k24f/k24f_hal.c
@@ -7,6 +7,7 @@
 #include "fsl_clock.h"
 #include "clock_config.h"
 #include "fsl_mmcau.h"
+#include "fsl_rnga.h"
 
 #include <stdint.h>
 
@@ -16,6 +17,8 @@ static uint32_t AES_KEY_SCH[44];
 void platform_init(void)
 {
      BOARD_BootClockRUN();
+     RNGA_Init(RNG);
+     RNGA_SetMode(RNG, kRNGA_ModeNormal);
 }
 
 void init_uart(void)
@@ -75,6 +78,13 @@ char getch(void)
 void putch(char c)
 {
      UART_WriteBlocking(UART1, &c, 1);
+}
+
+uint32_t get_rand(void)
+{
+     uint32_t value;
+     RNGA_GetRandomData(RNG, &value, sizeof(value));
+     return value;
 }
 
 //nothing needed?

--- a/hardware/victims/firmware/hal/k24f/k24f_hal.h
+++ b/hardware/victims/firmware/hal/k24f/k24f_hal.h
@@ -29,6 +29,8 @@ void trigger_setup(void);
 void trigger_low(void);
 void trigger_high(void);
 
+uint32_t get_rand(void);
+
 void HW_AES128_Init(void);
 void HW_AES128_LoadKey(uint8_t* key);
 void HW_AES128_Enc(uint8_t* pt);

--- a/hardware/victims/firmware/hal/lpc55s6x/Makefile.lpc55s6x
+++ b/hardware/victims/firmware/hal/lpc55s6x/Makefile.lpc55s6x
@@ -1,16 +1,16 @@
 VPATH += :$(HALPATH)/lpc55s6x :$(HALPATH)/lpc55s6x/device
-SRC += lpc55s6x_hal.c startup_lpc55s69_cm33_core0.c system_LPC55S69_cm33_core0.c semihost_hardfault.c 
+SRC += lpc55s6x_hal.c startup_lpc55s69_cm33_core0.c system_LPC55S69_cm33_core0.c semihost_hardfault.c
 
 VPATH += :$(HALPATH)/lpc55s6x/utilities
 SRC += fsl_assert.c fsl_debug_console.c fsl_str.c
 
 VPATH += :$(HALPATH)/lpc55s6x/drivers
-SRC += fsl_clock.c fsl_common.c fsl_flexcomm.c fsl_gpio.c fsl_hashcrypt.c fsl_inputmux.c fsl_power.c fsl_puf.c fsl_reset.c fsl_usart.c
+SRC += fsl_clock.c fsl_common.c fsl_flexcomm.c fsl_gpio.c fsl_hashcrypt.c fsl_inputmux.c fsl_power.c fsl_puf.c fsl_reset.c fsl_rng.c fsl_usart.c
 
 VPATH += :$(HALPATH)/lpc55s6x/component
 SRC += fsl_generic_list.c fsl_serial_manager.c fsl_serial_port_uart.c fsl_usart_adapter.c
 
-EXTRAINCDIRS += $(HALPATH)/lpc55s6x $(HALPATH)/lpc55s6x/CMSIS 
+EXTRAINCDIRS += $(HALPATH)/lpc55s6x $(HALPATH)/lpc55s6x/CMSIS
 EXTRAINCDIRS += $(HALPATH)/lpc55s6x/utilities $(HALPATH)/lpc55s6x/drivers
 EXTRAINCDIRS += $(HALPATH)/lpc55s6x/device
 EXTRAINCDIRS += $(HALPATH)/lpc55s6x/component

--- a/hardware/victims/firmware/hal/lpc55s6x/drivers/fsl_rng.c
+++ b/hardware/victims/firmware/hal/lpc55s6x/drivers/fsl_rng.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017, 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_rng.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.rng_1"
+#endif
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*******************************************************************************
+ * Prototypes
+ *******************************************************************************/
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+void RNG_Init(RNG_Type *base)
+{
+    /* Clear ring oscilator disable bit*/
+    PMC->PDRUNCFGCLR0 = PMC_PDRUNCFG0_PDEN_RNG_MASK;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    CLOCK_EnableClock(kCLOCK_Rng);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+void RNG_Deinit(RNG_Type *base)
+{
+    /* Set ring oscilator disable bit*/
+    PMC->PDRUNCFGSET0 = PMC_PDRUNCFG0_PDEN_RNG_MASK;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    CLOCK_DisableClock(kCLOCK_Rng);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+status_t RNG_GetRandomData(RNG_Type *base, void *data, size_t dataSize)
+{
+    status_t result = kStatus_Fail;
+    uint32_t random32;
+    uint32_t randomSize;
+    uint8_t *pRandom;
+    uint8_t *pData = (uint8_t *)data;
+    uint32_t i;
+
+    /* Check input parameters.*/
+    if (!((base != NULL) && (data != NULL) && (dataSize != 0U)))
+    {
+        result = kStatus_InvalidArgument;
+    }
+    else
+    {
+        /* Check that ring oscilator is enabled */
+        if (0U == (PMC->PDRUNCFG0 & PMC_PDRUNCFG0_PDEN_RNG_MASK))
+        {
+            do
+            {
+                /* Read Entropy.*/
+                random32 = base->RANDOM_NUMBER;
+                pRandom  = (uint8_t *)&random32;
+
+                if (dataSize < sizeof(random32))
+                {
+                    randomSize = dataSize;
+                }
+                else
+                {
+                    randomSize = sizeof(random32);
+                }
+
+                for (i = 0; i < randomSize; i++)
+                {
+                    *pData++ = *pRandom++;
+                }
+
+                dataSize -= randomSize;
+            } while (dataSize > 0U);
+
+            result = kStatus_Success;
+        }
+    }
+
+    return result;
+}

--- a/hardware/victims/firmware/hal/lpc55s6x/drivers/fsl_rng.h
+++ b/hardware/victims/firmware/hal/lpc55s6x/drivers/fsl_rng.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017, 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _FSL_RNG_DRIVER_H_
+#define _FSL_RNG_DRIVER_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup rng
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ *******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief RNG driver version. Version 2.0.1.
+ *
+ * Current version: 2.0.1
+ *
+ * Change log:
+ * - Version 2.0.0
+ *   - Initial version
+ *
+ * - Version 2.0.1
+ *   - Fix MISRA C-2012 issue.
+ */
+#define FSL_RNG_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*@}*/
+
+/*******************************************************************************
+ * API
+ *******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @brief Initializes the RNG.
+ *
+ * This function initializes the RNG.
+ * When called, the RNG module and ring oscillator is enabled.
+ *
+ * @param base  RNG base address
+ * @return If successful, returns the kStatus_RNG_Success. Otherwise, it returns an error.
+ */
+void RNG_Init(RNG_Type *base);
+
+/*!
+ * @brief Shuts down the RNG.
+ *
+ * This function shuts down the RNG.
+ *
+ * @param base  RNG base address.
+ */
+void RNG_Deinit(RNG_Type *base);
+
+/*!
+ * @brief Gets random data.
+ *
+ * This function gets random data from the RNG.
+ *
+ * @param base  RNG base address.
+ * @param data  Pointer address used to store random data.
+ * @param dataSize  Size of the buffer pointed by the data parameter.
+ * @return random data
+ */
+status_t RNG_GetRandomData(RNG_Type *base, void *data, size_t dataSize);
+
+/*!
+ * @brief Returns random 32-bit number.
+ *
+ * This function gets random number from the RNG.
+ *
+ * @param base  RNG base address.
+ * @return random number
+ */
+static inline uint32_t RNG_GetRandomWord(RNG_Type *base)
+{
+    return base->RANDOM_NUMBER;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /*_FSL_RNG_H_*/

--- a/hardware/victims/firmware/hal/lpc55s6x/lpc55s6x_hal.c
+++ b/hardware/victims/firmware/hal/lpc55s6x/lpc55s6x_hal.c
@@ -30,13 +30,13 @@ void platform_init(void)
     BOARD_InitBootClocks();
     //BOARD_BootClockPLL100M();
 
-    
+    RNG_Init(RNG);
 }
 
 void init_uart(void)
 {
     BOARD_InitDebugConsole();
-}    
+}
 
 void putch(char c)
 {
@@ -203,6 +203,13 @@ void trigger_high(void)
     GPIO_PinWrite(GPIO, 0, 24, 1);
 }
 
+uint32_t get_rand(void)
+{
+    uint32_t value;
+    RNG_GetRandomData(RNG, &value, sizeof(value));
+    return value;
+}
+
 void HW_AES128_Init(void)
 {
 }
@@ -216,9 +223,17 @@ void HW_AES128_LoadKey(uint8_t* key)
     HASHCRYPT_AES_SetKey(HASHCRYPT, &hch, key, 16);
 }
 
+void HW_AES128_Enc_pretrigger(uint8_t* pt)
+{
+}
+
 void HW_AES128_Enc(uint8_t* pt)
 {
     HASHCRYPT_AES_EncryptEcb(HASHCRYPT, &hch, pt, pt, 16);
+}
+
+void HW_AES128_Enc_posttrigger(uint8_t* pt)
+{
 }
 
 void HW_AES128_Dec(uint8_t *pt)

--- a/hardware/victims/firmware/hal/lpc55s6x/lpc55s6x_hal.h
+++ b/hardware/victims/firmware/hal/lpc55s6x/lpc55s6x_hal.h
@@ -81,4 +81,6 @@ void trigger_setup(void);
 void trigger_low(void);
 void trigger_high(void);
 
+uint32_t get_rand(void);
+
 #endif /* _LPC55S6X_HAL_H_ */

--- a/hardware/victims/firmware/hal/stm32f4/Makefile.stm32f4
+++ b/hardware/victims/firmware/hal/stm32f4/Makefile.stm32f4
@@ -1,5 +1,5 @@
 VPATH += :$(HALPATH)/stm32f4
-SRC += stm32f4_hal.c stm32f4_hal_lowlevel.c stm32f4_sysmem.c
+SRC += stm32f4_hal.c stm32f4_hal_lowlevel.c stm32f4_sysmem.c stm32f4xx_hal_rng.c
 EXTRAINCDIRS += $(HALPATH)/stm32f4 $(HALPATH)/stm32f4/CMSIS $(HALPATH)/stm32f4/CMSIS/core $(HALPATH)/stm32f4/CMSIS/device $(HALPATH)/stm32f4/Legacy
 
 ASRC += stm32f4_startup.S

--- a/hardware/victims/firmware/hal/stm32f4/stm32f4_hal.c
+++ b/hardware/victims/firmware/hal/stm32f4/stm32f4_hal.c
@@ -6,7 +6,9 @@
 #include "stm32f4xx_hal_dma.h"
 #include "stm32f4xx_hal_uart.h"
 #include "stm32f4xx_hal_cryp.h"
+#include "stm32f4xx_hal_rng.h"
 
+RNG_HandleTypeDef RngHandle;
 UART_HandleTypeDef UartHandle;
 
 uint8_t hw_key[16];
@@ -26,7 +28,12 @@ void platform_init(void)
      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
      RCC_OscInitStruct.HSEState       = RCC_HSE_OFF;
      RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-     RCC_OscInitStruct.PLL.PLLSource  = RCC_PLL_NONE;
+	 RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;  // we need PLL to use RNG
+	 RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI;
+	 RCC_OscInitStruct.PLL.PLLM       = 16;  // Internal clock is 16MHz.
+	 RCC_OscInitStruct.PLL.PLLN       = 336;
+	 RCC_OscInitStruct.PLL.PLLP       = 2;
+	 RCC_OscInitStruct.PLL.PLLQ       = 7;  // divisor for RNG, USB and SDIO
      HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
      RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -41,8 +48,13 @@ void platform_init(void)
 	RCC_OscInitTypeDef RCC_OscInitStruct;
 	RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI;
 	RCC_OscInitStruct.HSEState       = RCC_HSE_BYPASS;
-	RCC_OscInitStruct.HSIState       = RCC_HSI_OFF;
-	RCC_OscInitStruct.PLL.PLLSource  = RCC_PLL_NONE;
+	RCC_OscInitStruct.HSIState       = RCC_HSI_ON;  // HSI is needed for the RNG
+	RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;  // we need PLL to use RNG
+	RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI;
+	RCC_OscInitStruct.PLL.PLLM       = 16;  // Internal clock is 16MHz
+	RCC_OscInitStruct.PLL.PLLN       = 336;
+	RCC_OscInitStruct.PLL.PLLP       = 2;
+	RCC_OscInitStruct.PLL.PLLQ       = 7;  // divisor for RNG, USB and SDIO
 	HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
 	RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -53,6 +65,12 @@ void platform_init(void)
 	RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 	HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_ACR_LATENCY_5WS);
 #endif
+
+	// Configure and starts the RNG
+	__HAL_RCC_RNG_CLK_ENABLE();
+	RngHandle.Instance = RNG;
+	RngHandle.State = HAL_RNG_STATE_RESET;
+	HAL_RNG_Init(&RngHandle);
 }
 
 void init_uart(void)
@@ -92,7 +110,7 @@ void trigger_setup(void)
 	GpioInit.Pull      = GPIO_NOPULL;
 	GpioInit.Speed     = GPIO_SPEED_FREQ_HIGH;
     __GPIOD_CLK_ENABLE();
-    HAL_GPIO_Init(GPIOD, &GpioInit);   
+    HAL_GPIO_Init(GPIOD, &GpioInit);
 #else
 	GPIO_InitTypeDef GpioInit;
 	GpioInit.Pin       = GPIO_PIN_12;
@@ -130,6 +148,18 @@ void putch(char c)
 {
 	uint8_t d  = c;
 	HAL_UART_Transmit(&UartHandle,  &d, 1, 5000);
+}
+
+uint32_t get_rand(void)
+{
+	uint32_t prev_rand = RngHandle.RandomNumber;
+	uint32_t next_rand;
+	HAL_StatusTypeDef error;
+
+	do {
+		error = HAL_RNG_GenerateRandomNumber(&RngHandle, &next_rand);
+  	} while (error != HAL_OK && prev_rand == next_rand);
+  	return next_rand;
 }
 
 void HW_AES128_Init(void)

--- a/hardware/victims/firmware/hal/stm32f4/stm32f4_hal.h
+++ b/hardware/victims/firmware/hal/stm32f4/stm32f4_hal.h
@@ -10,6 +10,8 @@ void init_uart(void);
 void putch(char c);
 char getch(void);
 
+uint32_t get_rand(void);
+
 void trigger_setup(void);
 void trigger_low(void);
 void trigger_high(void);

--- a/hardware/victims/firmware/hal/stm32f4/stm32f4xx_hal_rng.c
+++ b/hardware/victims/firmware/hal/stm32f4/stm32f4xx_hal_rng.c
@@ -1,0 +1,530 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_rng.c
+  * @author  MCD Application Team
+  * @version V1.7.1
+  * @date    14-April-2017
+  * @brief   RNG HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Random Number Generator (RNG) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+      The RNG HAL driver can be used as follows:
+
+      (#) Enable the RNG controller clock using __HAL_RCC_RNG_CLK_ENABLE() macro 
+          in HAL_RNG_MspInit().
+      (#) Activate the RNG peripheral using HAL_RNG_Init() function.
+      (#) Wait until the 32 bit Random Number Generator contains a valid 
+          random data using (polling/interrupt) mode.   
+      (#) Get the 32 bit random number using HAL_RNG_GenerateRandomNumber() function.
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+//#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_rng.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RNG 
+  * @{
+  */
+
+//#ifdef HAL_RNG_MODULE_ENABLED
+
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||\
+    defined(STM32F410Tx) || defined(STM32F410Cx) || defined(STM32F410Rx) || defined(STM32F469xx) ||\
+    defined(STM32F479xx) || defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) ||\
+    defined(STM32F412Cx) || defined(STM32F413xx) || defined(STM32F423xx)
+
+
+/* Private types -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @addtogroup RNG_Private_Constants
+  * @{
+  */
+#define RNG_TIMEOUT_VALUE     2U
+/**
+  * @}
+  */ 
+/* Private macros ------------------------------------------------------------*/
+/* Private functions prototypes ----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup RNG_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group1
+ *  @brief   Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+          ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the RNG according to the specified parameters 
+          in the RNG_InitTypeDef and create the associated handle
+      (+) DeInitialize the RNG peripheral
+      (+) Initialize the RNG MSP
+      (+) DeInitialize RNG MSP 
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initializes the RNG peripheral and creates the associated handle.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  __HAL_LOCK(hrng);
+  
+  if(hrng->State == HAL_RNG_STATE_RESET)
+  {  
+    /* Allocate lock resource and initialize it */
+    hrng->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware */
+    HAL_RNG_MspInit(hrng);
+  }
+  
+  /* Change RNG peripheral state */
+  hrng->State = HAL_RNG_STATE_BUSY;
+
+  /* Enable the RNG Peripheral */
+  __HAL_RNG_ENABLE(hrng);
+
+  /* Initialize the RNG state */
+  hrng->State = HAL_RNG_STATE_READY;
+  
+  __HAL_UNLOCK(hrng);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the RNG peripheral. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_DeInit(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Disable the RNG Peripheral */
+  CLEAR_BIT(hrng->Instance->CR, RNG_CR_IE | RNG_CR_RNGEN);
+  
+  /* Clear RNG interrupt status flags */
+  CLEAR_BIT(hrng->Instance->SR, RNG_SR_CEIS | RNG_SR_SEIS);
+  
+  /* DeInit the low level hardware */
+  HAL_RNG_MspDeInit(hrng);
+  
+  /* Update the RNG state */
+  hrng->State = HAL_RNG_STATE_RESET; 
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrng);
+  
+  /* Return the function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  DeInitializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspDeInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group2
+ *  @brief   Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Get the 32 bit Random number
+      (+) Get the 32 bit Random number with interrupt enabled
+      (+) Handle RNG interrupt request 
+
+@endverbatim
+  * @{
+  */
+   
+/**
+  * @brief  Generates a 32-bit random number.
+  * @note   Each time the random number data is read the RNG_FLAG_DRDY flag 
+  *         is automatically cleared.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @param  random32bit: pointer to generated random number variable if successful.
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit)
+{
+  uint32_t tickstart = 0U;    
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hrng); 
+  
+  /* Check RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */  
+    hrng->State = HAL_RNG_STATE_BUSY;  
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+  
+    /* Check if data register contains valid random data */
+    while(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RNG_TIMEOUT_VALUE)
+      {    
+        hrng->State = HAL_RNG_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrng);
+      
+        return HAL_TIMEOUT;
+      } 
+    }
+  
+    /* Get a 32bit Random number */
+    hrng->RandomNumber = hrng->Instance->DR;
+    *random32bit = hrng->RandomNumber;
+  
+    hrng->State = HAL_RNG_STATE_READY;
+  }
+  else
+  {
+    status = HAL_ERROR;
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrng);
+  
+  return status;
+}
+
+/**
+  * @brief  Generates a 32-bit random number in interrupt mode.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Process Locked */
+  __HAL_LOCK(hrng);
+  
+  /* Check RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */  
+    hrng->State = HAL_RNG_STATE_BUSY;  
+  
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+    
+    /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */ 
+    __HAL_RNG_ENABLE_IT(hrng);
+  }
+  else
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+    
+    status = HAL_ERROR;
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Handles RNG interrupt request.
+  * @note   In the case of a clock error, the RNG is no more able to generate 
+  *         random numbers because the PLL48CLK clock is not correct. User has 
+  *         to check that the clock controller is correctly configured to provide
+  *         the RNG clock and clear the CEIS bit using __HAL_RNG_CLEAR_IT(). 
+  *         The clock error has no impact on the previously generated 
+  *         random numbers, and the RNG_DR register contents can be used.
+  * @note   In the case of a seed error, the generation of random numbers is 
+  *         interrupted as long as the SECS bit is '1'. If a number is 
+  *         available in the RNG_DR register, it must not be used because it may 
+  *         not have enough entropy. In this case, it is recommended to clear the 
+  *         SEIS bit using __HAL_RNG_CLEAR_IT(), then disable and enable 
+  *         the RNG peripheral to reinitialize and restart the RNG.
+  * @note   User-written HAL_RNG_ErrorCallback() API is called once whether SEIS
+  *         or CEIS are set.  
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+
+  */
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
+{
+  /* RNG clock error interrupt occurred */
+  if((__HAL_RNG_GET_IT(hrng, RNG_IT_CEI) != RESET) ||  (__HAL_RNG_GET_IT(hrng, RNG_IT_SEI) != RESET))
+  { 
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_ERROR;
+  
+    HAL_RNG_ErrorCallback(hrng);
+    
+    /* Clear the clock error flag */
+    __HAL_RNG_CLEAR_IT(hrng, RNG_IT_CEI|RNG_IT_SEI);
+    
+  }
+  
+  /* Check RNG data ready interrupt occurred */    
+  if(__HAL_RNG_GET_IT(hrng, RNG_IT_DRDY) != RESET)
+  {
+    /* Generate random number once, so disable the IT */
+    __HAL_RNG_DISABLE_IT(hrng);
+    
+    /* Get the 32bit Random number (DRDY flag automatically cleared) */ 
+    hrng->RandomNumber = hrng->Instance->DR;
+    
+    if(hrng->State != HAL_RNG_STATE_ERROR)
+    {
+      /* Change RNG peripheral state */
+      hrng->State = HAL_RNG_STATE_READY; 
+      
+      /* Data Ready callback */ 
+      HAL_RNG_ReadyDataCallback(hrng, hrng->RandomNumber);
+    } 
+  }
+} 
+
+/**
+  * @brief  Returns generated random number in polling mode (Obsolete)
+  *         Use HAL_RNG_GenerateRandomNumber() API instead.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval Random value
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  if(HAL_RNG_GenerateRandomNumber(hrng, &(hrng->RandomNumber)) == HAL_OK)
+  {
+    return hrng->RandomNumber; 
+  }
+  else
+  {
+    return 0U;
+  }
+}
+
+/**
+  * @brief  Returns a 32-bit random number with interrupt enabled (Obsolete),
+  *         Use HAL_RNG_GenerateRandomNumber_IT() API instead.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval 32-bit random number
+  */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  uint32_t random32bit = 0U;
+  
+  /* Process locked */
+  __HAL_LOCK(hrng);
+  
+  /* Change RNG peripheral state */  
+  hrng->State = HAL_RNG_STATE_BUSY;  
+  
+  /* Get a 32bit Random number */ 
+  random32bit = hrng->Instance->DR;
+  
+  /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */ 
+  __HAL_RNG_ENABLE_IT(hrng); 
+  
+  /* Return the 32 bit random number */   
+  return random32bit;
+}
+
+/**
+  * @brief  Read latest generated random number. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval random value
+  */
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  return(hrng->RandomNumber);
+}
+
+/**
+  * @brief  Data Ready callback in non-blocking mode. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @param  random32bit: generated random number.
+  * @retval None
+  */
+__weak void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef *hrng, uint32_t random32bit)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+  UNUSED(random32bit);
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ReadyDataCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  RNG error callbacks.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ErrorCallback must be implemented in the user file.
+   */
+}
+/**
+  * @}
+  */ 
+
+  
+/** @addtogroup RNG_Exported_Functions_Group3
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Returns the RNG state.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL state
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
+{
+  return hrng->State;
+}
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F427xx || STM32F437xx ||\
+          STM32F429xx || STM32F439xx || STM32F410xx || STM32F469xx || STM32F479xx || STM32F412Zx ||\
+          STM32F412Vx || STM32F412Rx || STM32F412Cx || STM32F413xx || STM32F423xx */
+
+//#endif /* HAL_RNG_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hardware/victims/firmware/hal/stm32f4/stm32f4xx_hal_rng.h
+++ b/hardware/victims/firmware/hal/stm32f4/stm32f4xx_hal_rng.h
@@ -1,0 +1,368 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_rng.h
+  * @author  MCD Application Team
+  * @version V1.7.1
+  * @date    14-April-2017
+  * @brief   Header file of RNG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_HAL_RNG_H
+#define __STM32F4xx_HAL_RNG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||\
+    defined(STM32F410Tx) || defined(STM32F410Cx) || defined(STM32F410Rx) || defined(STM32F469xx) ||\
+    defined(STM32F479xx) || defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) ||\
+    defined(STM32F412Cx) || defined(STM32F413xx) || defined(STM32F423xx)
+      
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal_def.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RNG RNG
+  * @brief RNG HAL module driver
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup RNG_Exported_Types RNG Exported Types
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Types_Group1 RNG State Structure definition 
+  * @{
+  */
+typedef enum
+{
+  HAL_RNG_STATE_RESET     = 0x00U,  /*!< RNG not yet initialized or disabled */
+  HAL_RNG_STATE_READY     = 0x01U,  /*!< RNG initialized and ready for use   */
+  HAL_RNG_STATE_BUSY      = 0x02U,  /*!< RNG internal process is ongoing     */ 
+  HAL_RNG_STATE_TIMEOUT   = 0x03U,  /*!< RNG timeout state                   */
+  HAL_RNG_STATE_ERROR     = 0x04U   /*!< RNG error state                     */
+    
+}HAL_RNG_StateTypeDef;
+
+/** 
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Types_Group2 RNG Handle Structure definition   
+  * @{
+  */ 
+typedef struct
+{
+  RNG_TypeDef                 *Instance;    /*!< Register base address   */ 
+  
+  HAL_LockTypeDef             Lock;         /*!< RNG locking object      */
+  
+  __IO HAL_RNG_StateTypeDef   State;        /*!< RNG communication state */
+  
+  uint32_t                    RandomNumber; /*!< Last Generated RNG Data */
+  
+}RNG_HandleTypeDef;
+
+/** 
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+   
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Constants RNG Exported Constants
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Constants_Group1 RNG Interrupt definition
+  * @{
+  */
+#define RNG_IT_DRDY  RNG_SR_DRDY  /*!< Data Ready interrupt  */
+#define RNG_IT_CEI   RNG_SR_CEIS  /*!< Clock error interrupt */
+#define RNG_IT_SEI   RNG_SR_SEIS  /*!< Seed error interrupt  */
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Constants_Group2 RNG Flag definition
+  * @{
+  */
+#define RNG_FLAG_DRDY   RNG_SR_DRDY  /*!< Data ready                 */
+#define RNG_FLAG_CECS   RNG_SR_CECS  /*!< Clock error current status */
+#define RNG_FLAG_SECS   RNG_SR_SECS  /*!< Seed error current status  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Macros RNG Exported Macros
+  * @{
+  */
+
+/** @brief Reset RNG handle state
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RNG_STATE_RESET)
+
+/**
+  * @brief  Enables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_RNGEN)
+
+/**
+  * @brief  Disables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_RNGEN)
+
+/**
+  * @brief  Check the selected RNG flag status.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __FLAG__: RNG flag
+  *          This parameter can be one of the following values:
+  *            @arg RNG_FLAG_DRDY: Data ready                
+  *            @arg RNG_FLAG_CECS: Clock error current status
+  *            @arg RNG_FLAG_SECS: Seed error current status 
+  * @retval The new state of __FLAG__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the selected RNG flag status.
+  * @param  __HANDLE__: RNG handle
+  * @param  __FLAG__: RNG flag to clear  
+  * @note   WARNING: This is a dummy macro for HAL code alignment,
+  *         flags RNG_FLAG_DRDY, RNG_FLAG_CECS and RNG_FLAG_SECS are read-only.
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__)                      /* dummy  macro */
+
+
+
+/**
+  * @brief  Enables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_IE)
+    
+/**
+  * @brief  Disables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_IE)
+
+/**
+  * @brief  Checks whether the specified RNG interrupt has occurred or not.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg RNG_IT_DRDY: Data ready interrupt              
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @retval The new state of __INTERRUPT__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR & (__INTERRUPT__)) == (__INTERRUPT__))   
+
+/**
+  * @brief  Clear the RNG interrupt status flags.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to clear.
+  *          This parameter can be one of the following values:            
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @note   RNG_IT_DRDY flag is read-only, reading RNG_DR register automatically clears RNG_IT_DRDY.          
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR) = ~(__INTERRUPT__))
+
+/**
+  * @}
+  */ 
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup RNG_Exported_Functions RNG Exported Functions
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */  
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng);
+HAL_StatusTypeDef HAL_RNG_DeInit (RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng);
+
+/**
+  * @}
+  */ 
+
+/** @defgroup RNG_Exported_Functions_Group2 Peripheral Control functions
+  * @{
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng);    /* Obsolete, use HAL_RNG_GenerateRandomNumber() instead    */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng); /* Obsolete, use HAL_RNG_GenerateRandomNumber_IT() instead */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit);
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng);
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng);
+
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef* hrng, uint32_t random32bit);
+
+/**
+  * @}
+  */ 
+
+/** @defgroup RNG_Exported_Functions_Group3 Peripheral State functions
+  * @{
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+
+/* Private types -------------------------------------------------------------*/
+/** @defgroup RNG_Private_Types RNG Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup RNG_Private_Defines RNG Private Defines
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+          
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Variables RNG Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Constants RNG Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RNG_Private_Macros RNG Private Macros
+  * @{
+  */
+#define IS_RNG_IT(IT) (((IT) == RNG_IT_CEI) || \
+                       ((IT) == RNG_IT_SEI))
+
+#define IS_RNG_FLAG(FLAG) (((FLAG) == RNG_FLAG_DRDY) || \
+                           ((FLAG) == RNG_FLAG_CECS) || \
+                           ((FLAG) == RNG_FLAG_SECS))
+
+/**
+  * @}
+  */ 
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup RNG_Private_Functions_Prototypes RNG Private Functions Prototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Functions RNG Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F427xx || STM32F437xx ||\
+          STM32F429xx || STM32F439xx || STM32F410xx || STM32F469xx || STM32F479xx || STM32F412Zx ||\
+          STM32F412Vx || STM32F412Rx || STM32F412Cx || STM32F413xx || STM32F423xx */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F4xx_HAL_RNG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Implementations comes from:
- Sebastien Riou (https://github.com/sebastien-riou/masked-bit-sliced-aes-128)
- knarfrank (https://github.com/knarfrank/Higher-Order-Masked-AES-128)

Unlike the implementation from ANSSI, the mask here can't be chosen. They both require to have a working RNG to generate it. Therefore not all the ARM targets are supported yet.

This PR adds support for:
- STM32F4
- NRF52
- LPC55
- K24F
- K82F

Currently working on SAML11 target. I'll create follow-up PRs for each architecture that I manage to add and validate on hardware.