### PR TITLE
Fix removal of inaccessible devices

### DIFF
--- a/software/chipwhisperer/hardware/naeusb/naeusb.py
+++ b/software/chipwhisperer/hardware/naeusb/naeusb.py
@@ -498,7 +498,7 @@ class NAEUSB_Backend:
         if len(dev_list) == 0:
             return []
 
-        for dev in dev_list:
+        for dev in dev_list[:]:
             try:
                 a = dev.getSerialNumber()
                 naeusb_logger.info("Found ChipWhisperer with serial number {}".format(a))


### PR DESCRIPTION
When having multiple ChipWhisperer scopes attached and the user permissions for accessing one these scopes is missing, ```cw.scope()``` failes:
```
>>> import chipwhisperer as cw
>>> scope = cw.scope()
[<usb1.USBDevice object at 0x7f7dcc43cd90>]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/venv/src/chipwhisperer/software/chipwhisperer/__init__.py", line 384, in scope
    scope_type = get_cw_type(**kwargs)
  File "/opt/venv/src/chipwhisperer/software/chipwhisperer/common/utils/util.py", line 522, in get_cw_type
    device = cwusb.find(serial_number=sn, idProduct=possible_ids, hw_location=hw_location)
  File "/opt/venv/src/chipwhisperer/software/chipwhisperer/hardware/naeusb/naeusb.py", line 353, in find
    sns = ["{}:{}".format(dev.getProduct(), dev.getSerialNumber()) for dev in dev_list]
  File "/opt/venv/src/chipwhisperer/software/chipwhisperer/hardware/naeusb/naeusb.py", line 353, in <listcomp>
    sns = ["{}:{}".format(dev.getProduct(), dev.getSerialNumber()) for dev in dev_list]
  File "/opt/venv/lib/python3.8/site-packages/usb1/__init__.py", line 2003, in getProduct
    return self.open().getProduct()
  File "/opt/venv/lib/python3.8/site-packages/usb1/__init__.py", line 2055, in open
    mayRaiseUSBError(libusb1.libusb_open(self.device_p, byref(handle)))
  File "/opt/venv/lib/python3.8/site-packages/usb1/__init__.py", line 127, in mayRaiseUSBError
    __raiseUSBError(value)
  File "/opt/venv/lib/python3.8/site-packages/usb1/__init__.py", line 119, in raiseUSBError
    raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorNoDevice: LIBUSB_ERROR_NO_DEVICE [-4]
```
Although the [get_possible_devices](https://github.com/newaetech/chipwhisperer/blob/a891ded296bf4eaada2b90e795c0bd1d02e97cf9/software/chipwhisperer/hardware/naeusb/naeusb.py#L469) function in ```naeusb``` checks whether permissions are fine, the [removal](https://github.com/newaetech/chipwhisperer/blob/a891ded296bf4eaada2b90e795c0bd1d02e97cf9/software/chipwhisperer/hardware/naeusb/naeusb.py#L508) in the ```dev_list``` is incorrectly implemented. Instead of iterating over the list and removing items, the iteration should happen over a copy of the list.
