### PR TITLE
Support scope and target with context

### DIFF
--- a/software/chipwhisperer/capture/scopes/OpenADC.py
+++ b/software/chipwhisperer/capture/scopes/OpenADC.py
@@ -879,4 +879,8 @@ class OpenADC(util.DisableNewAttr, ChipWhispererCommonInterface):
         """
         return self.sc.sendMessage(CODE_WRITE, addr, listofbytes)
 
+    def __enter__(self):
+        return self
 
+    def __exit__(self, type, value, traceback):
+        self.dis()

--- a/software/chipwhisperer/capture/scopes/cwnano.py
+++ b/software/chipwhisperer/capture/scopes/cwnano.py
@@ -746,3 +746,9 @@ is in an error state, or is being used by another tool.") from e
 
     def usbdev(self):
         return self._cwusb
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.dis()

--- a/software/chipwhisperer/capture/targets/_base.py
+++ b/software/chipwhisperer/capture/targets/_base.py
@@ -163,3 +163,9 @@ class TargetTemplate:
 
     def __str__(self):
         return self.__repr__()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.dis()


### PR DESCRIPTION
The idea is to add support for scope and target in context. I personally find that much better to use and it has advantages in my opinion during development in Jupyter notebooks when `dis()` is not called and usb is still busy.

This is just a rough mockup and works for my purpose. If you like it, I can further get into any issues with it an adopt documentation/courses to reflect this usage.

Open a scope with context:

    with cw.scope() as scope:
        raise Exception # Something goes wrong

instead of:

    try:
	scope = cw.scope()
        raise Exception # Something goes wrong
    final:
        scope.dis()

Much code uses:

    scope = cw.scope()
    raise Exception # Something goes wrong
    scope.dis()

In Jupyter this leads to a claimed USB interface.

Some is for target, combined they can be opened:

    try cw.scope() as scope, cw.target(scope) as target:
        raise Exception # Something goes wrong