### PR TITLE
Added reset of the scope's connection before closing it

### DIFF
--- a/software/chipwhisperer/capture/scopes/openadc_interface/naeusbchip.py
+++ b/software/chipwhisperer/capture/scopes/openadc_interface/naeusbchip.py
@@ -106,6 +106,7 @@ class OpenADCInterface_NAEUSBChip(DisableNewAttr):
 
     def dis(self):
         if not self.ser is None:
+            self.ser.reset()
             self.ser.close()
             self.ser = None
         else:


### PR DESCRIPTION
I'm using a CW-Lite, and I was lost when using the capture function of it.

Every time I made a capture, the result was different even though the firmware on the board was re-flash, and so I was a lot confused about what I got. In fact, I later understood that only the first capture was what I expected, while all others were noise. An option was then to unplug/plug the CW every time I needed to make a capture.

I then noticed that when disconnecting the scope's connection, the D4 led that popped green when I establish a connection for the first time was not disappearing.
After a few investigations, it appears that when disconnecting the scope, the latter connection was not reseted, which seems non-natural (I would not expect the scope to have any side-effects outside of the connection's period). Furthermore, when reseting it, it appears that the led switch-offs, which is, I think, the expected behavior.

Thus, here is a PR adding a reset before a disconnect :)

As I could not find documentation on what's the reset about (the 0x22 cmd), I don't know if it's the better solution, but it seems fine by me.

I could not test this on another device than the CW-Lite as it's the only one at my disposal.