### PR TITLE
Add USART dependency for CW310

### DIFF
--- a/software/chipwhisperer/capture/targets/CW310.py
+++ b/software/chipwhisperer/capture/targets/CW310.py
@@ -28,6 +28,7 @@ from ...hardware.naeusb.fpga import FPGA
 from ...logging import *
 from collections import OrderedDict
 from ...common.utils import util
+from ...hardware.naeusb.serial import USART
 
 class CW310(CW305):
     """CW310 Bergen Board target object.


### PR DESCRIPTION
The CW310 target currently is missing the USART dependency. This PR fixes the issue.