### PR TITLE
fixed segment's samples modulo

### DIFF
--- a/software/chipwhisperer/capture/scopes/_OpenADCInterface.py
+++ b/software/chipwhisperer/capture/scopes/_OpenADCInterface.py
@@ -1635,7 +1635,7 @@ class TriggerSettings(util.DisableNewAttr):
                 scope_logger.warning("Sakura G samples must be divisible by 12, rounding up to {}...".format(samples))
 
         if self._get_fifo_fill_mode() == "segment":
-            diff = (3 - (samples - 1) % 3)
+            diff = ((3 - (samples - 1)) % 3)
             samples += diff
             if diff > 0:
                 scope_logger.warning("segment mode requires (samples-1) divisible by 3, rounding up to {}...".format(samples))


### PR DESCRIPTION
The segment mode (activated with `scope.adc.fifo_fill_mode = "segment"`) keeps warning about (sample-1) not being divisible by 3 (warning in `_OpenADCInterface.py`, line 1574) even if sample-1 *is* divisible by 3. In fact, the modulo to check for rounding lack some parentheses.
This commit and PR fixes it :)