### PR TITLE
Expose data type arguments for capturing non-float waves

### DIFF
--- a/software/chipwhisperer/__init__.py
+++ b/software/chipwhisperer/__init__.py
@@ -371,7 +371,9 @@ def target(scope : Optional[scopes.ScopeTypes],
     return rtn
 
 def capture_trace(scope : scopes.ScopeTypes, target : targets.TargetTypes, plaintext : bytearray,
-    key : Optional[bytearray]=None, ack : bool=True, poll_done : bool=False) -> Optional[Trace]:
+    key : Optional[bytearray]=None, ack : bool=True, poll_done : bool=False,
+    as_int : bool=False) -> Optional[Trace]:
+
     """Capture a trace, sending plaintext and key
 
     Does all individual steps needed to capture a trace (arming the scope
@@ -395,6 +397,8 @@ def capture_trace(scope : scopes.ScopeTypes, target : targets.TargetTypes, plain
             captures.  Can also result in slightly faster captures when the
             number of samples is high. Defaults to False. Supported by Husky
             only.
+        as_int (bool, optional): If False, return trace as a float. Otherwise,
+            return as an int.
 
     Returns:
         :class:`Trace <chipwhisperer.common.traces.Trace>` or None if capture
@@ -449,7 +453,7 @@ def capture_trace(scope : scopes.ScopeTypes, target : targets.TargetTypes, plain
         return None
 
     response = target.simpleserial_read('r', target.output_len, ack=ack)
-    wave = scope.get_last_trace()
+    wave = scope.get_last_trace(as_int=as_int)
 
     if len(wave) >= 1:
         return Trace(wave, plaintext, response, key)

--- a/software/chipwhisperer/common/api/ProjectFormat.py
+++ b/software/chipwhisperer/common/api/ProjectFormat.py
@@ -669,11 +669,12 @@ class Traces:
     def keys(self):
         return self._keys
 
-    def append(self, trace):
+    def append(self, trace, dtype=np.double):
         """Append a Trace containing the trace and related operation information.
 
         Args:
             trace (:class:`Trace <chipwhisperer.common.trace.Trace>`): A captured or created trace.
+            dtype: Numpy data type for storing trace.wave
 
         Raises:
             TypeError: When trying to append something other than a trace.
@@ -686,7 +687,7 @@ class Traces:
             self.cur_seg = self.project.segments.new()
             self.project.segments.append(self.cur_seg)
             self.cur_trace_num = 0
-        self.cur_seg.add_trace(*trace)
+        self.cur_seg.add_trace(*trace, dtype=dtype)
         self.cur_trace_num += 1
 
     def extend(self, iterable):


### PR DESCRIPTION
Both the OpenADC scope and the Trace class can already output and store
integers instead of doubles for the waves, respectively. But the
corresponding arguments were not exposed to the API previously. This
commit exposes these arguments to the API to allow users capture e.g.
waves as uint16 instead of doubles. This allows to reduce the memory
and storage requirements of long captures by roughly 4x.

This is related to NewAETech/ChipWhisperer#344.