### PR TITLE
Make logging non-exclusive

### DIFF
--- a/software/chipwhisperer/logging.py
+++ b/software/chipwhisperer/logging.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 
-log_dir = tempfile.gettempdir()
+log_dir =  tempfile.mkdtemp(prefix='chipwhisperer')
 
 logging.basicConfig(level=logging.WARNING)
 cw_formatter = logging.Formatter("(%(name)s %(levelname)s|File %(filename)s:%(lineno)d) %(message)s")


### PR DESCRIPTION
The current solution did not work when multiple people were using chipwhisperer on the same machine.