### PR TITLE
Mark CW310 reset as implemented so we can use it.

### DIFF
--- a/software/chipwhisperer/hardware/naeusb/naeusb.py
+++ b/software/chipwhisperer/hardware/naeusb/naeusb.py
@@ -133,7 +133,7 @@ SAM_FW_FEATURE_BY_DEVICE = {
         SAM_FW_FEATURES[1]: '1.0.0',
         SAM_FW_FEATURES[2]: '1.0.0',
         SAM_FW_FEATURES[3]: '1.0.0',
-        SAM_FW_FEATURES[4]: '1.0.0',
+        SAM_FW_FEATURES[4]: '0.40.1',
         SAM_FW_FEATURES[5]: '1.0.0',
         SAM_FW_FEATURES[6]: '1.0.0',
         SAM_FW_FEATURES[7]: '1.0.0',


### PR DESCRIPTION
I've tested reset on 0.40.1 on my bergen board and it works, so I'd like to mark it as available as of this version of the firmware.