### PR TITLE
Add coefficient vs trace number function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ ChipWhisperer 5.5 has brought some exciting new features that make it easier to 
 
 1. The ChipWhisperer Windows installer now includes everything you need to use ChipWhisperer, including
 Python/Juptyer, Git, Make, and compilers! For more information, check out our [Windows installer page](https://chipwhisperer.readthedocs.io/en/latest/installing.html#windows-installer) on ReadTheDocs.
-1. ChipWhisperer capture devices (CWLite, Nano, Pro, etc.) have gotten a few firmware update that gives them a
+1. ChipWhisperer capture devices (CWLite, Nano, Pro, etc.) have gotten a new firmware update that gives them a
 USB-CDC serial port for talking over USART. This means you can use your favourite serial program, such as PuTTy,
 to talk to and listen to the target's USART communication. For more info, see our [rtfm serial port page](https://rtfm.newae.com/Serial%20Ports/).
 1. We've recently added two ECC power analysis attack notebooks. One attacks a hardware ECC implementation running on the CW305
 and the other attacks a software ECC implementation running on a microcontroller. Both can be found in `jupyter/demos`.
 1. There's a new segmented capture mode that allows you to fill the ChipWhisperer capture buffer with multiple power traces
 before transferring data to the PC. This greatly reduces the overhead on trace transfer, allowing capture speeds
-of 1000+ captures/second for FPGA AES implementations. See our [API documentation](https://chipwhisperer.readthedocs.io/en/latest/api.html#chipwhisperer.capture.scopes._OpenADCInterface.OpenADC.TriggerSettings.fifo_fill_mode)
+of 1000+ captures/second for FPGA AES implementations. See our [API documentation](https://chipwhisperer.readthedocs.io/en/latest/api.html#chipwhisperer.capture.scopes._OpenADCInterface.OpenADC.TriggerSettings.fifo_fill_mode) to see how to use it.
 
 Also, if you haven't checked it out yet, ChipWhisperer 5.4 included TraceWhisperer, which allows you to use Arm trace to
 timestamp microcontroller operations/functions in your powertrace. It requires a CW305 or PhyWhisperer. For more information, see

--- a/software/chipwhisperer/analyzer/attacks/coefficient_vs_trace_number.py
+++ b/software/chipwhisperer/analyzer/attacks/coefficient_vs_trace_number.py
@@ -1,0 +1,131 @@
+import matplotlib.pyplot as plt
+from tqdm import tnrange
+import numpy as np
+
+class CoeffecientVsTracesNumber:
+    """Calculate coefficient from increasing number of traces.
+
+    We can see the changes of specific subkey coefficient while number of traces increase.
+    And the time complexity is o(N).
+
+    coeffecient(X, Y) = cov(X, Y) / (std(X) * std(Y))
+    cov(X, Y) = E(X * Y) - E(X) * E(Y)
+    std(X) = sqrt(E(X**2) - E(X)**2)
+    std(Y) = sqrt(E(Y**2) - E(Y)**2)
+    coeffecient(X, Y) = (E(X * Y) - E(X) * E(Y)) / ((sqrt(E(X**2) - E(X)**2)) * (sqrt(E(Y**2) - E(Y)**2)))
+
+    Let X = [X1, X2]
+    E(X) = (E(X1) * len(X1) + E(X2) * len(X2)) / (len(X1) + len(X2))
+    Store E(X1 * Y1), E(X1), E(Y1), E(X1**2), E(Y1**2),
+    calculate coming E(X2 * Y2), E(X2), E(Y2), E(X2**2), E(Y2**2).
+    We can get the new coeffeicient([X1, X2], [Y1, Y2]) without overlapping coeffeicient(X1, Y1) that we have calculated.
+
+
+
+    Example:
+        import chipwhisperer.analyzer as cwa
+        import chipwhisperer as cw
+
+        project = cw.open_project('my_project')
+        leak_model = cwa.leakage_models.sbox_output
+        interval = 100
+        subkey_index = 0  # First subkey.
+        coeffecient = CoeffecientVsTracesNumber(proj.traces, subkey_index, interval, leak_model)
+        results = coeffecient.get_effecient()
+        coeffecient.plot_and_save(results, [20,8], 'your_path_saving_figure')
+
+
+    Args:
+        traces (Iterable of :class:`Traces <chipwhisperer.common.traces.Trace>`): An iterable of traces.
+        subkey (int): The subkey you want to obverse.
+        interval (int): The number of traces that we use for once calculation.
+        leak_model (ModelsBase): A leakage model selected from.
+
+    """
+    def __init__(self, traces, subkey_index, interval, leak_model):
+        self.traces = traces
+        self.subkey_index = subkey_index
+        self.interval = interval
+        self.leak_model = leak_model
+
+    def get_effecient(self):
+        # Get all hamming weights or other measurements related to leakage.
+        all_hws = []
+        for kguess in tnrange(0, 256):
+            all_hws.append(np.array([self.leak_model.leakage(trace_tmp.textin, trace_tmp.textout, kguess, self.subkey_index, {'knownkey': trace_tmp.key}) for trace_tmp in self.traces]))
+        maxcpa = [0] * 256
+        all_traces = np.array(list(map(lambda x:x.wave, self.traces)))
+
+        N = len(all_traces)
+        all_coef = [[0 for _ in range(int(N / self.interval))] for _ in range(256)]
+
+        # Initialize first state by first set of traces.
+        trace_array = all_traces[:self.interval]
+        t_bar = self.mean(trace_array)
+        t_old_square_bar = self.mean(trace_array ** 2)
+        o_t = self.std_dev(trace_array, t_bar)
+        all_hws_bar = []
+        all_hws_old_square_bar = []
+        all_hws_x_t_bar = []
+
+        for kguess in range(256):
+            hws = all_hws[kguess][: self.interval][:, np.newaxis]
+            all_hws_bar.append(self.mean(hws))
+            o_hws = self.std_dev(hws, all_hws_bar[kguess])
+            all_hws_old_square_bar.append(self.mean(hws ** 2))
+            all_hws_x_t_bar.append(self.mean(hws * trace_array))
+            correlation = self.cov(trace_array, t_bar, hws, all_hws_bar[kguess])
+            cpaoutput = correlation / (o_t * o_hws)
+            maxcpa[kguess] = max(abs(cpaoutput))
+
+        for j in range(256):
+            all_coef[j][0] = maxcpa[j]
+
+        # Update correaltion by coming traces.
+        for i in tnrange(1, int(N/interval)):
+            trace_array = all_traces[i * self.interval:(i  +1) * self.interval]
+            maxcpa = [0] * 256
+            t_bar = self.continue_mean(trace_array, t_bar, i)
+            o_t, t_old_square_bar = self.continue_std(trace_array, t_bar, t_old_square_bar, i)
+
+            for kguess in range(256):
+                hws = all_hws[kguess][i * self.interval: (i + 1) * self.interval][:, np.newaxis]
+                all_hws_bar[kguess] = self.continue_mean(hws, all_hws_bar[kguess], i)
+                o_hws, tmp_square = self.continue_std(hws, all_hws_bar[kguess], all_hws_old_square_bar[kguess], i)
+                all_hws_old_square_bar[kguess] = tmp_square
+                all_hws_x_t_bar[kguess] = self.continue_mean(hws * trace_array, all_hws_x_t_bar[kguess], i)
+                correlation = self.continue_cov(all_hws_x_t_bar[kguess], t_bar, all_hws_bar[kguess])
+                cpaoutput = correlation/(o_t*o_hws)
+                maxcpa[kguess] = max(abs(cpaoutput))
+
+            for j in range(256):
+                all_coef[j][i] = maxcpa[j]
+        return all_coef
+
+    def plot_and_save(self, all_coef, figsize, save_path=None):
+        plt.figure(figsize=[20,8])
+        for item in all_coef:
+            plt.plot([i*self.interval for i in range(len(all_coef[0]))], item)
+        if save_path:
+            plt.savefig(save_path)
+        plt.show()
+
+    def mean(self, X):
+        return np.sum(X, axis=0)/len(X)
+
+    def std_dev(self, X, X_bar):
+        return np.sqrt(np.sum((X-X_bar)**2, axis=0))
+
+    def cov(self, X, X_bar, Y, Y_bar):
+        return np.sum((X-X_bar)*(Y-Y_bar), axis=0)
+
+    def continue_mean(self, X, X_old_bar, n):
+        return (X_old_bar*n + self.mean(X))/(n + 1)
+
+    def continue_std(self, X, X_bar, X_old_square_bar, n):
+        X_square_bar = self.continue_mean(X**2, X_old_square_bar, n)
+        output = np.sqrt(X_square_bar - X_bar**2)
+        return output, X_square_bar
+
+    def continue_cov(self, XY_bar, X_bar, Y_bar):
+        return XY_bar - X_bar * Y_bar

--- a/software/chipwhisperer/analyzer/attacks/coefficient_vs_trace_number.py
+++ b/software/chipwhisperer/analyzer/attacks/coefficient_vs_trace_number.py
@@ -2,24 +2,22 @@ import matplotlib.pyplot as plt
 from tqdm import tnrange
 import numpy as np
 
-class CoeffecientVsTracesNumber:
+class CoefficientVsTracesNumber:
     """Calculate coefficient from increasing number of traces.
 
-    We can see the changes of specific subkey coefficient while number of traces increase.
+    We can see the changes of specific subkey coefficient while number of traces increases.
     And the time complexity is o(N).
 
-    coeffecient(X, Y) = cov(X, Y) / (std(X) * std(Y))
+    coefficient(X, Y) = cov(X, Y) / (std(X) * std(Y))
     cov(X, Y) = E(X * Y) - E(X) * E(Y)
     std(X) = sqrt(E(X**2) - E(X)**2)
     std(Y) = sqrt(E(Y**2) - E(Y)**2)
-    coeffecient(X, Y) = (E(X * Y) - E(X) * E(Y)) / ((sqrt(E(X**2) - E(X)**2)) * (sqrt(E(Y**2) - E(Y)**2)))
-
+    coefficient(X, Y) = (E(X * Y) - E(X) * E(Y)) / ((sqrt(E(X**2) - E(X)**2)) * (sqrt(E(Y**2) - E(Y)**2)))
     Let X = [X1, X2]
     E(X) = (E(X1) * len(X1) + E(X2) * len(X2)) / (len(X1) + len(X2))
     Store E(X1 * Y1), E(X1), E(Y1), E(X1**2), E(Y1**2),
     calculate coming E(X2 * Y2), E(X2), E(Y2), E(X2**2), E(Y2**2).
-    We can get the new coeffeicient([X1, X2], [Y1, Y2]) without overlapping coeffeicient(X1, Y1) that we have calculated.
-
+    We can get the new coefficient([X1, X2], [Y1, Y2]) without overlapping coefficient(X1, Y1) that we have calculated.
 
 
     Example:
@@ -30,9 +28,9 @@ class CoeffecientVsTracesNumber:
         leak_model = cwa.leakage_models.sbox_output
         interval = 100
         subkey_index = 0  # First subkey.
-        coeffecient = CoeffecientVsTracesNumber(proj.traces, subkey_index, interval, leak_model)
-        results = coeffecient.get_effecient()
-        coeffecient.plot_and_save(results, [20,8], 'your_path_saving_figure')
+        coefficient = CoefficientVsTracesNumber(proj.traces, subkey_index, interval, leak_model)
+        results = coefficient.get_effecient()
+        coefficient.plot_and_save(results, [20,8], 'your_path_saving_figure')
 
 
     Args:


### PR DESCRIPTION
Get the coefficient vs trace number figure.

![coeffecient_subkey_0](https://user-images.githubusercontent.com/75358398/114046395-65d9a200-98bb-11eb-8ffd-c1c20ec0e4f4.png)

We can see the changes of specific subkey coefficient while number of traces increases.
And the time complexity is o(N).

coefficient(X, Y) = cov(X, Y) / (std(X) * std(Y))
cov(X, Y) = E(X * Y) - E(X) * E(Y)
std(X) = sqrt(E(X**2) - E(X)**2)
std(Y) = sqrt(E(Y**2) - E(Y)**2)
coefficient(X, Y) = (E(X * Y) - E(X) * E(Y)) / ((sqrt(E(X**2) - E(X)**2)) * (sqrt(E(Y**2) - E(Y)**2)))
Let X = [X1, X2]
E(X) = (E(X1) * len(X1) + E(X2) * len(X2)) / (len(X1) + len(X2))
Store E(X1 * Y1), E(X1), E(Y1), E(X1**2), E(Y1**2),
calculate coming E(X2 * Y2), E(X2), E(Y2), E(X2**2), E(Y2**2).
We can get the new coefficient([X1, X2], [Y1, Y2]) without overlapping coefficient(X1, Y1) that we have calculated.
