### PR TITLE
Make LED HAL functions for STM32F0 and STM32F3 use the same argument type

### DIFF
--- a/hardware/victims/firmware/hal/stm32f3/stm32f3_hal.c
+++ b/hardware/victims/firmware/hal/stm32f3/stm32f3_hal.c
@@ -129,7 +129,7 @@ void putch(char c)
   HAL_UART_Transmit(&UartHandle,  &d, 1, 5000);
 }
 #if (PLATFORM==CWLITEARM)
-void change_err_led(int x)
+void change_err_led(unsigned int x)
 {
     if (x)
          HAL_GPIO_WritePin(GPIOC, GPIO_PIN_13, RESET);
@@ -137,7 +137,7 @@ void change_err_led(int x)
          HAL_GPIO_WritePin(GPIOC, GPIO_PIN_13, SET);
 }
 
-void change_ok_led(int x)
+void change_ok_led(unsigned int x)
 {
      if (x)
           HAL_GPIO_WritePin(GPIOC, GPIO_PIN_14, RESET);

--- a/hardware/victims/firmware/hal/stm32f3/stm32f3_hal.h
+++ b/hardware/victims/firmware/hal/stm32f3/stm32f3_hal.h
@@ -31,8 +31,8 @@ void trigger_high(void);
 
 
 #if (PLATFORM==CWLITEARM)
-void change_err_led(int x);
-void change_ok_led(int x);
+void change_err_led(unsigned int x);
+void change_ok_led(unsigned int x);
 #define led_error(X) (change_err_led(X))
 #define led_ok(X) (change_ok_led(X))
 #endif


### PR DESCRIPTION
I am currently well under way in wrapping all the HALs and SimpleSerial in such a way that I can write firmware all ChipWhisperer targets in Rust. I noticed this small inconsistency in the `STM32F3` HAL versus the `STM32F0` HAL. It should not impact anything regarding actual usage. Although, there might be a compiler warning when people update.

This is mostly so that the ABI is consistent between the `STM32F0` (`led_ok`, `led_error`) and `STM32F3` (`change_ok_led`, `change_error_led`) interfaces.