### PR TITLE
[naeusb] Remove claimInterface

### DIFF
--- a/software/chipwhisperer/hardware/naeusb/naeusb.py
+++ b/software/chipwhisperer/hardware/naeusb/naeusb.py
@@ -432,9 +432,6 @@ class NAEUSB_Backend:
             raise
         self._usbdev = self.handle
 
-        # claim bulk interface, may not be necessary?
-        self.handle.claimInterface(0)
-
         self.sn = self.handle.getSerialNumber()
         self.pid = self.device.getProductID()
         naeusb_logger.debug('Found %s, Serial Number = %s' % (self.handle.getProduct(), self.sn))


### PR DESCRIPTION
When using CW in a podman container, establishing a connection with CW305 failes in `naeusb.py` with a `LIBUSB_ERROR_BUSY` error (but with CW310 it works).

As suggested [here](https://forum.newae.com/t/having-problems-setting-up-the-chipwhisperer-nano/3008/11), removing `self.handle.claimInterface(0)` solves the issue and a successful connection to CW305 (and CW310) can be established.