### PR TITLE
Fix call to hex_decode in bootloader-glitch (wrong argument order)

### DIFF
--- a/hardware/victims/firmware/bootloader-glitch/bootloader.c
+++ b/hardware/victims/firmware/bootloader-glitch/bootloader.c
@@ -87,7 +87,7 @@ int main(void)
 		else if (state == INPUT) {
 			if ((c == '\n') || (c == '\r')) {
 				// We received the final character - decode our string
-				hex_decode((char*)ascii_buffer, ascii_idx, data_buffer);
+				hex_decode(ascii_idx, (char*)ascii_buffer, data_buffer);
 
 				// Decrypt data in-place
 				decrypt_data(data_buffer, DATA_BUFLEN);


### PR DESCRIPTION
Hey! I was battling with Fault 1_3 and only managing to dump empty memory...
Then I realized that the [argument order](https://github.com/newaetech/chipwhisperer/blob/a03e37ba6cdcb201c2d9d9d4d86a17dcc2f699f1/hardware/victims/firmware/simpleserial/simpleserial.c#L41) was wrong when the target calls `hex_decode`.

Hope it helps other people!