### PR TITLE
Claim interface on macos

### DIFF
--- a/software/chipwhisperer/hardware/naeusb/naeusb.py
+++ b/software/chipwhisperer/hardware/naeusb/naeusb.py
@@ -22,6 +22,7 @@ import math
 from threading import Thread
 import usb1  # type: ignore
 import os
+import sys
 import array
 from typing import Optional, Union, List, Tuple, Dict, cast
 from ...common.utils import util
@@ -431,7 +432,7 @@ class NAEUSB_Backend:
                 naeusb_logger.error("Or that you have the proper permissions to access it")
             raise
         self._usbdev = self.handle
-        if os.name == "nt":
+        if os.name == "nt" or sys.platform == "darwin":
             self.handle.claimInterface(0)
 
         self.sn = self.handle.getSerialNumber()


### PR DESCRIPTION
Solves #467 
Darwin also needs claim of interface for bulk. `os.name` only shows `posix` on macos so i think `sys.platform` is a better candidate.