### PR TITLE
Add N76E003 firmware

### DIFF
--- a/hardware/victims/firmware/numicro8051/.gitignore
+++ b/hardware/victims/firmware/numicro8051/.gitignore
@@ -1,0 +1,2 @@
+out/
+objdir-*/

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -128,7 +128,7 @@ ifneq ($(CRYPTO_OPTIONS),NONE)
 endif
 
 ifeq ($(BAUD_RATE),)
-    BAUD_RATE = 115200
+    BAUD_RATE = 230400
 endif
 CDEFS += -DBAUD_RATE=$(BAUD_RATE)
 

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -127,6 +127,11 @@ ifneq ($(CRYPTO_OPTIONS),NONE)
   endif
 endif
 
+ifeq ($(BAUD_RATE),)
+    BAUD_RATE = 115200
+endif
+CDEFS += -DBAUD_RATE=$(BAUD_RATE)
+
 # Not enough memory to run crypto targets with SS_VER_1_1 when XRAM_SIZE <= 768, only SS_VER_2_1
 SMALL_XRAM_SIZES = 128 256 512 768
 ifneq ($(MAKECMDGOALS),clean)

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -18,15 +18,14 @@ ifeq ($(PLATFORM),)
     $(error PLATFORM not defined)
 endif
 
-CLOCK =
-F_CPUS_ALLOWED = 11059200 16000000 16600000 18432000 20000000 22100000 24000000
+# These CPUs aren't really stable at other frequencies when using the internal oscillator
+INT_OSC_ALLOWED = 16000000 16600000
 ifeq ($(PLATFORM), CW308_N76E003)
     ifeq ($(F_CPU),)
         F_CPU = 16000000
     endif
+    SUPPORTS_24MHZ = 0
     INCDIR = $(PINCDIR)/N76E003
-    # Not stable at other frequencies
-    F_CPUS_ALLOWED = 16000000 16600000
     # PRG Size = 18K Bytes
     CODE_SIZE = 18432
     # INT-MEM Size = 256 Bytes
@@ -37,9 +36,8 @@ else ifeq ($(PLATFORM), CW308_N76S003)
     ifeq ($(F_CPU),)
         F_CPU = 16000000
     endif
+    SUPPORTS_24MHZ = 0
     INCDIR = $(PINCDIR)/N76S003
-    # Not stable at other frequencies
-    F_CPUS_ALLOWED = 16000000 16600000
     # PRG Size = 18K Bytes, -128 for SPROM (maybe????)
     # Spec sheet implies it has an SPROM area, but it is not clear if it actually does.
     # The feature part looks like they sloppily copied it from the MS51 series spec sheet:
@@ -56,7 +54,7 @@ else ifeq ($(PLATFORM), CW308_MS5116K)
     ifeq ($(F_CPU),)
         F_CPU = 24000000
     endif
-    CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
+    SUPPORTS_24MHZ = 1
     INCDIR = $(PINCDIR)/MS5132K
     # PRG Size = 16K Bytes, -128 for the SPROM
     CODE_SIZE = 16256
@@ -68,6 +66,7 @@ else ifeq ($(PLATFORM), CW308_MS5132K)
     ifeq ($(F_CPU),)
         F_CPU = 24000000
     endif
+    SUPPORTS_24MHZ = 1
     CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
     INCDIR = $(PINCDIR)/MS5132K
     # PRG Size = 32K Bytes, -128 for the SPROM
@@ -79,11 +78,25 @@ else ifeq ($(PLATFORM), CW308_MS5132K)
 else
     $(error Unsupported PLATFORM: $(PLATFORM))
 endif
-ifeq ($(filter $(F_CPU),$(F_CPUS_ALLOWED)),)
-    $(error Invalid F_CPU: $(F_CPU); allowed values for platform $(PLATFORM): $(F_CPUS_ALLOWED))
+# default: Use the External clock
+ifeq ($(USE_EXTERNAL_CLOCK),)
+    USE_EXTERNAL_CLOCK = 1
+endif
+ifeq ($(SUPPORTS_24MHZ),1)
+    CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
+    INT_OSC_ALLOWED = 16000000 16600000 24000000
+else
+    ifeq ($(shell test $(F_CPU) -gt 16600000; echo $$?),0)
+        $(warning WARNING: F_CPU is set to $(F_CPU), but $(PLATFORM) only supports up to 16.6MHz)
+    endif
 endif
 
-USE_EXTERNAL_CLOCK := 1
+ifeq ($(USE_EXTERNAL_CLOCK),0)
+    ifeq ($(filter $(F_CPU),$(INT_OSC_ALLOWED)),)
+        $(error Invalid F_CPU: $(F_CPU); When using internal clock, allowed values for $(PLATFORM) are: $(INT_OSC_ALLOWED))
+    endif
+endif
+
 # CDEFS :=
 CDEFS += -DF_CPU=$(F_CPU) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
 # ------------------------------------------------------
@@ -107,7 +120,7 @@ ifneq ($(CRYPTO_OPTIONS),NONE)
 endif
 
 ifeq ($(BAUD_RATE),)
-    BAUD_RATE = 230400
+    BAUD_RATE = 115200
 endif
 CDEFS += -DBAUD_RATE=$(BAUD_RATE)
 

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -12,19 +12,15 @@ TOOLSDIR = $(FIRMWAREPATH)/tools
 EXTRAINCDIRS += $(HALDIR)
 VPATH += $(LIBDIR):$(HALDIR)
 
-# Platform Specific defines
 # ------------------------------------------------------
+# Platform Specific defines
 ifeq ($(PLATFORM),)
     $(error PLATFORM not defined)
 endif
 
-# These CPUs aren't really stable at other frequencies when using the internal oscillator
-INT_OSC_ALLOWED = 16000000 16600000
 ifeq ($(PLATFORM), CW308_N76E003)
-    ifeq ($(F_CPU),)
-        F_CPU = 16000000
-    endif
     SUPPORTS_24MHZ = 0
+    DEFAULT_CLK = 16000000
     INCDIR = $(PINCDIR)/N76E003
     # PRG Size = 18K Bytes
     CODE_SIZE = 18432
@@ -32,11 +28,9 @@ ifeq ($(PLATFORM), CW308_N76E003)
     IRAM_SIZE = 256
     # EXT-MEM Size = 768 Bytes
     XRAM_SIZE = 768
-else ifeq ($(PLATFORM), CW308_N76S003)
-    ifeq ($(F_CPU),)
-        F_CPU = 16000000
-    endif
+else ifeq ($(PLATFORM), CW308_N76S003_AT20)
     SUPPORTS_24MHZ = 0
+    DEFAULT_CLK = 16000000
     INCDIR = $(PINCDIR)/N76S003
     # PRG Size = 18K Bytes, -128 for SPROM (maybe????)
     # Spec sheet implies it has an SPROM area, but it is not clear if it actually does.
@@ -50,11 +44,9 @@ else ifeq ($(PLATFORM), CW308_N76S003)
     IRAM_SIZE = 256
     # EXT-MEM Size = 1K Bytes
     XRAM_SIZE = 1024
-else ifeq ($(PLATFORM), CW308_MS5116K)
-    ifeq ($(F_CPU),)
-        F_CPU = 24000000
-    endif
+else ifeq ($(PLATFORM), CW308_MS5116K_AT20)
     SUPPORTS_24MHZ = 1
+    DEFAULT_CLK = 24000000
     INCDIR = $(PINCDIR)/MS5132K
     # PRG Size = 16K Bytes, -128 for the SPROM
     CODE_SIZE = 16256
@@ -62,12 +54,9 @@ else ifeq ($(PLATFORM), CW308_MS5116K)
     IRAM_SIZE = 256
     # EXT-MEM Size = 1K Bytes
     XRAM_SIZE = 1024
-else ifeq ($(PLATFORM), CW308_MS5132K)
-    ifeq ($(F_CPU),)
-        F_CPU = 24000000
-    endif
+else ifeq ($(PLATFORM), CW308_MS5132K_AT20)
     SUPPORTS_24MHZ = 1
-    CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
+    DEFAULT_CLK = 24000000
     INCDIR = $(PINCDIR)/MS5132K
     # PRG Size = 32K Bytes, -128 for the SPROM
     CODE_SIZE = 32512
@@ -78,22 +67,59 @@ else ifeq ($(PLATFORM), CW308_MS5132K)
 else
     $(error Unsupported PLATFORM: $(PLATFORM))
 endif
-# default: Use the External clock
+
+# ------------------------------------------------------
+# Clock speeds and options
+
+# Use the External clock by default
 ifeq ($(USE_EXTERNAL_CLOCK),)
     USE_EXTERNAL_CLOCK = 1
 endif
+
+ifeq ($(USE_EXTERNAL_CLOCK),1)
+    # Common F_CPU for all platforms
+    ifeq ($(F_CPU),)
+        F_CPU = 7372800
+    endif
+    # EXT_CLK is used by the `delay_xx_us()` functions
+    ifeq ($(EXT_CLK),)
+        EXT_CLK = $(DEFAULT_CLK)
+    endif
+    ifneq ($(findstring UL,$(EXT_CLK)),UL)
+        EXT_CLK := $(addsuffix UL,$(EXT_CLK))
+    endif
+    CDEFS += -DEXT_CLK=$(EXT_CLK)
+else # USE_EXTERNAL_CLOCK = 0
+    ifeq ($(F_CPU),)
+        F_CPU = $(DEFAULT_CLK)
+    endif
+endif
+
+ifneq ($(findstring UL,$(F_CPU)),UL)
+    F_CPU := $(addsuffix UL,$(F_CPU))
+endif
+F_CPU_INT := $(subst UL,,$(F_CPU))
+EXT_CLK_INT := $(subst UL,,$(EXT_CLK))
+
+# These chips aren't stable at other frequencies when using the internal oscillator
+INT_OSC_ALLOWED = 16000000 16600000
 ifeq ($(SUPPORTS_24MHZ),1)
     CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
     INT_OSC_ALLOWED = 16000000 16600000 24000000
 else
-    ifeq ($(shell test $(F_CPU) -gt 16600000; echo $$?),0)
-        $(warning WARNING: F_CPU is set to $(F_CPU), but $(PLATFORM) only supports up to 16.6MHz)
+    ifeq ($(shell test $(F_CPU_INT) -gt 16600000; echo $$?),0)
+        $(warning WARNING: F_CPU is set to $(F_CPU_INT), but $(PLATFORM) only supports up to 16.6MHz)
+    endif
+    ifneq ($(EXT_CLK),)
+        ifeq ($(shell test $(EXT_CLK_INT) -gt 16600000; echo $$?),0)
+            $(warning WARNING: EXT_CLK is set to $(EXT_CLK_INT), but $(PLATFORM) only supports up to 16.6MHz)
+        endif
     endif
 endif
 
 ifeq ($(USE_EXTERNAL_CLOCK),0)
-    ifeq ($(filter $(F_CPU),$(INT_OSC_ALLOWED)),)
-        $(error Invalid F_CPU: $(F_CPU); When using internal clock, allowed values for $(PLATFORM) are: $(INT_OSC_ALLOWED))
+    ifeq ($(filter $(F_CPU_INT),$(INT_OSC_ALLOWED)),)
+        $(error Invalid F_CPU: $(F_CPU_INT); When using internal clock, allowed values for $(PLATFORM) are: $(INT_OSC_ALLOWED))
     endif
 endif
 
@@ -159,22 +185,8 @@ CTOASM = $(addprefix $(OUTDIR)/, $(C_TO_ASM_FILE))
 
 # Memory Model (small, medium, large, huge)
 ifeq ($(MODEL),)
-    MODEL  := medium
+    MODEL := medium
 endif
-$(info MODEL=$(MODEL))
-MODEL_VAL =
-ifeq ($(MODEL), small)
-    MODEL_VAL = 0
-else ifeq ($(MODEL), medium)
-    MODEL_VAL = 1
-else ifeq ($(MODEL), large)
-    MODEL_VAL = 2
-else ifeq ($(MODEL), huge)
-    MODEL_VAL = 3
-else
-    $(error Invalid MODEL: $(MODEL))
-endif
-CDEFS += -DMODEL=$(MODEL_VAL)
 
 # USE_FLOATS (this should be combined with model large if set 1)
 # -DUSE_FLOATS=1

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -83,30 +83,9 @@ ifeq ($(filter $(F_CPU),$(F_CPUS_ALLOWED)),)
     $(error Invalid F_CPU: $(F_CPU); allowed values for platform $(PLATFORM): $(F_CPUS_ALLOWED))
 endif
 
-ifeq ($(F_CPU), 24000000)
-    CLOCK = FOSC_240000
-endif
-ifeq ($(F_CPU), 22100000)
-    CLOCK = FOSC_221000
-endif
-ifeq ($(F_CPU), 20000000)
-    CLOCK = FOSC_200000
-endif
-ifeq ($(F_CPU), 18432000)
-    CLOCK = FOSC_184320
-endif
-ifeq ($(F_CPU), 16600000)
-    CLOCK = FOSC_166000
-endif
-ifeq ($(F_CPU), 16000000)
-    CLOCK = FOSC_160000
-endif
-ifeq ($(F_CPU), 11059200)
-    CLOCK = FOSC_110592
-endif
 USE_EXTERNAL_CLOCK := 1
 # CDEFS :=
-CDEFS += -D$(CLOCK) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
+CDEFS += -DF_CPU=$(F_CPU) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
 # ------------------------------------------------------
 # Target and Source
 

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -1,0 +1,248 @@
+#
+# SDCC Makefile for mcs51
+# Modified for Numicro 8051 series
+# ------------------------------------------------------
+# PATH
+PLATFORM := CW308_N76E003
+PINCDIR  = $(FIRMWAREPATH)/inc
+OBJDIR  = objdir-$(PLATFORM)
+LIBDIR  = $(FIRMWAREPATH)/commonlib
+HALDIR = $(FIRMWAREPATH)/hal
+TOOLSDIR = $(FIRMWAREPATH)/tools
+EXTRAINCDIRS += $(HALDIR)
+VPATH += $(LIBDIR):$(HALDIR)
+
+# Platform Specific defines
+# ------------------------------------------------------
+ifeq ($(PLATFORM),)
+    $(error PLATFORM not defined)
+endif
+
+CLOCK =
+F_CPUS_ALLOWED = 11059200 16000000 16600000 18432000 20000000 22100000 24000000
+ifeq ($(PLATFORM), CW308_N76E003)
+    ifeq ($(F_CPU),)
+        F_CPU = 16000000
+    endif
+    INCDIR = $(PINCDIR)/N76E003
+    # Not stable at other frequencies
+    F_CPUS_ALLOWED = 16000000 16600000
+    # PRG Size = 18K Bytes
+    CODE_SIZE = 18432
+    # INT-MEM Size = 256 Bytes
+    IRAM_SIZE = 256
+    # EXT-MEM Size = 768 Bytes
+    XRAM_SIZE = 768
+else ifeq ($(PLATFORM), CW308_N76S003)
+    ifeq ($(F_CPU),)
+        F_CPU = 16000000
+    endif
+    INCDIR = $(PINCDIR)/N76S003
+    # Not stable at other frequencies
+    F_CPUS_ALLOWED = 16000000 16600000
+    # PRG Size = 18K Bytes, -128 for SPROM (maybe????)
+    # Spec sheet implies it has an SPROM area, but it is not clear if it actually does.
+    # The feature part looks like they sloppily copied it from the MS51 series spec sheet:
+    #  - "128-bytes security protection memory SPROM (only for 32KB/16KB APROM)"
+    # The MS51 has 32KB/16KB APROM options; the N76S003 only has an 18KB option.
+    # It is also missing parts that explain how the SPROM works like the MS51 series spec sheet does.
+    # Setting it anyway so that we don't inadvertantly overwrite the last byte and lock it if it does.
+    CODE_SIZE = 18304
+    # INT-MEM Size = 256 Bytes
+    IRAM_SIZE = 256
+    # EXT-MEM Size = 1K Bytes
+    XRAM_SIZE = 1024
+else ifeq ($(PLATFORM), CW308_MS5116K)
+    ifeq ($(F_CPU),)
+        F_CPU = 24000000
+    endif
+    CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
+    INCDIR = $(PINCDIR)/MS5132K
+    # PRG Size = 16K Bytes, -128 for the SPROM
+    CODE_SIZE = 16256
+    # INT-MEM Size = 256 Bytes
+    IRAM_SIZE = 256
+    # EXT-MEM Size = 1K Bytes
+    XRAM_SIZE = 1024
+else ifeq ($(PLATFORM), CW308_MS5132K)
+    ifeq ($(F_CPU),)
+        F_CPU = 24000000
+    endif
+    CDEFS += -DNUM51_CPU24MHZ_SUPPORTED
+    INCDIR = $(PINCDIR)/MS5132K
+    # PRG Size = 32K Bytes, -128 for the SPROM
+    CODE_SIZE = 32512
+    # INT-MEM Size = 256 Bytes
+    IRAM_SIZE = 256
+    # EXT-MEM Size = 2K Bytes
+    XRAM_SIZE = 2048
+else
+    $(error Unsupported PLATFORM: $(PLATFORM))
+endif
+ifeq ($(filter $(F_CPU),$(F_CPUS_ALLOWED)),)
+    $(error Invalid F_CPU: $(F_CPU); allowed values for platform $(PLATFORM): $(F_CPUS_ALLOWED))
+endif
+
+ifeq ($(F_CPU), 24000000)
+    CLOCK = FOSC_240000
+endif
+ifeq ($(F_CPU), 22100000)
+    CLOCK = FOSC_221000
+endif
+ifeq ($(F_CPU), 20000000)
+    CLOCK = FOSC_200000
+endif
+ifeq ($(F_CPU), 18432000)
+    CLOCK = FOSC_184320
+endif
+ifeq ($(F_CPU), 16600000)
+    CLOCK = FOSC_166000
+endif
+ifeq ($(F_CPU), 16000000)
+    CLOCK = FOSC_160000
+endif
+ifeq ($(F_CPU), 11059200)
+    CLOCK = FOSC_110592
+endif
+USE_EXTERNAL_CLOCK := 1
+# CDEFS :=
+CDEFS += -D$(CLOCK) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
+# ------------------------------------------------------
+# Target and Source
+
+SRC += $(wildcard $(SRCDIR)/*.c $(LIBDIR)/*.c $(HALDIR)/*.c)
+ASM_SRC = $(wildcard $(SRCDIR)/*.asm)
+
+ifeq ($(CRYPTO_OPTIONS),)
+    CRYPTO_OPTIONS = NONE
+endif
+ifeq ($(CRYPTO_TARGET),)
+    CRYPTO_TARGET = NONE
+endif
+ifneq ($(CRYPTO_OPTIONS),NONE)
+  ifeq ($(CRYPTO_OPTIONS), AES128C)
+    ifeq ($(CRYPTO_TARGET),NONE)
+        CRYPTO_TARGET = TINYAES128C
+    endif
+  endif
+endif
+
+# Not enough memory to run crypto targets with SS_VER_1_1 when XRAM_SIZE <= 768, only SS_VER_2_1
+SMALL_XRAM_SIZES = 128 256 512 768
+ifneq ($(MAKECMDGOALS),clean)
+    ifneq ($(CRYPTO_TARGET),NONE)
+        ifneq ($(CRYPTO_TARGET),TINYAES128C)
+            $(error TINYAES128C is the only supported CRYPTO_TARGET for $(PLATFORM))
+        endif
+        ifneq ($(SS_VER), SS_VER_2_1)
+            ifneq ($(filter $(XRAM_SIZE),$(SMALL_XRAM_SIZES)),)
+                $(error CRYPTO_TARGET is not supported with SS_VER=$(SS_VER) for $(PLATFORM), use SS_VER_2_1)
+            endif
+        endif
+        include $(FIRMWAREPATH)/crypto/Makefile.crypto
+    endif
+endif
+
+C_SRC_FILE = $(notdir $(SRC))
+C_OBJ_FILE = $(C_SRC_FILE:%.c=%.c.rel)
+C_TO_ASM_FILE = $(C_SRC_FILE:%.c=%.asm)
+
+ASM_SRC_FILE = $(notdir $(ASM_SRC))
+ASM_OBJ_FILE = $(ASM_SRC_FILE:%.asm=%.asm.rel)
+
+OBJ = $(addprefix $(OBJDIR)/, $(C_OBJ_FILE)) $(addprefix $(OBJDIR)/, $(ASM_OBJ_FILE))
+CTOASM = $(addprefix $(OUTDIR)/, $(C_TO_ASM_FILE))
+
+#$(info $(CTOASM))
+
+# ------------------------------------------------------
+# Usually SDCC's small memory model is the best choice.  If
+# you run out of internal RAM, you will need to declare
+# variables as "xdata", or switch to larger model
+
+# Memory Model (small, medium, large, huge)
+ifeq ($(MODEL),)
+    MODEL  := medium
+endif
+$(info MODEL=$(MODEL))
+MODEL_VAL =
+ifeq ($(MODEL), small)
+    MODEL_VAL = 0
+else ifeq ($(MODEL), medium)
+    MODEL_VAL = 1
+else ifeq ($(MODEL), large)
+    MODEL_VAL = 2
+else ifeq ($(MODEL), huge)
+    MODEL_VAL = 3
+else
+    $(error Invalid MODEL: $(MODEL))
+endif
+CDEFS += -DMODEL=$(MODEL_VAL)
+
+# USE_FLOATS (this should be combined with model large if set 1)
+# -DUSE_FLOATS=1
+# $(info OBJ=$(OBJ))
+# $(info SRC=$(SRC))
+# $(info CDEFS=$(CDEFS))
+# $(info EXTRAINCDIRS=$(EXTRAINCDIRS))
+# $(info VPATH=$(VPATH))
+# $(info TARGET=$(TARGET))
+
+# ------------------------------------------------------
+# SDCC
+
+CC = sdcc
+AS = sdas8051
+
+MCU_MODEL = mcs51
+
+#LIBS    =
+#LIBPATH = -L $(LIBDIR)
+
+#DEBUG = --debug
+# NOTE: --stack-auto seems to be broken for N76E003, not recommended
+AFLAGS =  -l -s
+CFLAGS = --less-pedantic --disable-warning 85 -I$(INCDIR) -I$(LIBDIR) -m$(MCU_MODEL) --model-$(MODEL) --out-fmt-ihx --no-xinit-opt $(DEBUG) $(CDEFS) --peep-file $(TOOLSDIR)/peep.def
+CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
+LFLAGS = $(LIBPATH) $(LIBS) -m$(MCU_MODEL) --model-$(MODEL) --code-size $(CODE_SIZE) --iram-size $(IRAM_SIZE) --xram-size $(XRAM_SIZE) --out-fmt-ihx $(DEBUG) $(CDEFS)
+
+TARGET-PLAT = $(TARGET)-$(PLATFORM)
+# ------------------------------------------------------
+# Recepies, see GNU MAKE manual
+
+.PHONY: all
+
+all: make-dirs $(TARGET-PLAT).bin $(TARGET-PLAT).hex
+
+make-dirs:
+	mkdir -p $(OBJDIR)
+
+%.hex: $(OBJDIR)/%.ihx
+	packihx $^ > $@
+
+%.bin: $(OBJDIR)/%.ihx
+	makebin -p $^ $@
+
+$(OBJDIR)/%.ihx: $(OBJ)
+	$(CC) -o $@ $(LFLAGS) $^
+
+$(OBJDIR)/%.c.rel: %.c
+	$(CC) -o $@ $(CFLAGS) -c $^
+
+$(OBJDIR)/%.asm.rel: %.asm
+	$(AS) $(AFLAGS) -o $@ $^
+
+.PHONY: clean
+
+clean:
+	rm -rf $(OBJDIR)/*
+	rm -rf $(TARGET-PLAT).hex
+	rm -rf $(TARGET-PLAT).bin
+	rm -rf $(TARGET-PLAT).asm
+
+
+asm: $(CTOASM)
+
+%.asm: %.c
+	$(CC) -o $@ -S $(CFLAGS) -c $^
+

--- a/hardware/victims/firmware/numicro8051/Makefile.inc
+++ b/hardware/victims/firmware/numicro8051/Makefile.inc
@@ -5,7 +5,8 @@
 # PATH
 PLATFORM := CW308_N76E003
 PINCDIR  = $(FIRMWAREPATH)/inc
-OBJDIR  = objdir-$(PLATFORM)
+_OBJDIR = objdir
+OBJDIR  = $(_OBJDIR)-$(PLATFORM)
 LIBDIR  = $(FIRMWAREPATH)/commonlib
 HALDIR = $(FIRMWAREPATH)/hal
 TOOLSDIR = $(FIRMWAREPATH)/tools
@@ -47,7 +48,7 @@ else ifeq ($(PLATFORM), CW308_N76S003_AT20)
 else ifeq ($(PLATFORM), CW308_MS5116K_AT20)
     SUPPORTS_24MHZ = 1
     DEFAULT_CLK = 24000000
-    INCDIR = $(PINCDIR)/MS5132K
+    INCDIR = $(PINCDIR)/MS5116K
     # PRG Size = 16K Bytes, -128 for the SPROM
     CODE_SIZE = 16256
     # INT-MEM Size = 256 Bytes
@@ -83,23 +84,29 @@ ifeq ($(USE_EXTERNAL_CLOCK),1)
     endif
     # EXT_CLK is used by the `delay_xx_us()` functions
     ifeq ($(EXT_CLK),)
-        EXT_CLK = $(DEFAULT_CLK)
+        _EXT_CLK = $(DEFAULT_CLK)UL
+    else
+        ifneq ($(findstring UL,$(EXT_CLK)),UL)
+            _EXT_CLK = $(addsuffix UL,$(EXT_CLK))
+        endif
     endif
-    ifneq ($(findstring UL,$(EXT_CLK)),UL)
-        EXT_CLK := $(addsuffix UL,$(EXT_CLK))
-    endif
-    CDEFS += -DEXT_CLK=$(EXT_CLK)
+    CDEFS += -DEXT_CLK=$(_EXT_CLK)
 else # USE_EXTERNAL_CLOCK = 0
     ifeq ($(F_CPU),)
-        F_CPU = $(DEFAULT_CLK)
+        F_CPU = $(DEFAULT_CLK)UL
     endif
 endif
 
 ifneq ($(findstring UL,$(F_CPU)),UL)
-    F_CPU := $(addsuffix UL,$(F_CPU))
+    _F_CPU = $(addsuffix UL,$(F_CPU))
+else
+    _F_CPU = $(F_CPU)
 endif
-F_CPU_INT := $(subst UL,,$(F_CPU))
-EXT_CLK_INT := $(subst UL,,$(EXT_CLK))
+
+
+F_CPU_INT := $(subst UL,,$(_F_CPU))
+EXT_CLK_INT := $(subst UL,,$(_EXT_CLK))
+$(info FCPU=$(F_CPU))
 
 # These chips aren't stable at other frequencies when using the internal oscillator
 INT_OSC_ALLOWED = 16000000 16600000
@@ -117,14 +124,16 @@ else
     endif
 endif
 
-ifeq ($(USE_EXTERNAL_CLOCK),0)
-    ifeq ($(filter $(F_CPU_INT),$(INT_OSC_ALLOWED)),)
-        $(error Invalid F_CPU: $(F_CPU_INT); When using internal clock, allowed values for $(PLATFORM) are: $(INT_OSC_ALLOWED))
+ifneq ($(MAKECMDGOALS),clean)
+    ifeq ($(USE_EXTERNAL_CLOCK),0)
+        ifeq ($(filter $(F_CPU_INT),$(INT_OSC_ALLOWED)),)
+            $(error Invalid F_CPU: $(F_CPU_INT); When using internal clock, allowed values for $(PLATFORM) are: $(INT_OSC_ALLOWED))
+        endif
     endif
 endif
 
 # CDEFS :=
-CDEFS += -DF_CPU=$(F_CPU) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
+CDEFS += -DF_CPU=$(_F_CPU) -DUSE_EXTERNAL_CLOCK=$(USE_EXTERNAL_CLOCK) -D__SDCC__
 # ------------------------------------------------------
 # Target and Source
 
@@ -145,10 +154,9 @@ ifneq ($(CRYPTO_OPTIONS),NONE)
   endif
 endif
 
-ifeq ($(BAUD_RATE),)
-    BAUD_RATE = 115200
+ifneq ($(BAUD_RATE),)
+    CDEFS += -DBAUD_RATE=$(BAUD_RATE)
 endif
-CDEFS += -DBAUD_RATE=$(BAUD_RATE)
 
 # Not enough memory to run crypto targets with SS_VER_1_1 when XRAM_SIZE <= 768, only SS_VER_2_1
 SMALL_XRAM_SIZES = 128 256 512 768
@@ -244,10 +252,10 @@ $(OBJDIR)/%.asm.rel: %.asm
 .PHONY: clean
 
 clean:
-	rm -rf $(OBJDIR)/*
-	rm -rf $(TARGET-PLAT).hex
-	rm -rf $(TARGET-PLAT).bin
-	rm -rf $(TARGET-PLAT).asm
+	rm -rf $(_OBJDIR)-*/*
+	rm -rf $(TARGET)-*.hex
+	rm -rf $(TARGET)-*.bin
+	rm -rf $(TARGET)-*.asm
 
 
 asm: $(CTOASM)

--- a/hardware/victims/firmware/numicro8051/README.md
+++ b/hardware/victims/firmware/numicro8051/README.md
@@ -1,10 +1,8 @@
 # N76E003 target firmware for chipwhisperer
-
 This contains the platform firmware to be loaded onto the CW308_N76E003 target.
 
 ## Requirements
 - SDCC
-- nuvo51icpy
 - makebin
 - packihx
 
@@ -13,7 +11,4 @@ In the target directory (e.g. simpleserial-glitch, simpleserial-aes, etc), run:
     `make SS_VER=SS_VER_2_1`
 
 ### Caveats
-Only SS_VER_2_1 is supported at this time. This is due to the N76E003 having a very small amount of memory, and the SS_VER_1_1 firmware won't fit the memory model for most targets.
-
-## Programming
-Use `nuvo51icpy`.
+Only SS_VER_2_1 is supported when using a crypto target. This is due to the N76E003 having a very small amount of memory, and the SS_VER_1_1 firmware won't fit the memory model for most targets.

--- a/hardware/victims/firmware/numicro8051/README.md
+++ b/hardware/victims/firmware/numicro8051/README.md
@@ -1,0 +1,19 @@
+# N76E003 target firmware for chipwhisperer
+
+This contains the platform firmware to be loaded onto the CW308_N76E003 target.
+
+## Requirements
+- SDCC
+- nuvo51icpy
+- makebin
+- packihx
+
+## Building
+In the target directory (e.g. simpleserial-glitch, simpleserial-aes, etc), run:
+    `make SS_VER=SS_VER_2_1`
+
+### Caveats
+Only SS_VER_2_1 is supported at this time. This is due to the N76E003 having a very small amount of memory, and the SS_VER_1_1 firmware won't fit the memory model for most targets.
+
+## Programming
+Use `nuvo51icpy`.

--- a/hardware/victims/firmware/numicro8051/basic-passwdcheck/basic-passwdcheck.c
+++ b/hardware/victims/firmware/numicro8051/basic-passwdcheck/basic-passwdcheck.c
@@ -1,0 +1,132 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define IDLE 0
+#define KEY 1
+#define PLAIN 2
+
+#define BUFLEN 64
+
+uint8_t memory[BUFLEN];
+// uint8_t tmp[BUFLEN];
+char asciibuf[BUFLEN];
+uint8_t pt[16];
+
+static void delay_2_ms(void);
+
+
+void my_puts(char *c)
+{
+  do {
+    putch(*c);
+
+  } while (*++c);
+}
+
+static void delay_2_ms()
+{
+  for (volatile unsigned int i=0; i < 0xfff; i++ ){
+    ;
+  }
+}
+
+void my_read(char *buf, int len)
+{
+  for(int i = 0; i < len; i++) {
+    while (buf[i] = getch(), buf[i] == '\0');
+
+    if (buf[i] == '\n') {
+      buf[i] = '\0';
+      return;
+    }
+  }
+  buf[len - 1] = '\0';
+}
+
+int main(void)
+  {
+    platform_init();
+  init_uart();
+  trigger_setup();
+
+    char passwd[32];
+    char correct_passwd[] = "h0px3";
+
+  while(1){
+
+        my_puts("*****Safe-o-matic 3000 Booting...\n");
+        //Print some fancy-sounding stuff so that attackers
+        //will get scared and leave us alone
+        my_puts("Aligning bits........[DONE]\n");
+        delay_2_ms();
+        my_puts("Checking Cesium RNG..[DONE]\n");
+        delay_2_ms();
+        my_puts("Masquerading flash...[DONE]\n");
+        delay_2_ms();
+        my_puts("Decrypting database..[DONE]\n");
+        delay_2_ms();
+        my_puts("\n\n");
+
+        //Give them one last warning
+        my_puts("WARNING: UNAUTHORIZED ACCESS WILL BE PUNISHED\n");
+
+        trigger_low();
+
+        //Get password
+        my_puts("Please enter password to continue: ");
+        my_read(passwd, 32);
+
+        uint8_t passbad = 0;
+
+        trigger_high();
+
+        for(uint8_t i = 0; i < sizeof(correct_passwd); i++){
+            if (correct_passwd[i] != passwd[i]){
+                passbad = 1;
+                break;
+            }
+        }
+
+        if (passbad){
+            //Stop them fancy timing attacks
+             int wait = 1;
+            for(volatile int i = 0; i < wait; i++){
+                ;
+            }
+            delay_2_ms();
+            delay_2_ms();
+            my_puts("PASSWORD FAIL\n");
+            led_error(1);
+        } else {
+            my_puts("Access granted, Welcome!\n");
+            led_ok(1);
+        }
+
+        //All done;
+        while(1);
+  }
+
+  return 1;
+  }
+
+

--- a/hardware/victims/firmware/numicro8051/basic-passwdcheck/makefile
+++ b/hardware/victims/firmware/numicro8051/basic-passwdcheck/makefile
@@ -1,0 +1,52 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = basic-passwdcheck
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += basic-passwdcheck.c
+
+# -----------------------------------------------------------------------------
+# ifeq ($(CRYPTO_OPTIONS),)
+# CRYPTO_OPTIONS = AES128C
+# endif
+
+# SS_VER = SS_VER_1_0
+
+#Add simpleserial project to build
+# include ../simpleserial/Makefile.simpleserial
+
+MODEL = medium
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/blink-forever/Makefile
+++ b/hardware/victims/firmware/numicro8051/blink-forever/Makefile
@@ -1,0 +1,48 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = blink-forever
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += blink-forever.c
+
+# -----------------------------------------------------------------------------
+
+CRYPTO_TARGET=NONE
+
+#Add simpleserial project to build
+# include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
+++ b/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
@@ -23,27 +23,9 @@
 #include <stdlib.h>
 #include "Delay.h"
 #include "clock.h"
-#define TIMER_DIV12_VALUE_10ms_16MHZ			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
 
-// the idea is that the device will blink at different intervals depending on the clock speed
-void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
-{
-    clr_T1M;      // T1M=0, Timer1 Clock = Fsys/12
-    TMOD |= 0x10; // Timer1 is 16-bit mode
-    set_TR1;      // Start Timer1
-    while (u32CNT != 0)
-    {
-        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_16MHZ); // Find  define in "Function_define.h" "TIMER VALUE"
-        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_16MHZ);
-        while (TF1 != 1)
-            ; // Check Timer1 Time-Out Flag
-        clr_TF1;
-        u32CNT--;
-    }
-    clr_TR1; // Stop Timer1
-}
-
-#define BLINK_DELAY 50 // half a second
+// Half a second
+#define BLINK_DELAY 50
 
 int main(void)
 {
@@ -55,8 +37,8 @@ int main(void)
     P05 = 0;
     while(1){
         led_ok(1);
-        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+        Timer1_Delay10ms(BLINK_DELAY);
         led_ok(0);
-        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+        Timer1_Delay10ms(BLINK_DELAY);
     }
 }

--- a/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
+++ b/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
@@ -25,20 +25,21 @@
 #include "clock.h"
 
 // Half a second
-#define BLINK_DELAY 50
+#define BLINK_DELAY 500
 
 int main(void)
 {
-    P03_PUSHPULL_MODE;
-    P12_PUSHPULL_MODE;
-    P05_PUSHPULL_MODE;
-    P03 = 1;
-    P12 = 0;
-    P05 = 0;
+    platform_init();
+    PIN_LED_STATUS_PUSHPULL_MODE;
+    PIN_LED_OK_PUSHPULL_MODE;
+    PIN_LED_ERROR_PUSHPULL_MODE;
+    PIN_LED_STATUS = 1;
+    PIN_LED_ERROR = 0;
+    PIN_LED_OK = 0;
     while(1){
         led_ok(1);
-        Timer1_Delay10ms(BLINK_DELAY);
+        Timer0_Delay1ms(BLINK_DELAY);
         led_ok(0);
-        Timer1_Delay10ms(BLINK_DELAY);
+        Timer0_Delay1ms(BLINK_DELAY);
     }
 }

--- a/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
+++ b/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include "Delay.h"
 #include "clock.h"
-#define TIMER_DIV12_VALUE_10ms_FOSC_160000			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
+#define TIMER_DIV12_VALUE_10ms_16MHZ			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
 
 // the idea is that the device will blink at different intervals depending on the clock speed
 void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
@@ -33,8 +33,8 @@ void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
     set_TR1;      // Start Timer1
     while (u32CNT != 0)
     {
-        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000); // Find  define in "Function_define.h" "TIMER VALUE"
-        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000);
+        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_16MHZ); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_16MHZ);
         while (TF1 != 1)
             ; // Check Timer1 Time-Out Flag
         clr_TF1;

--- a/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
+++ b/hardware/victims/firmware/numicro8051/blink-forever/blink-forever.c
@@ -1,0 +1,62 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2020 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include "Common.h"
+#include "isp_uart0.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include "Delay.h"
+#include "clock.h"
+#define TIMER_DIV12_VALUE_10ms_FOSC_160000			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
+
+// the idea is that the device will blink at different intervals depending on the clock speed
+void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
+{
+    clr_T1M;      // T1M=0, Timer1 Clock = Fsys/12
+    TMOD |= 0x10; // Timer1 is 16-bit mode
+    set_TR1;      // Start Timer1
+    while (u32CNT != 0)
+    {
+        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000);
+        while (TF1 != 1)
+            ; // Check Timer1 Time-Out Flag
+        clr_TF1;
+        u32CNT--;
+    }
+    clr_TR1; // Stop Timer1
+}
+
+#define BLINK_DELAY 50 // half a second
+
+int main(void)
+{
+    P03_PUSHPULL_MODE;
+    P12_PUSHPULL_MODE;
+    P05_PUSHPULL_MODE;
+    P03 = 1;
+    P12 = 0;
+    P05 = 0;
+    while(1){
+        led_ok(1);
+        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+        led_ok(0);
+        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+    }
+}

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/bootloader.c
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/bootloader.c
@@ -1,0 +1,139 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include <stdint.h>
+#include <stdlib.h>
+// #include <util/delay.h>
+#include "decryption.h"
+#include "hex_decode.h"
+
+char hex_lookup[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+void hex_print(const uint8_t * in, int len, char *out)
+{
+	unsigned int i,j;
+	j=0;
+	for (i=0; i < len; i++) {
+		out[j++] = hex_lookup[in[i] >> 4];
+		out[j++] = hex_lookup[in[i] & 0x0F];
+	}
+	
+	out[j] = 0;
+}
+
+#define DATA_BUFLEN 40
+#define ASCII_BUFLEN (2 * DATA_BUFLEN)
+
+// uint8_t buffer[ASCII_BUFLEN + DATA_BUFLEN];
+// uint8_t *ascii_buffer = buffer;
+// uint8_t *data_buffer = buffer + ASCII_BUFLEN;
+uint8_t ascii_buffer[ASCII_BUFLEN];
+uint8_t data_buffer[DATA_BUFLEN];
+
+#define IDLE 0
+#define INPUT 1
+#define RESPOND 2
+
+int main(void)
+{
+    platform_init();
+	init_uart();	
+	trigger_setup();
+	
+ 	/* Uncomment this to get a HELLO message for debug */
+	// putch('h');
+	// putch('e');
+	// putch('l');
+	// putch('l');
+	// putch('o');
+	// putch('\n');
+		
+	char c;
+	char state = 0;
+	uint8_t ascii_idx = 0;
+	 
+	while(1){
+		c = getch();
+		
+		if (c == 'x' || c == 'k') 
+		{
+			ascii_idx = 0;
+			state = IDLE;
+			continue;		
+		}	
+		
+		else if (c == 'p') 
+		{
+			ascii_idx = 0;
+			state = INPUT;
+			continue;
+		}
+		
+		else if (state == INPUT) {
+			if ((c == '\n') || (c == '\r')) {
+				// We received the final character - decode our string
+				hex_decode(ascii_idx, (char*)ascii_buffer, data_buffer);
+
+				// Decrypt data in-place
+				decrypt_data(data_buffer, DATA_BUFLEN);
+				
+				// This is where we would write the image into memory
+				
+				// Send back a positive response
+				ascii_idx = 0;
+				ascii_buffer[ascii_idx++] = 'r';
+				ascii_buffer[ascii_idx++] = '0';
+				ascii_buffer[ascii_idx++] = '\n';
+				ascii_buffer[ascii_idx++] = '\n';
+				ascii_buffer[ascii_idx++] = '\n';
+				ascii_buffer[ascii_idx++] = '\n';
+				ascii_buffer[ascii_idx++] = '\n';
+				ascii_buffer[ascii_idx++] = '\n';
+				state = RESPOND;
+			} 
+			else if (ascii_idx >= ASCII_BUFLEN)
+			{
+				// We have nowhere to put this character - give up!
+				state = IDLE;
+			} 
+			else 
+			{
+				// Store the character in the buffer so we can use it later
+				ascii_buffer[ascii_idx++] = c;
+			}
+		}
+		
+		
+		if(state == RESPOND)
+		{
+			// Send the ascii buffer back 
+			trigger_high();
+			
+			int i;
+			for(i = 0; i < ascii_idx; i++)
+			{
+				putch(ascii_buffer[i]);
+			}
+			trigger_low();
+			state = IDLE;
+		}
+	}
+		
+	return 1;
+}

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/decryption.c
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/decryption.c
@@ -1,0 +1,32 @@
+// decryption.c
+// Decrypt data using rot-13
+// TODO: Improve security by using double-rot-13
+//
+// Authors:
+//   Greg d'Eon <gdeon@newae.com>
+
+#include "decryption.h"
+#include <stdint.h>
+
+int num_chars = 2*26;
+char __xdata input[]  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+char __xdata output[] = "nopqrstuvwxyzabcdefghijklmNOPQRSTUVWXYZABCDEFGHIJKLM";
+
+// Decrypt len bytes in the buffer
+void decrypt_data(uint8_t* buffer, uint8_t len)
+{
+	// Apply rot-13 to each byte
+	int i, j;
+	for(i = 0; i < len; i++)
+	{
+		// Search for character inside input array
+		for(j = 0; j < num_chars; j++)
+		{
+			if(buffer[i] == input[j])
+			{
+				buffer[i] = output[j];
+				break;
+			}
+		}
+	}
+}

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/decryption.h
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/decryption.h
@@ -1,0 +1,10 @@
+// decryption.h
+// Super-secret decryption used in bootloader
+//
+// Authors:
+//   Greg d'Eon <gdeon@newae.com>
+
+#include <stdint.h>
+
+// Decrypt len bytes in the buffer
+void decrypt_data(uint8_t* buffer, uint8_t len);

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/encrypt.py
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/encrypt.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: latin-1 -*-
+
+# encrypt.py
+# Script for encrypting strings 
+
+# The string being encrypted
+input_str = "Don't forget to buy milk!"
+
+print "p{}\\n".format(input_str.encode('rot13').encode('hex'))

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/hex_decode.c
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/hex_decode.c
@@ -1,0 +1,29 @@
+#include "hex_decode.h"
+uint8_t hex_decode(int len, char* ascii_buf, uint8_t* data_buf)
+{
+	for(int i = 0; i < len; i++)
+	{
+		char n_hi = ascii_buf[2*i];
+		char n_lo = ascii_buf[2*i+1];
+
+		if(n_lo >= '0' && n_lo <= '9')
+			data_buf[i] = n_lo - '0';
+		else if(n_lo >= 'A' && n_lo <= 'F')
+			data_buf[i] = n_lo - 'A' + 10;
+		else if(n_lo >= 'a' && n_lo <= 'f')
+			data_buf[i] = n_lo - 'a' + 10;
+		else
+			return 1;
+
+		if(n_hi >= '0' && n_hi <= '9')
+			data_buf[i] |= (n_hi - '0') << 4;
+		else if(n_hi >= 'A' && n_hi <= 'F')
+			data_buf[i] |= (n_hi - 'A' + 10) << 4;
+		else if(n_hi >= 'a' && n_hi <= 'f')
+			data_buf[i] |= (n_hi - 'a' + 10) << 4;
+		else
+			return 1;
+	}
+
+	return 0;
+}

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/hex_decode.h
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/hex_decode.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+
+uint8_t hex_decode(int len, char *ascii_buf, uint8_t *data_buf);

--- a/hardware/victims/firmware/numicro8051/bootloader-glitch/makefile
+++ b/hardware/victims/firmware/numicro8051/bootloader-glitch/makefile
@@ -1,0 +1,50 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = bootloader
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += bootloader.c decryption.c hex_decode.c
+
+# -----------------------------------------------------------------------------
+
+# ifeq ($(CRYPTO_OPTIONS),)
+# CRYPTO_OPTIONS = AES128C
+# endif
+
+#Add simpleserial project to build
+# include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/commonlib/Common.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/Common.c
@@ -7,30 +7,10 @@ __bit BIT_TMP;
 //----------------------------------------------------------------------------------
 // UART0 baud rate initial setting
 //----------------------------------------------------------------------------------
-#define DIV_ROUND_CLOSEST_POS(n, d) (((n) - (d) / 2) / (d))
-#define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) == ((d) < 0)) ? (((n) + (d) / 2) / (d)) : (((n) - (d) / 2) / (d)))
 
-#ifdef FOSC_110592
-#define FSYS_DIV16 691200
-#endif
-#ifdef FOSC_160000
-#define FSYS_DIV16 1000000
-#endif
-#ifdef FOSC_166000
-#define FSYS_DIV16 1037500
-#endif
-#ifdef FOSC_184320
-#define FSYS_DIV16 1152000
-#endif
-#ifdef FOSC_200000
-#define FSYS_DIV16 1250000
-#endif
-#ifdef FOSC_221184
-#define FSYS_DIV16 1382400
-#endif
-#ifdef FOSC_240000
-#define FSYS_DIV16 1500000
-#endif
+// these are constant expressions, so SDCC should optimize them into constants
+#define FSYS_DIV16 DIV_ROUND_CLOSEST_UNSIGNED(F_CPU, 16)
+
 void InitialUART0_Timer1(UINT32 u32Baudrate) // T1M = 1, SMOD = 1
 {
     P06_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
@@ -43,7 +23,7 @@ void InitialUART0_Timer1(UINT32 u32Baudrate) // T1M = 1, SMOD = 1
     set_CKCON_T1M;
     clr_T3CON_BRCK; // Serial port 0 baud rate clock source = Timer1
 
-    TH1 = 256 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate);
+    TH1 = 256 - DIV_ROUND_CLOSEST_UNSIGNED(FSYS_DIV16, u32Baudrate);
     set_TCON_TR1;
     set_SCON_TI; // For printf function must setting TI = 1
 }
@@ -58,8 +38,8 @@ void InitialUART0_Timer3(UINT32 u32Baudrate) // use timer3 as Baudrate generator
     T3CON &= 0xF8;  // T3PS2=0,T3PS1=0,T3PS0=0(Prescale=1)
     set_T3CON_BRCK; // UART0 baud rate clock source = Timer3
 
-    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
-    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST_UNSIGNED(FSYS_DIV16, u32Baudrate));
+    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST_UNSIGNED(FSYS_DIV16, u32Baudrate));
     set_T3CON_TR3; // Trigger Timer3
     set_SCON_TI;  // For printf function must setting TI = 1
 }
@@ -93,8 +73,8 @@ void InitialUART1_Timer3(UINT32 u32Baudrate) // use timer3 as Baudrate generator
     SCON_1 = 0x50; // UART1 Mode1,REN_1=1,TI_1=1
     T3CON = 0x08;  // T3PS2=0,T3PS1=0,T3PS0=0(Prescale=1), UART1 in MODE 1
 
-    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
-    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST_UNSIGNED(FSYS_DIV16, u32Baudrate));
+    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST_UNSIGNED(FSYS_DIV16, u32Baudrate));
     set_T3CON_TR3; // Trigger Timer3
 }
 

--- a/hardware/victims/firmware/numicro8051/commonlib/Common.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/Common.c
@@ -1,0 +1,139 @@
+#include "numicro_8051.h"
+#include "Common.h"
+#include "Delay.h"
+
+__bit BIT_TMP;
+
+//----------------------------------------------------------------------------------
+// UART0 baud rate initial setting
+//----------------------------------------------------------------------------------
+#define DIV_ROUND_CLOSEST_POS(n, d) (((n) - (d) / 2) / (d))
+#define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) == ((d) < 0)) ? (((n) + (d) / 2) / (d)) : (((n) - (d) / 2) / (d)))
+
+#ifdef FOSC_110592
+#define FSYS_DIV16 691200
+#endif
+#ifdef FOSC_160000
+#define FSYS_DIV16 1000000
+#endif
+#ifdef FOSC_166000
+#define FSYS_DIV16 1037500
+#endif
+#ifdef FOSC_184320
+#define FSYS_DIV16 1152000
+#endif
+#ifdef FOSC_200000
+#define FSYS_DIV16 1250000
+#endif
+#ifdef FOSC_221184
+#define FSYS_DIV16 1382400
+#endif
+#ifdef FOSC_240000
+#define FSYS_DIV16 1500000
+#endif
+void InitialUART0_Timer1(UINT32 u32Baudrate) // T1M = 1, SMOD = 1
+{
+    P06_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+    P07_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+
+    SCON = 0x50;  // UART0 Mode1,REN=1,TI=1
+    TMOD |= 0x20; // Timer1 Mode1
+
+    set_PCON_SMOD; // UART0 Double Rate Enable
+    set_CKCON_T1M;
+    clr_T3CON_BRCK; // Serial port 0 baud rate clock source = Timer1
+
+    TH1 = 256 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate);
+    set_TCON_TR1;
+    set_SCON_TI; // For printf function must setting TI = 1
+}
+//---------------------------------------------------------------
+void InitialUART0_Timer3(UINT32 u32Baudrate) // use timer3 as Baudrate generator
+{
+    P06_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+    P07_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+
+    SCON = 0x50;    // UART0 Mode1,REN=1,TI=1
+    set_PCON_SMOD;  // UART0 Double Rate Enable
+    T3CON &= 0xF8;  // T3PS2=0,T3PS1=0,T3PS0=0(Prescale=1)
+    set_T3CON_BRCK; // UART0 baud rate clock source = Timer3
+
+    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    set_T3CON_TR3; // Trigger Timer3
+    set_SCON_TI;  // For printf function must setting TI = 1
+}
+
+UINT8 Receive_Data_From_UART0(void)
+{
+    UINT8 c;
+    while (!RI)
+        ;
+    c = SBUF;
+    RI = 0;
+    return (c);
+}
+
+void Send_Data_To_UART0(UINT8 c)
+{
+    TI = 0;
+    SBUF = c;
+    while (TI == 0)
+        ;
+}
+
+//----------------------------------------------------------------------------------
+// UART1 baud rate initial setting
+//----------------------------------------------------------------------------------
+void InitialUART1_Timer3(UINT32 u32Baudrate) // use timer3 as Baudrate generator
+{
+    P02_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+    P16_QUASI_MODE; // Setting UART pin as Quasi mode for transmit
+
+    SCON_1 = 0x50; // UART1 Mode1,REN_1=1,TI_1=1
+    T3CON = 0x08;  // T3PS2=0,T3PS1=0,T3PS0=0(Prescale=1), UART1 in MODE 1
+
+    RH3 = HIBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    RL3 = LOBYTE(65536 - DIV_ROUND_CLOSEST(FSYS_DIV16, u32Baudrate));
+    set_T3CON_TR3; // Trigger Timer3
+}
+
+UINT8 Receive_Data_From_UART1(void)
+{
+    UINT8 c;
+
+    while (!RI_1)
+        ;
+    c = SBUF_1;
+    RI_1 = 0;
+    return (c);
+}
+
+void Send_Data_To_UART1(UINT8 c)
+{
+    TI_1 = 0;
+    SBUF_1 = c;
+    while (TI_1 == 0)
+        ;
+}
+
+/*==========================================================================*/
+#ifdef SW_Reset
+void SW_Reset(void)
+{
+    TA = 0xAA;
+    TA = 0x55;
+    set_SWRST;
+}
+#endif
+
+unsigned char
+_sdcc_external_startup(void)
+{
+    // power on reset disable, as recommended by N76E003 errata
+    _enable_TA;
+    PORDIS=0x5A;
+    _enable_TA;
+    PORDIS=0xA5;
+    return 0;
+}

--- a/hardware/victims/firmware/numicro8051/commonlib/Common.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Common.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdint.h>
+#include <numicro_8051.h>
+
+#define     CID_READ				0x0B
+#define     DID_READ				0x0C
+
+#define     ERASE_APROM				0x22
+#define     READ_APROM				0x00
+#define     PROGRAM_APROM			0x21
+#define     READ_CFG				0xC0
+#define     PROGRAM_CFG				0xE1
+#define		READ_UID				0x04
+
+
+/*   general macros                                                          */
+#define _enable_TA TA=0xAA;TA=0x55 // Enable writes to a TA-protected register without disabling interrupts (ensure interrupts are disabled before writing to a TA-protected register)
+#define _asgn_TAR(reg, val) _enable_TA;reg=val    // Assign (=) value to TA-protected register without disabling interrupts (ensure interrupts are disabled before using)
+#define _anda_TAR(reg, val) _enable_TA;reg&=val   // And-assign (&=) value to TA-protected register without disabling interrupts (ensure interrupts are disabled before using)
+#define _nanda_TAR(reg, val) _enable_TA;reg&=~val // Nand-assign (&=~) value to TA-protected register without disabling interrupts (ensure interrupts are disabled before using)
+#define _ora_TAR(reg, val) _enable_TA;reg|=val    // Or-assign (|=) value to TA-protected register without disabling interrupts (ensure interrupts are disabled before using)
+#define _xora_TAR(reg, val) _enable_TA;reg^=val   // Xor-assign (^=) value to TA-protected register without disabling interrupts (ensure interrupts are disabled before using)
+
+#define asgn_TAR(reg, val) BIT_TMP=EA;EA=0;_asgn_TAR(reg, val);EA=BIT_TMP // Assign (=) value to TA-protected register
+#define anda_TAR(reg, val) BIT_TMP=EA;EA=0;_anda_TAR(reg, val);EA=BIT_TMP // And-assign (&=) value to TA-protected register
+#define nanda_TAR(reg, val) BIT_TMP=EA;EA=0;_nanda_TAR(reg, val);EA=BIT_TMP // Nand-assign (&=~) value to TA-protected register
+#define ora_TAR(reg, val) BIT_TMP=EA;EA=0;_ora_TAR(reg, val);EA=BIT_TMP // Or-assign (|=) value to TA-protected register
+#define xora_TAR(reg, val) BIT_TMP=EA;EA=0;_xora_TAR(reg, val);EA=BIT_TMP // Xor-assign (^=) value to TA-protected register
+
+#define tmp_clr_EA(statement) BIT_TMP=EA;EA=0;statement;EA=BIT_TMP // Disable interrupts for the length of the statement, then enables them again if they were already enabled
+
+
+
+void  InitialUART0_Timer1(UINT32 u32Baudrate); //T1M = 1, SMOD = 1
+void  InitialUART0_Timer3(UINT32 u32Baudrate); //Timer3 as Baudrate, SMOD=1, Prescale=0
+void  InitialUART1_Timer3(UINT32 u32Baudrate);
+void  Send_Data_To_UART0(UINT8 c);
+UINT8 Receive_Data_From_UART0(void);
+void  Send_Data_To_UART1(UINT8 c);
+UINT8 Receive_Data_From_UART1(void);
+
+// unsigned char _sdcc_external_startup (void);
+
+extern BIT BIT_TMP;

--- a/hardware/victims/firmware/numicro8051/commonlib/Common.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Common.h
@@ -30,6 +30,9 @@
 
 #define tmp_clr_EA(statement) BIT_TMP=EA;EA=0;statement;EA=BIT_TMP // Disable interrupts for the length of the statement, then enables them again if they were already enabled
 
+#define DIV_ROUND_CLOSEST_UNSIGNED(n, d) (((n) + (d) / 2) / (d))
+#define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) == ((d) < 0)) ? DIV_ROUND_CLOSEST_UNSIGNED(n, d) : (((n) - (d) / 2) / (d)))
+
 
 
 void  InitialUART0_Timer1(UINT32 u32Baudrate); //T1M = 1, SMOD = 1

--- a/hardware/victims/firmware/numicro8051/commonlib/Common.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Common.h
@@ -2,6 +2,14 @@
 
 #include <stdint.h>
 #include <numicro_8051.h>
+#define _SELECT_ASSERT_FUNC(x, EXPR, MSG, ASSERT_MACRO, ...) ASSERT_MACRO
+#define STATIC_ASSERT_SIMPLE(EXPR)      _Static_assert(EXPR, "unspecified message")
+#define STATIC_ASSERT_MSG(EXPR, MSG)    _Static_assert(EXPR, MSG)
+#define STATIC_ASSERT(...)                                                                          \
+    _SELECT_ASSERT_FUNC(x, ##__VA_ARGS__,                                                           \
+                        STATIC_ASSERT_MSG(__VA_ARGS__),                                             \
+                        STATIC_ASSERT_SIMPLE(__VA_ARGS__))
+
 
 #define     CID_READ				0x0B
 #define     DID_READ				0x0C

--- a/hardware/victims/firmware/numicro8051/commonlib/Delay.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/Delay.c
@@ -1,0 +1,106 @@
+#include "numicro_8051.h"
+#include "Common.h"
+#include "Delay.h"
+
+//-------------------------------------------------------------------------
+void Timer0_Delay100us(UINT32 u32CNT)
+{
+    clr_CKCON_T0M;      // T0M=0, Timer0 Clock = Fsys/12
+    TMOD |= 0x01; // Timer0 is 16-bit mode
+    set_TCON_TR0;      // Start Timer0
+    while (u32CNT != 0)
+    {
+        TL0 = LOBYTE(TIMER_DIV12_VALUE_100us); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH0 = HIBYTE(TIMER_DIV12_VALUE_100us);
+        while (TF0 != 1)
+            ; // Check Timer0 Time-Out Flag
+        clr_TCON_TF0;
+        u32CNT--;
+    }
+    clr_TCON_TR0; // Stop Timer0
+}
+//------------------------------------------------------------------------------
+void Timer0_Delay1ms(UINT32 u32CNT)
+{
+    clr_CKCON_T0M;      // T0M=0, Timer0 Clock = Fsys/12
+    TMOD |= 0x01; // Timer0 is 16-bit mode
+    set_TCON_TR0;      // Start Timer0
+    while (u32CNT != 0)
+    {
+        TL0 = LOBYTE(TIMER_DIV12_VALUE_1ms); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH0 = HIBYTE(TIMER_DIV12_VALUE_1ms);
+        while (TF0 != 1)
+            ; // Check Timer0 Time-Out Flag
+        clr_TCON_TF0;
+        u32CNT--;
+    }
+    clr_TCON_TR0; // Stop Timer0
+}
+
+//------------------------------------------------------------------------------
+void Timer1_Delay10ms(UINT32 u32CNT)
+{
+    clr_CKCON_T1M;      // T1M=0, Timer1 Clock = Fsys/12
+    TMOD |= 0x10; // Timer1 is 16-bit mode
+    set_TCON_TR1;      // Start Timer1
+    while (u32CNT != 0)
+    {
+        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms);
+        while (TF1 != 1)
+            ; // Check Timer1 Time-Out Flag
+        clr_TCON_TF1;
+        u32CNT--;
+    }
+    clr_TCON_TR1; // Stop Timer1
+}
+//------------------------------------------------------------------------------
+void Timer2_Delay500us(UINT32 u32CNT)
+{
+    clr_T2MOD_T2DIV2; // Timer2 Clock = Fsys/4
+    clr_T2MOD_T2DIV1;
+    set_T2MOD_T2DIV0;
+    set_T2CON_TR2; // Start Timer2
+    while (u32CNT != 0)
+    {
+        TL2 = LOBYTE(TIMER_DIV4_VALUE_500us); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH2 = HIBYTE(TIMER_DIV4_VALUE_500us);
+        while (TF2 != 1)
+            ; // Check Timer2 Time-Out Flag
+        clr_T2CON_TF2;
+        u32CNT--;
+    }
+    clr_T2CON_TR2; // Stop Timer2
+}
+//------------------------------------------------------------------------------
+void Timer3_Delay100ms(UINT32 u32CNT)
+{
+    T3CON = 0x07; // Timer3 Clock = Fsys/128
+    set_T3CON_TR3;      // Trigger Timer3
+    while (u32CNT != 0)
+    {
+        RL3 = LOBYTE(TIMER_DIV128_VALUE_100ms); // Find  define in "Function_define.h" "TIMER VALUE"
+        RH3 = HIBYTE(TIMER_DIV128_VALUE_100ms);
+        while ((T3CON & SET_BIT4) != SET_BIT4)
+            ; // Check Timer3 Time-Out Flag
+        clr_T3CON_TF3;
+        u32CNT--;
+    }
+    clr_T3CON_TR3; // Stop Timer3
+}
+//------------------------------------------------------------------------------
+void Timer3_Delay10us(UINT32 u32CNT)
+{
+    T3CON = 0x07; // Timer3 Clock = Fsys/128
+    set_T3CON_TR3;      // Trigger Timer3
+    while (u32CNT != 0)
+    {
+        RL3 = LOBYTE(TIMER_DIV4_VALUE_10us); // Find  define in "Function_define.h" "TIMER VALUE"
+        RH3 = HIBYTE(TIMER_DIV4_VALUE_10us);
+        while ((T3CON & SET_BIT4) != SET_BIT4)
+            ; // Check Timer3 Time-Out Flag
+        clr_T3CON_TF3;
+        u32CNT--;
+    }
+    clr_T3CON_TR3; // Stop Timer3
+}

--- a/hardware/victims/firmware/numicro8051/commonlib/Delay.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Delay.h
@@ -4,8 +4,7 @@
 
 
 #define _DIV_ROUND_CLOSEST_POS(n, d) (((n) + (d) / 2) / (d))
-#define _get_minus_factor(delay_us, clk_div, cpu_hz) (_DIV_ROUND_CLOSEST_POS((delay_us * cpu_hz / clk_div), 1000000))
-#define get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536 - _get_minus_factor(delay_us, clk_div, cpu_hz))
+#define get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536 - (_DIV_ROUND_CLOSEST_POS((delay_us * cpu_hz / clk_div), 1000000)))
 
 // Because these are all constant expressions, SDCC should optimize all usages of these into constant values
 #define TIMER_DIV12_VALUE_10us	   get_delay_timer_value(10, 12, F_CPU)

--- a/hardware/victims/firmware/numicro8051/commonlib/Delay.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Delay.h
@@ -2,27 +2,33 @@
 #include <stdint.h>
 #include "numicro_8051.h"
 
+// We are using the external clock value here so that we delay for the correct amount of time
+#ifndef EXT_CLK
+#define EXT_CLK F_CPU
+#endif
 
 #define _DIV_ROUND_CLOSEST_POS(n, d) (((n) + (d) / 2) / (d))
-#define get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536 - (_DIV_ROUND_CLOSEST_POS((delay_us * cpu_hz / clk_div), 1000000)))
+#define get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536 - (_DIV_ROUND_CLOSEST_POS((delay_us * _DIV_ROUND_CLOSEST_POS(cpu_hz/ 1000000UL)), clk_div)))
+// Only use this for constant expressions
+#define constexpr_get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536ULL - (_DIV_ROUND_CLOSEST_POS((delay_us * cpu_hz / clk_div), 1000000ULL)))
 
 // Because these are all constant expressions, SDCC should optimize all usages of these into constant values
-#define TIMER_DIV12_VALUE_10us	   get_delay_timer_value(10, 12, F_CPU)
-#define TIMER_DIV12_VALUE_100us	   get_delay_timer_value(100, 12, F_CPU)
-#define TIMER_DIV12_VALUE_1ms	   get_delay_timer_value(1000, 12, F_CPU)
-#define	TIMER_DIV12_VALUE_10ms	   get_delay_timer_value(10000, 12, F_CPU)
-#define TIMER_DIV12_VALUE_40ms	   get_delay_timer_value(40000, 12, F_CPU)
-#define TIMER_DIV4_VALUE_10us	   get_delay_timer_value(10, 4, F_CPU)
-#define TIMER_DIV4_VALUE_100us	   get_delay_timer_value(100, 4, F_CPU)
-#define TIMER_DIV4_VALUE_200us	   get_delay_timer_value(200, 4, F_CPU)
-#define TIMER_DIV4_VALUE_500us	   get_delay_timer_value(500, 4, F_CPU)
-#define TIMER_DIV4_VALUE_1ms       get_delay_timer_value(1000, 4, F_CPU)
-#define TIMER_DIV16_VALUE_10ms	   get_delay_timer_value(10000, 16, F_CPU)
-#define TIMER_DIV64_VALUE_30ms	   get_delay_timer_value(30000, 64, F_CPU)
-#define	TIMER_DIV128_VALUE_100ms   get_delay_timer_value(100000, 128, F_CPU)
-#define	TIMER_DIV128_VALUE_200ms   get_delay_timer_value(200000, 128, F_CPU)
-#define TIMER_DIV256_VALUE_500ms   get_delay_timer_value(500000, 256, F_CPU)
-#define	TIMER_DIV512_VALUE_1s      get_delay_timer_value(1000000, 512, F_CPU)
+#define TIMER_DIV12_VALUE_10us	   constexpr_get_delay_timer_value(10ULL, 12ULL, EXT_CLK)
+#define TIMER_DIV12_VALUE_100us	   constexpr_get_delay_timer_value(100ULL, 12ULL, EXT_CLK)
+#define TIMER_DIV12_VALUE_1ms	   constexpr_get_delay_timer_value(1000ULL, 12ULL, EXT_CLK)
+#define	TIMER_DIV12_VALUE_10ms	   constexpr_get_delay_timer_value(10000ULL, 12ULL, EXT_CLK)
+#define TIMER_DIV12_VALUE_40ms	   constexpr_get_delay_timer_value(40000ULL, 12ULL, EXT_CLK)
+#define TIMER_DIV4_VALUE_10us	   constexpr_get_delay_timer_value(10ULL, 4ULL, EXT_CLK)
+#define TIMER_DIV4_VALUE_100us	   constexpr_get_delay_timer_value(100ULL, 4ULL, EXT_CLK)
+#define TIMER_DIV4_VALUE_200us	   constexpr_get_delay_timer_value(200ULL, 4ULL, EXT_CLK)
+#define TIMER_DIV4_VALUE_500us	   constexpr_get_delay_timer_value(500ULL, 4ULL, EXT_CLK)
+#define TIMER_DIV4_VALUE_1ms       constexpr_get_delay_timer_value(1000ULL, 4ULL, EXT_CLK)
+#define TIMER_DIV16_VALUE_10ms	   constexpr_get_delay_timer_value(10000ULL, 16ULL, EXT_CLK)
+#define TIMER_DIV64_VALUE_30ms	   constexpr_get_delay_timer_value(30000ULL, 64ULL, EXT_CLK)
+#define	TIMER_DIV128_VALUE_100ms   constexpr_get_delay_timer_value(100000ULL, 128ULL, EXT_CLK)
+#define	TIMER_DIV128_VALUE_200ms   constexpr_get_delay_timer_value(200000ULL, 128ULL, EXT_CLK)
+#define TIMER_DIV256_VALUE_500ms   constexpr_get_delay_timer_value(500000ULL, 256ULL, EXT_CLK)
+#define	TIMER_DIV512_VALUE_1s      constexpr_get_delay_timer_value(1000000ULL, 512ULL, EXT_CLK)
 
 void Timer0_Delay100us(UINT32 u32CNT);
 void Timer0_Delay1ms(UINT32 u32CNT);

--- a/hardware/victims/firmware/numicro8051/commonlib/Delay.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Delay.h
@@ -1,0 +1,108 @@
+#pragma once
+#include <stdint.h>
+#include "numicro_8051.h"
+#ifdef FOSC_110592		// if Fsys = 11.0592MHz 
+    	#define TIMER_DIV12_VALUE_10us			65536-9			//9*12/11.0592 = 10 uS,  				// Timer divider = 12 for TM0/TM1
+    	#define TIMER_DIV12_VALUE_1ms				65536-923		//923*12/11.0592 = 1 mS					// Timer divider = 12
+		#define	TIMER_DIV12_VALUE_10ms			65536-9216	//18432*12/22118400 = 10 ms			// Timer divider = 12
+    	#define TIMER_DIV4_VALUE_10us				65536-28		//28*4/11.0592 = 10 uS					// Timer divider = 4	for TM2/TM3
+    	#define TIMER_DIV4_VALUE_1ms				65536-2765	//2765*4/11.0592 = 1 mS					// Timer divider = 4
+		#define TIMER_DIV4_VALUE_100us			65536-277		//553*4/22118400 = 100 us				// Timer divider = 4
+		#define TIMER_DIV4_VALUE_200us			65536-553		//1106*4/22118400 = 200 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_500us			65536-1383	//2765*4/22118400 = 500 us			// Timer divider = 4		
+		#define TIMER_DIV16_VALUE_10ms			65536-6912	//1500*16/22118400 = 10 ms			// Timer divider = 16
+		#define TIMER_DIV64_VALUE_30ms			65536-5184	//10368*64/22118400 = 30 ms			// Timer divider = 64
+		#define	TIMER_DIV128_VALUE_100ms		65536-8640	//17280*128/22118400 = 100 ms		// Timer divider = 128
+		#define	TIMER_DIV128_VALUE_200ms		65536-17280	//34560*128/22118400 = 200 ms		// Timer divider = 128
+		#define TIMER_DIV256_VALUE_500ms		65536-21600	//43200*256/22118400 = 500 ms 	// Timer divider = 256
+		#define TIMER_DIV512_VALUE_1s				65536-21600	//43200*512/22118400 = 1 s			// Timer divider = 512
+#endif
+#ifdef FOSC_160000		// if Fsys = 16MHz 
+		#define TIMER_DIV12_VALUE_10us			65536-13		//13*12/16000000 = 10 uS,  			// Timer divider = 12 for TM0/TM1
+		#define TIMER_DIV12_VALUE_100us			65536-130		//130*12/16000000 = 10 uS,  		// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_1ms				65536-1334	//1334*12/16000000 = 1 mS, 			// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_10ms			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_40ms			65536-53336	//53336*12/16000000 = 40 ms			// Timer divider = 12 
+		#define TIMER_DIV4_VALUE_10us				65536-40		//40*4/16000000 = 10 uS,    		// Timer divider = 4	for TM2/TM3
+		#define TIMER_DIV4_VALUE_100us			65536-400		//400*4/16000000 = 100 us				// Timer divider = 4
+		#define TIMER_DIV4_VALUE_200us			65536-800		//800*4/16000000 = 200 us				// Timer divider = 4
+		#define TIMER_DIV4_VALUE_500us			65536-2000	//2000*4/16000000 = 500 us			// Timer divider = 4
+    	#define TIMER_DIV4_VALUE_1ms				65536-4000	//4000*4/16000000 = 1 mS,   		// Timer divider = 4
+		#define TIMER_DIV16_VALUE_10ms			65536-10000	//10000*16/16000000 = 10 ms			// Timer	divider = 16
+		#define TIMER_DIV64_VALUE_30ms			65536-7500	//7500*64/16000000 = 30 ms			// Timer divider = 64
+		#define	TIMER_DIV128_VALUE_100ms		65536-12500	//12500*128/16000000 = 100 ms		// Timer divider = 128
+		#define	TIMER_DIV128_VALUE_200ms		65536-25000	//25000*128/16000000 = 200 ms		// Timer divider = 128
+		#define TIMER_DIV256_VALUE_500ms		65536-31250	//31250*256/16000000 = 500 ms 	// Timer divider = 256
+		#define	TIMER_DIV512_VALUE_1s				65536-31250	//31250*512/16000000 = 1 s.  		// Timer Divider = 512
+#endif
+#ifdef FOSC_166000		// if Fsys = 16.6MHz 
+		#define TIMER_DIV12_VALUE_10us			65536-13		//13*12/16600000 = 10 uS,  			// Timer divider = 12 for TM0/TM1
+		#define TIMER_DIV12_VALUE_100us			65536-138		//138*12/16600000 = 100 uS,  		// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_1ms			65536-1384	//1384*12/16600000 = 1 mS, 			// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_10ms			65536-13834	//13834*12/16600000 = 10 mS 		// Timer divider = 12 
+		#define TIMER_DIV12_VALUE_40ms			65536-55334	//55334*12/16600000 = 40 ms			// Timer divider = 12 
+		#define TIMER_DIV4_VALUE_10us			65536-41		//41*4/16600000 = 10 uS,    		// Timer divider = 4	for TM2/TM3
+		#define TIMER_DIV4_VALUE_100us			65536-415		//415*4/16600000 = 100 us				// Timer divider = 4
+		#define TIMER_DIV4_VALUE_200us			65536-830		//830*4/16600000 = 200 us				// Timer divider = 4
+		#define TIMER_DIV4_VALUE_500us			65536-2075	//2075*4/16600000 = 500 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_1ms			65536-4150	//4150*4/16600000 = 1 mS,   		// Timer divider = 4
+		#define TIMER_DIV16_VALUE_10ms			65536-10375	//10375*16/16600000 = 10 ms			// Timer	divider = 16
+		#define TIMER_DIV64_VALUE_30ms			65536-7781	//7781*64/16600000 = 30 ms			// Timer divider = 64
+		#define	TIMER_DIV128_VALUE_100ms		65536-12969	//12969*128/16600000 = 100 ms		// Timer divider = 128
+		#define	TIMER_DIV128_VALUE_200ms		65536-25938	//25938*128/16600000 = 200 ms		// Timer divider = 128
+		#define TIMER_DIV256_VALUE_500ms		65536-32422	//32422*256/16600000 = 500 ms 	// Timer divider = 256
+		#define	TIMER_DIV512_VALUE_1s			65536-32422	//32422*512/16600000 = 1 s.  		// Timer Divider = 512
+#endif
+#ifdef FOSC_184320		// if Fsys = 18.432MHz 
+    	#define TIMER_DIV12_VALUE_10us				65536-15    //15*12/18.432 = 10 uS,  Timer Clock = Fsys/12
+    	#define TIMER_DIV12_VALUE_1ms				65536-1536  //1536*12/18.432 = 1 mS, Timer Clock = Fsys/12
+    	#define TIMER_DIV4_VALUE_10us				65536-46    //46*4/18.432 = 10 uS,   Timer Clock = Fsys/4
+    	#define TIMER_DIV4_VALUE_1ms				65536-4608  //4608*4/18.432 = 1 mS,  Timer Clock = Fsys/4
+#endif
+#ifdef FOSC_200000		// if Fsys = 20 MHz
+    	#define TIMER_DIV12_VALUE_10us				65536-17 	 	//17*12/20000000 = 10 uS,  Timer Clock = Fsys/12
+    	#define TIMER_DIV12_VALUE_1ms				65536-1667  	//1667*12/20000000 = 1 mS, Timer Clock = Fsys/12
+    	#define TIMER_DIV4_VALUE_10us				65536-50    	//50*4/20000000 = 10 uS,    Timer Clock = Fsys/4
+    	#define TIMER_DIV4_VALUE_1ms				65536-5000  	//5000*4/20000000 = 1 mS,   Timer Clock = Fsys/4
+#endif
+#ifdef FOSC_221184		// if Fsys = 22.1184 MHz 
+		#define TIMER_DIV12_VALUE_10us			65536-18   			//18*12/22118400 = 10 uS,  			// Timer divider = 12
+		#define TIMER_DIV12_VALUE_1ms			65536-1843  		//1843*12/22118400 = 1 mS, 			// Timer divider = 12
+		#define	TIMER_DIV12_VALUE_10ms			65536-18432			//18432*12/22118400 = 10 ms			// Timer divider = 12
+		#define TIMER_DIV4_VALUE_10us			65536-56			//9*4/22118400 = 10 uS,  		  	// Timer divider = 4
+		#define TIMER_DIV4_VALUE_1ms			65536-5530			//923*4/22118400 = 1 mS,   			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_100us			65536-553			//553*4/22118400 = 100 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_200us			65536-1106			//1106*4/22118400 = 200 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_500us			65536-2765			//2765*4/22118400 = 500 us			// Timer divider = 4		
+		#define TIMER_DIV16_VALUE_10ms			65536-13824			//1500*16/22118400 = 10 ms			// Timer divider = 16
+		#define TIMER_DIV64_VALUE_30ms			65536-10368			//10368*64/22118400 = 30 ms			// Timer divider = 64
+		#define	TIMER_DIV128_VALUE_100ms		65536-17280			//17280*128/22118400 = 100 ms		// Timer divider = 128
+		#define	TIMER_DIV128_VALUE_200ms		65536-34560			//34560*128/22118400 = 200 ms		// Timer divider = 128
+		#define TIMER_DIV256_VALUE_500ms		65536-43200			//43200*256/22118400 = 500 ms 		// Timer divider = 256
+		#define TIMER_DIV512_VALUE_1s			65536-43200			//43200*512/22118400 = 1 s			// Timer divider = 512
+#endif
+#ifdef FOSC_240000		// if Fsys = 24 MHz
+		#define TIMER_DIV12_VALUE_10us			65536-20			//20*12/24000000 = 10 uS,  			// Timer divider = 12
+		#define TIMER_DIV12_VALUE_100us			65536-200			//200*12/24000000 = 10 uS,  		// Timer divider = 12
+    	#define TIMER_DIV12_VALUE_1ms			65536-2000			//2000*12/24000000 = 1 mS, 			// Timer divider = 12
+		#define TIMER_DIV12_VALUE_10ms			65536-20000			//20000*12/24000000 = 10 mS 		// Timer divider = 12
+		#define TIMER_DIV4_VALUE_10us			65536-60			//60*4/24000000 = 10 uS,    		// Timer divider = 4
+		#define TIMER_DIV4_VALUE_100us			65536-600			//600*4/24000000 = 100 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_200us			65536-1200			//1200*4/24000000 = 200 us			// Timer divider = 4
+		#define TIMER_DIV4_VALUE_500us			65536-3000			//3000*4/24000000 = 500 us			// Timer divider = 4
+    	#define TIMER_DIV4_VALUE_1ms			65536-6000			//6000*4/24000000 = 1 mS,   		// Timer divider = 4
+		#define TIMER_DIV16_VALUE_10ms			65536-15000			//15000*16/24000000 = 10 ms			// Timer divider = 16
+		#define TIMER_DIV64_VALUE_30ms			65536-11250			//11250*64/24000000 = 30 ms			// Timer divider = 64
+		#define	TIMER_DIV128_VALUE_100ms		65536-18750			//37500*128/24000000 = 200 ms		// Timer divider = 128
+		#define	TIMER_DIV128_VALUE_200ms		65536-37500			//37500*128/24000000 = 200 ms		// Timer divider = 128
+		#define TIMER_DIV256_VALUE_500ms		65536-46875			//46875*256/24000000 = 500 ms 		// Timer divider = 256
+		#define	TIMER_DIV512_VALUE_1s			65536-46875			//46875*512/24000000 = 1 s.  		// Timer Divider = 512
+#endif
+void Timer0_Delay100us(UINT32 u32CNT);
+void Timer0_Delay1ms(UINT32 u32CNT);
+void Timer1_Delay10ms(UINT32 u32CNT);
+void Timer2_Delay500us(UINT32 u32CNT);
+void Timer3_Delay100ms(UINT32 u32CNT);
+
+void Timer0_Delay40ms(UINT32 u32CNT);
+void Timer3_Delay10us(UINT32 u32CNT);

--- a/hardware/victims/firmware/numicro8051/commonlib/Delay.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/Delay.h
@@ -1,103 +1,30 @@
 #pragma once
 #include <stdint.h>
 #include "numicro_8051.h"
-#ifdef FOSC_110592		// if Fsys = 11.0592MHz 
-    	#define TIMER_DIV12_VALUE_10us			65536-9			//9*12/11.0592 = 10 uS,  				// Timer divider = 12 for TM0/TM1
-    	#define TIMER_DIV12_VALUE_1ms				65536-923		//923*12/11.0592 = 1 mS					// Timer divider = 12
-		#define	TIMER_DIV12_VALUE_10ms			65536-9216	//18432*12/22118400 = 10 ms			// Timer divider = 12
-    	#define TIMER_DIV4_VALUE_10us				65536-28		//28*4/11.0592 = 10 uS					// Timer divider = 4	for TM2/TM3
-    	#define TIMER_DIV4_VALUE_1ms				65536-2765	//2765*4/11.0592 = 1 mS					// Timer divider = 4
-		#define TIMER_DIV4_VALUE_100us			65536-277		//553*4/22118400 = 100 us				// Timer divider = 4
-		#define TIMER_DIV4_VALUE_200us			65536-553		//1106*4/22118400 = 200 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_500us			65536-1383	//2765*4/22118400 = 500 us			// Timer divider = 4		
-		#define TIMER_DIV16_VALUE_10ms			65536-6912	//1500*16/22118400 = 10 ms			// Timer divider = 16
-		#define TIMER_DIV64_VALUE_30ms			65536-5184	//10368*64/22118400 = 30 ms			// Timer divider = 64
-		#define	TIMER_DIV128_VALUE_100ms		65536-8640	//17280*128/22118400 = 100 ms		// Timer divider = 128
-		#define	TIMER_DIV128_VALUE_200ms		65536-17280	//34560*128/22118400 = 200 ms		// Timer divider = 128
-		#define TIMER_DIV256_VALUE_500ms		65536-21600	//43200*256/22118400 = 500 ms 	// Timer divider = 256
-		#define TIMER_DIV512_VALUE_1s				65536-21600	//43200*512/22118400 = 1 s			// Timer divider = 512
-#endif
-#ifdef FOSC_160000		// if Fsys = 16MHz 
-		#define TIMER_DIV12_VALUE_10us			65536-13		//13*12/16000000 = 10 uS,  			// Timer divider = 12 for TM0/TM1
-		#define TIMER_DIV12_VALUE_100us			65536-130		//130*12/16000000 = 10 uS,  		// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_1ms				65536-1334	//1334*12/16000000 = 1 mS, 			// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_10ms			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_40ms			65536-53336	//53336*12/16000000 = 40 ms			// Timer divider = 12 
-		#define TIMER_DIV4_VALUE_10us				65536-40		//40*4/16000000 = 10 uS,    		// Timer divider = 4	for TM2/TM3
-		#define TIMER_DIV4_VALUE_100us			65536-400		//400*4/16000000 = 100 us				// Timer divider = 4
-		#define TIMER_DIV4_VALUE_200us			65536-800		//800*4/16000000 = 200 us				// Timer divider = 4
-		#define TIMER_DIV4_VALUE_500us			65536-2000	//2000*4/16000000 = 500 us			// Timer divider = 4
-    	#define TIMER_DIV4_VALUE_1ms				65536-4000	//4000*4/16000000 = 1 mS,   		// Timer divider = 4
-		#define TIMER_DIV16_VALUE_10ms			65536-10000	//10000*16/16000000 = 10 ms			// Timer	divider = 16
-		#define TIMER_DIV64_VALUE_30ms			65536-7500	//7500*64/16000000 = 30 ms			// Timer divider = 64
-		#define	TIMER_DIV128_VALUE_100ms		65536-12500	//12500*128/16000000 = 100 ms		// Timer divider = 128
-		#define	TIMER_DIV128_VALUE_200ms		65536-25000	//25000*128/16000000 = 200 ms		// Timer divider = 128
-		#define TIMER_DIV256_VALUE_500ms		65536-31250	//31250*256/16000000 = 500 ms 	// Timer divider = 256
-		#define	TIMER_DIV512_VALUE_1s				65536-31250	//31250*512/16000000 = 1 s.  		// Timer Divider = 512
-#endif
-#ifdef FOSC_166000		// if Fsys = 16.6MHz 
-		#define TIMER_DIV12_VALUE_10us			65536-13		//13*12/16600000 = 10 uS,  			// Timer divider = 12 for TM0/TM1
-		#define TIMER_DIV12_VALUE_100us			65536-138		//138*12/16600000 = 100 uS,  		// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_1ms			65536-1384	//1384*12/16600000 = 1 mS, 			// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_10ms			65536-13834	//13834*12/16600000 = 10 mS 		// Timer divider = 12 
-		#define TIMER_DIV12_VALUE_40ms			65536-55334	//55334*12/16600000 = 40 ms			// Timer divider = 12 
-		#define TIMER_DIV4_VALUE_10us			65536-41		//41*4/16600000 = 10 uS,    		// Timer divider = 4	for TM2/TM3
-		#define TIMER_DIV4_VALUE_100us			65536-415		//415*4/16600000 = 100 us				// Timer divider = 4
-		#define TIMER_DIV4_VALUE_200us			65536-830		//830*4/16600000 = 200 us				// Timer divider = 4
-		#define TIMER_DIV4_VALUE_500us			65536-2075	//2075*4/16600000 = 500 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_1ms			65536-4150	//4150*4/16600000 = 1 mS,   		// Timer divider = 4
-		#define TIMER_DIV16_VALUE_10ms			65536-10375	//10375*16/16600000 = 10 ms			// Timer	divider = 16
-		#define TIMER_DIV64_VALUE_30ms			65536-7781	//7781*64/16600000 = 30 ms			// Timer divider = 64
-		#define	TIMER_DIV128_VALUE_100ms		65536-12969	//12969*128/16600000 = 100 ms		// Timer divider = 128
-		#define	TIMER_DIV128_VALUE_200ms		65536-25938	//25938*128/16600000 = 200 ms		// Timer divider = 128
-		#define TIMER_DIV256_VALUE_500ms		65536-32422	//32422*256/16600000 = 500 ms 	// Timer divider = 256
-		#define	TIMER_DIV512_VALUE_1s			65536-32422	//32422*512/16600000 = 1 s.  		// Timer Divider = 512
-#endif
-#ifdef FOSC_184320		// if Fsys = 18.432MHz 
-    	#define TIMER_DIV12_VALUE_10us				65536-15    //15*12/18.432 = 10 uS,  Timer Clock = Fsys/12
-    	#define TIMER_DIV12_VALUE_1ms				65536-1536  //1536*12/18.432 = 1 mS, Timer Clock = Fsys/12
-    	#define TIMER_DIV4_VALUE_10us				65536-46    //46*4/18.432 = 10 uS,   Timer Clock = Fsys/4
-    	#define TIMER_DIV4_VALUE_1ms				65536-4608  //4608*4/18.432 = 1 mS,  Timer Clock = Fsys/4
-#endif
-#ifdef FOSC_200000		// if Fsys = 20 MHz
-    	#define TIMER_DIV12_VALUE_10us				65536-17 	 	//17*12/20000000 = 10 uS,  Timer Clock = Fsys/12
-    	#define TIMER_DIV12_VALUE_1ms				65536-1667  	//1667*12/20000000 = 1 mS, Timer Clock = Fsys/12
-    	#define TIMER_DIV4_VALUE_10us				65536-50    	//50*4/20000000 = 10 uS,    Timer Clock = Fsys/4
-    	#define TIMER_DIV4_VALUE_1ms				65536-5000  	//5000*4/20000000 = 1 mS,   Timer Clock = Fsys/4
-#endif
-#ifdef FOSC_221184		// if Fsys = 22.1184 MHz 
-		#define TIMER_DIV12_VALUE_10us			65536-18   			//18*12/22118400 = 10 uS,  			// Timer divider = 12
-		#define TIMER_DIV12_VALUE_1ms			65536-1843  		//1843*12/22118400 = 1 mS, 			// Timer divider = 12
-		#define	TIMER_DIV12_VALUE_10ms			65536-18432			//18432*12/22118400 = 10 ms			// Timer divider = 12
-		#define TIMER_DIV4_VALUE_10us			65536-56			//9*4/22118400 = 10 uS,  		  	// Timer divider = 4
-		#define TIMER_DIV4_VALUE_1ms			65536-5530			//923*4/22118400 = 1 mS,   			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_100us			65536-553			//553*4/22118400 = 100 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_200us			65536-1106			//1106*4/22118400 = 200 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_500us			65536-2765			//2765*4/22118400 = 500 us			// Timer divider = 4		
-		#define TIMER_DIV16_VALUE_10ms			65536-13824			//1500*16/22118400 = 10 ms			// Timer divider = 16
-		#define TIMER_DIV64_VALUE_30ms			65536-10368			//10368*64/22118400 = 30 ms			// Timer divider = 64
-		#define	TIMER_DIV128_VALUE_100ms		65536-17280			//17280*128/22118400 = 100 ms		// Timer divider = 128
-		#define	TIMER_DIV128_VALUE_200ms		65536-34560			//34560*128/22118400 = 200 ms		// Timer divider = 128
-		#define TIMER_DIV256_VALUE_500ms		65536-43200			//43200*256/22118400 = 500 ms 		// Timer divider = 256
-		#define TIMER_DIV512_VALUE_1s			65536-43200			//43200*512/22118400 = 1 s			// Timer divider = 512
-#endif
-#ifdef FOSC_240000		// if Fsys = 24 MHz
-		#define TIMER_DIV12_VALUE_10us			65536-20			//20*12/24000000 = 10 uS,  			// Timer divider = 12
-		#define TIMER_DIV12_VALUE_100us			65536-200			//200*12/24000000 = 10 uS,  		// Timer divider = 12
-    	#define TIMER_DIV12_VALUE_1ms			65536-2000			//2000*12/24000000 = 1 mS, 			// Timer divider = 12
-		#define TIMER_DIV12_VALUE_10ms			65536-20000			//20000*12/24000000 = 10 mS 		// Timer divider = 12
-		#define TIMER_DIV4_VALUE_10us			65536-60			//60*4/24000000 = 10 uS,    		// Timer divider = 4
-		#define TIMER_DIV4_VALUE_100us			65536-600			//600*4/24000000 = 100 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_200us			65536-1200			//1200*4/24000000 = 200 us			// Timer divider = 4
-		#define TIMER_DIV4_VALUE_500us			65536-3000			//3000*4/24000000 = 500 us			// Timer divider = 4
-    	#define TIMER_DIV4_VALUE_1ms			65536-6000			//6000*4/24000000 = 1 mS,   		// Timer divider = 4
-		#define TIMER_DIV16_VALUE_10ms			65536-15000			//15000*16/24000000 = 10 ms			// Timer divider = 16
-		#define TIMER_DIV64_VALUE_30ms			65536-11250			//11250*64/24000000 = 30 ms			// Timer divider = 64
-		#define	TIMER_DIV128_VALUE_100ms		65536-18750			//37500*128/24000000 = 200 ms		// Timer divider = 128
-		#define	TIMER_DIV128_VALUE_200ms		65536-37500			//37500*128/24000000 = 200 ms		// Timer divider = 128
-		#define TIMER_DIV256_VALUE_500ms		65536-46875			//46875*256/24000000 = 500 ms 		// Timer divider = 256
-		#define	TIMER_DIV512_VALUE_1s			65536-46875			//46875*512/24000000 = 1 s.  		// Timer Divider = 512
-#endif
+
+
+#define _DIV_ROUND_CLOSEST_POS(n, d) (((n) + (d) / 2) / (d))
+#define _get_minus_factor(delay_us, clk_div, cpu_hz) (_DIV_ROUND_CLOSEST_POS((delay_us * cpu_hz / clk_div), 1000000))
+#define get_delay_timer_value(delay_us, clk_div, cpu_hz) (65536 - _get_minus_factor(delay_us, clk_div, cpu_hz))
+
+// Because these are all constant expressions, SDCC should optimize all usages of these into constant values
+#define TIMER_DIV12_VALUE_10us	   get_delay_timer_value(10, 12, F_CPU)
+#define TIMER_DIV12_VALUE_100us	   get_delay_timer_value(100, 12, F_CPU)
+#define TIMER_DIV12_VALUE_1ms	   get_delay_timer_value(1000, 12, F_CPU)
+#define	TIMER_DIV12_VALUE_10ms	   get_delay_timer_value(10000, 12, F_CPU)
+#define TIMER_DIV12_VALUE_40ms	   get_delay_timer_value(40000, 12, F_CPU)
+#define TIMER_DIV4_VALUE_10us	   get_delay_timer_value(10, 4, F_CPU)
+#define TIMER_DIV4_VALUE_100us	   get_delay_timer_value(100, 4, F_CPU)
+#define TIMER_DIV4_VALUE_200us	   get_delay_timer_value(200, 4, F_CPU)
+#define TIMER_DIV4_VALUE_500us	   get_delay_timer_value(500, 4, F_CPU)
+#define TIMER_DIV4_VALUE_1ms       get_delay_timer_value(1000, 4, F_CPU)
+#define TIMER_DIV16_VALUE_10ms	   get_delay_timer_value(10000, 16, F_CPU)
+#define TIMER_DIV64_VALUE_30ms	   get_delay_timer_value(30000, 64, F_CPU)
+#define	TIMER_DIV128_VALUE_100ms   get_delay_timer_value(100000, 128, F_CPU)
+#define	TIMER_DIV128_VALUE_200ms   get_delay_timer_value(200000, 128, F_CPU)
+#define TIMER_DIV256_VALUE_500ms   get_delay_timer_value(500000, 256, F_CPU)
+#define	TIMER_DIV512_VALUE_1s      get_delay_timer_value(1000000, 512, F_CPU)
+
 void Timer0_Delay100us(UINT32 u32CNT);
 void Timer0_Delay1ms(UINT32 u32CNT);
 void Timer1_Delay10ms(UINT32 u32CNT);

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.c
@@ -1,7 +1,7 @@
 #include "numicro_8051.h"
 #include "Common.h"
 
-void get_hircmap_16mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
+void get_hircmap_16mhz_vals(uint8_t *hircmap)
 {
     __bit IAPEN_val = CHPCON & SET_BIT0;
     if (!IAPEN_val)
@@ -12,17 +12,27 @@ void get_hircmap_16mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
     IAPAL = 0x30;
     IAPCN = READ_UID;
     set_IAPTRG_IAPGO;
-    *hircmap0 = IAPFD;
+    hircmap[0] = IAPFD;
     IAPAL = 0x31;
     set_IAPTRG_IAPGO;
-    *hircmap1 = IAPFD;
+    hircmap[1] = IAPFD;
     if (!IAPEN_val)
     {
         clr_CHPCON_IAPEN;
     }
 }
+
+void set_hircmap(uint8_t *hircmap){
+  TA = 0XAA;
+  TA = 0X55;
+  RCTRIM0 = hircmap[0];
+  TA = 0XAA;
+  TA = 0X55;
+  RCTRIM1 = hircmap[1];
+}
+
 #ifdef NUM51_CPU24MHZ_SUPPORTED
-void get_hircmap_24mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
+void get_hircmap_24mhz_vals(uint8_t *hircmap)
 {
     __bit IAPEN_val = CHPCON & SET_BIT0;
     if (!IAPEN_val)
@@ -33,57 +43,66 @@ void get_hircmap_24mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
     IAPAL = 0x38;
     IAPCN = READ_UID;
     set_IAPTRG_IAPGO;
-    *hircmap0 = IAPFD;
+    hircmap[0] = IAPFD;
     IAPAL = 0x39;
     set_IAPTRG_IAPGO;
-    *hircmap1 = IAPFD;
+    hircmap[1] = IAPFD;
     if (!IAPEN_val)
     {
         clr_CHPCON_IAPEN;
     }
 }
 
-void MODIFY_HIRC_24(void) // Modify HIRC to 24MHz, this isn't in the datasheet!
+void MODIFY_HIRC_24(void) // Modify HIRC to 24MHz
 {
-    UINT8 hircmap0, hircmap1;
-    get_hircmap_24mhz_vals(&hircmap0, &hircmap1);
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM0 = hircmap0;
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM1 = hircmap1;
+    UINT8 hircmap[2];
+    get_hircmap_24mhz_vals(hircmap);
+    set_hircmap(hircmap);
+    /* Clear power on flag */
+    PCON &= CLR_BIT4;
 }
 #endif
 void MODIFY_HIRC_166(void) // Modify HIRC to 16.6MHz, more detail please see datasheet V1.02
 {
-    UINT8 hircmap0, hircmap1;
+    UINT8 hircmap[2];
     UINT16 trimvalue16bit;
-    get_hircmap_16mhz_vals(&hircmap0, &hircmap1);
-    trimvalue16bit = ((hircmap0 << 1) + (hircmap1 & 0x01));
+    get_hircmap_16mhz_vals(hircmap);
+    trimvalue16bit = ((hircmap[0] << 1) + (hircmap[1] & 0x01));
     trimvalue16bit = trimvalue16bit - 14;
-    hircmap1 = trimvalue16bit & 0x01;
-    hircmap0 = trimvalue16bit >> 1;
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM0 = hircmap0;
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM1 = hircmap1;
+    hircmap[1] = trimvalue16bit & 0x01;
+    hircmap[0] = trimvalue16bit >> 1;
+    set_hircmap(hircmap);
     /* Clear power on flag */
     PCON &= CLR_BIT4;
 }
 
 void MODIFY_HIRC_16(void)
 {
-    UINT8 hircmap0, hircmap1;
-    get_hircmap_16mhz_vals(&hircmap0, &hircmap1);
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM0 = hircmap0;
-    TA = 0XAA;
-    TA = 0X55;
-    RCTRIM1 = hircmap1;
+    UINT8 hircmap[2];
+    get_hircmap_16mhz_vals(hircmap);
+    set_hircmap(hircmap);
+}
+
+#define TRIM_VALUE_UNIT 40000 // about 40kHz
+
+// Use this with caution! The internal oscillator(s) are not guaranteed to support arbitrary frequencies
+// It doesn't seem like it will support much else other than 16, 16.6, and 24MHz (if the CPU supports 24MHz)
+void MODIFY_HIRC_OTHER(void)
+{
+    UINT8 hircmap[2];
+    UINT16 trimvalue16bit;
+#if FCPU > 20000000
+    get_hircmap_24mhz_vals(hircmap);
+#define trimvalue16bit_adj DIV_ROUND_CLOSEST((24000000 - F_CPU), TRIM_VALUE_UNIT)
+#else
+    get_hircmap_16mhz_vals(hircmap);
+#define trimvalue16bit_adj DIV_ROUND_CLOSEST((16000000 - F_CPU), TRIM_VALUE_UNIT)
+#endif
+    trimvalue16bit = ((hircmap[0] << 1) + (hircmap[1] & 0x01));
+    trimvalue16bit = trimvalue16bit - trimvalue16bit_adj;
+    hircmap[1] = trimvalue16bit & 0x01;
+    hircmap[0] = trimvalue16bit >> 1;
+    set_hircmap(hircmap);
 }
 
 void enable_output_clock()
@@ -118,14 +137,18 @@ void use_internal_clock(void)
     clr_CKSWT_OSC0;
     while ((CKEN & SET_BIT0) == 1)
         ; // step4: check system clock switching OK or NG
-#ifdef FOSC_166000
+
+    uint8_t hircmap[2];
+#if (F_CPU == 16000000)
+    MODIFY_HIRC_16();
+#elif (F_CPU == 16600000)
     MODIFY_HIRC_166();
-#elif (defined(FOSC_240000))
+#elif (F_CPU == 24000000)
 #ifndef NUM51_CPU24MHZ_SUPPORTED
-    #error "FOSC_240000 is not supported on this CPU"
+    #error "This CPU does not support 24MHz!"
 #endif
     MODIFY_HIRC_24();
 #else
-    MODIFY_HIRC_16();
+    MODIFY_HIRC_OTHER();
 #endif
 }

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.c
@@ -1,0 +1,131 @@
+#include "numicro_8051.h"
+#include "Common.h"
+
+void get_hircmap_16mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
+{
+    __bit IAPEN_val = CHPCON & SET_BIT0;
+    if (!IAPEN_val)
+    {
+        set_CHPCON_IAPEN;
+    }
+    IAPAH = 0x00;
+    IAPAL = 0x30;
+    IAPCN = READ_UID;
+    set_IAPTRG_IAPGO;
+    *hircmap0 = IAPFD;
+    IAPAL = 0x31;
+    set_IAPTRG_IAPGO;
+    *hircmap1 = IAPFD;
+    if (!IAPEN_val)
+    {
+        clr_CHPCON_IAPEN;
+    }
+}
+#ifdef NUM51_CPU24MHZ_SUPPORTED
+void get_hircmap_24mhz_vals(uint8_t *hircmap0, uint8_t *hircmap1)
+{
+    __bit IAPEN_val = CHPCON & SET_BIT0;
+    if (!IAPEN_val)
+    {
+        set_CHPCON_IAPEN;
+    }
+    IAPAH = 0x00;
+    IAPAL = 0x38;
+    IAPCN = READ_UID;
+    set_IAPTRG_IAPGO;
+    *hircmap0 = IAPFD;
+    IAPAL = 0x39;
+    set_IAPTRG_IAPGO;
+    *hircmap1 = IAPFD;
+    if (!IAPEN_val)
+    {
+        clr_CHPCON_IAPEN;
+    }
+}
+
+void MODIFY_HIRC_24(void) // Modify HIRC to 24MHz, this isn't in the datasheet!
+{
+    UINT8 hircmap0, hircmap1;
+    get_hircmap_24mhz_vals(&hircmap0, &hircmap1);
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM0 = hircmap0;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM1 = hircmap1;
+}
+#endif
+void MODIFY_HIRC_166(void) // Modify HIRC to 16.6MHz, more detail please see datasheet V1.02
+{
+    UINT8 hircmap0, hircmap1;
+    UINT16 trimvalue16bit;
+    get_hircmap_16mhz_vals(&hircmap0, &hircmap1);
+    trimvalue16bit = ((hircmap0 << 1) + (hircmap1 & 0x01));
+    trimvalue16bit = trimvalue16bit - 14;
+    hircmap1 = trimvalue16bit & 0x01;
+    hircmap0 = trimvalue16bit >> 1;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM0 = hircmap0;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM1 = hircmap1;
+    /* Clear power on flag */
+    PCON &= CLR_BIT4;
+}
+
+void MODIFY_HIRC_16(void)
+{
+    UINT8 hircmap0, hircmap1;
+    get_hircmap_16mhz_vals(&hircmap0, &hircmap1);
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM0 = hircmap0;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM1 = hircmap1;
+}
+
+void enable_output_clock()
+{
+    P11_PUSHPULL_MODE; // Set P1.1 to push-pull mode
+    set_CKCON_CLOEN;         // Enable clock out pin
+}
+
+void disable_output_clock()
+{
+    P11_QUASI_MODE;
+    clr_CKCON_CLOEN;
+}
+
+void use_external_clock(void)
+{
+    set_CKEN_EXTEN1;
+    set_CKEN_EXTEN0;
+    clr_CKSWT_OSC1; // step3: switching system clock source if needed
+    set_CKSWT_OSC0;
+    clr_CKEN_HIRCEN;
+    // TODO: Make sure changing this from set_CT_T0 doesn't break anything
+    ENABLE_TIMER0_MODE0; // Timer0 Clock source = OSCIN (external clock)
+}
+
+void use_internal_clock(void)
+{
+    set_CKEN_HIRCEN; // step1: enable HIRC clock source run
+    while ((CKSWT & SET_BIT5) == 0)
+        ;     // step2: check ready
+    clr_CKSWT_OSC1; // step3: switching system clock source if needed
+    clr_CKSWT_OSC0;
+    while ((CKEN & SET_BIT0) == 1)
+        ; // step4: check system clock switching OK or NG
+#ifdef FOSC_166000
+    MODIFY_HIRC_166();
+#elif (defined(FOSC_240000))
+#ifndef NUM51_CPU24MHZ_SUPPORTED
+    #error "FOSC_240000 is not supported on this CPU"
+#endif
+    MODIFY_HIRC_24();
+#else
+    MODIFY_HIRC_16();
+#endif
+}

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.c
@@ -1,5 +1,6 @@
 #include "numicro_8051.h"
 #include "Common.h"
+#include "pin_defines.h"
 
 void get_hircmap_16mhz_vals(uint8_t *hircmap)
 {
@@ -107,13 +108,13 @@ void MODIFY_HIRC_OTHER(void)
 
 void enable_output_clock()
 {
-    P11_PUSHPULL_MODE; // Set P1.1 to push-pull mode
+    PIN_CLK_OUT_PUSHPULL_MODE;
     set_CKCON_CLOEN;         // Enable clock out pin
 }
 
 void disable_output_clock()
 {
-    P11_QUASI_MODE;
+    PIN_CLK_OUT_QUASI_MODE;
     clr_CKCON_CLOEN;
 }
 
@@ -121,11 +122,10 @@ void use_external_clock(void)
 {
     set_CKEN_EXTEN1;
     set_CKEN_EXTEN0;
+    while(!(CKSWT&SET_BIT3));
     clr_CKSWT_OSC1; // step3: switching system clock source if needed
     set_CKSWT_OSC0;
     clr_CKEN_HIRCEN;
-    // TODO: Make sure changing this from set_CT_T0 doesn't break anything
-    ENABLE_TIMER0_MODE0; // Timer0 Clock source = OSCIN (external clock)
 }
 
 void use_internal_clock(void)
@@ -137,7 +137,6 @@ void use_internal_clock(void)
     clr_CKSWT_OSC0;
     while ((CKEN & SET_BIT0) == 1)
         ; // step4: check system clock switching OK or NG
-
     uint8_t hircmap[2];
 #if (F_CPU == 16000000)
     MODIFY_HIRC_16();

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.c
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.c
@@ -24,12 +24,20 @@ void get_hircmap_16mhz_vals(uint8_t *hircmap)
 }
 
 void set_hircmap(uint8_t *hircmap){
-  TA = 0XAA;
-  TA = 0X55;
-  RCTRIM0 = hircmap[0];
-  TA = 0XAA;
-  TA = 0X55;
-  RCTRIM1 = hircmap[1];
+    // doing this to ensure that these are near accesses
+    // it screws up the timing of writing to TA-protected registers if we have to get a far pointer
+    uint8_t hircmap0, hircmap1;
+    hircmap0 = hircmap[0];
+    hircmap1 = hircmap[1];
+    BIT_TMP = EA;
+    EA = 0;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM0 = hircmap0;
+    TA = 0XAA;
+    TA = 0X55;
+    RCTRIM1 = hircmap1;
+    EA = BIT_TMP;
 }
 
 #ifdef NUM51_CPU24MHZ_SUPPORTED

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.h
@@ -1,0 +1,9 @@
+#ifndef CLOCK_H
+#define CLOCK_H
+void MODIFY_HIRC_16(void);
+void MODIFY_HIRC_166(void);
+void use_external_clock(void);
+void disable_output_clock(void);
+void use_internal_clock(void);
+void enable_output_clock(void);
+#endif // CLOCK_H

--- a/hardware/victims/firmware/numicro8051/commonlib/clock.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/clock.h
@@ -1,5 +1,6 @@
 #ifndef CLOCK_H
 #define CLOCK_H
+void MODIFY_HIRC_24(void);
 void MODIFY_HIRC_16(void);
 void MODIFY_HIRC_166(void);
 void use_external_clock(void);

--- a/hardware/victims/firmware/numicro8051/commonlib/isp_uart0.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/isp_uart0.h
@@ -1,0 +1,21 @@
+#define TRUE       1
+#define FALSE     0
+
+
+// IAP commands: IAPCN values
+// IAPB: 7:6
+// FOEN: 5
+// FOEN: 4
+// FCTRL: 3:0
+#define PAGE_ERASE_AP        0x22 // 00:1:0:0010, Page erase APROM
+#define BYTE_READ_AP         0x00 // 00:0:0:0000, Byte read APROM
+#define BYTE_PROGRAM_AP      0x21 // 00:1:0:0001, Program APROM
+#define BYTE_READ_ID         0x0C // 00:0:0:1100, Device ID
+#define PAGE_ERASE_CONFIG    0xE2 // 11:1:0:0010, Erase Config
+#define BYTE_READ_CONFIG     0xC0 // 11:0:0:0000, Read Config
+#define BYTE_PROGRAM_CONFIG  0xE1 // 11:1:0:0001, Program Config
+#define READ_UID             0x04 // 00:0:0:0100, Unique ID
+#define PAGE_ERASE_LD        0x62 // 01:1:0:0010, Page erase LDROM
+#define BYTE_PROGRAM_LD      0x61 // 01:1:0:0001, Byte program LDROM
+#define BYTE_READ_LD         0x40 // 01:0:0:0000, Byte read LDROM
+#define READ_CID             0x0B // 00:0:0:1011, Company ID

--- a/hardware/victims/firmware/numicro8051/commonlib/pin_defines.h
+++ b/hardware/victims/firmware/numicro8051/commonlib/pin_defines.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// If other boards with non-pin compatible MCUS are added, they should #ifdef these defines here:
+#define PIN_LED_STATUS  P03
+#define PIN_LED_OK      P12
+#define PIN_LED_ERROR   P05
+#define PIN_TRIGGER     P04
+#define PIN_CLK_OUT     P11
+
+#define PIN_LED_STATUS_PUSHPULL_MODE  P03_PUSHPULL_MODE
+#define PIN_LED_OK_PUSHPULL_MODE      P12_PUSHPULL_MODE
+#define PIN_LED_ERROR_PUSHPULL_MODE   P05_PUSHPULL_MODE
+#define PIN_TRIGGER_QUASI_MODE        P04_QUASI_MODE
+#define PIN_CLK_OUT_PUSHPULL_MODE     P11_PUSHPULL_MODE
+
+#define PIN_LED_STATUS_QUASI_MODE     P03_QUASI_MODE
+#define PIN_LED_OK_QUASI_MODE         P12_QUASI_MODE
+#define PIN_LED_ERROR_QUASI_MODE      P05_QUASI_MODE
+#define PIN_TRIGGER_QUASI_MODE        P04_QUASI_MODE
+#define PIN_CLK_OUT_QUASI_MODE        P11_QUASI_MODE

--- a/hardware/victims/firmware/numicro8051/crypto/Makefile.crypto
+++ b/hardware/victims/firmware/numicro8051/crypto/Makefile.crypto
@@ -1,0 +1,77 @@
+
+########################################
+########################################
+#### Default Options
+
+EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/
+VPATH += :$(FIRMWAREPATH)/crypto/
+
+########################################
+########################################
+#### Select the Crypto Library
+
+ifeq ($(CRYPTO_OPTIONS),)
+  ifneq ($(CRYPTO_TARGET),NONE)
+    ${info Blank crypto options, building for AES128}
+    CRYPTO_OPTIONS = AES128C
+  endif
+endif
+
+ifeq ($(CRYPTO_TARGET),AVRCRYPTOLIB)
+# avr-crypto-lib fom daslabor.de
+# Crypto Target: AVRCRYPTOLIB
+# Crypto Options:
+#    AES128C = AES128 in C
+#    AES128ASM = AES128 in Assembly
+# Notes:
+#
+  include $(FIRMWAREPATH)/crypto/Makefile.avrcryptolib
+
+
+else ifeq ($(CRYPTO_TARGET),AESSIMPLE)
+#
+# Crypto Target: AESSIMPLE
+# Crypto Options:
+#    None
+# Notes:
+#
+  include $(FIRMWAREPATH)/crypto/Makefile.straightforward-aes
+
+
+else ifeq ($(CRYPTO_TARGET),TINYAES128C)
+#
+# Crypto Target: TINYAES128C
+# Crypto Options:
+#   None
+# Notes:
+#   You can define AES_CONST_VAR to define what is used to put SBOX in flash (or other memory location)
+  include $(FIRMWAREPATH)/crypto/Makefile.tinyaes128c
+
+
+else ifeq ($(CRYPTO_TARGET),MBEDTLS)
+#
+# Crypto Target: MBEDTLS
+# Crypto Options:
+#    AES128 = AES128
+#    SHA1 
+# Notes:
+#
+  include $(FIRMWAREPATH)/crypto/Makefile.mbedtls
+
+else ifeq ($(CRYPTO_TARGET),MASKEDAES)
+  include $(FIRMWAREPATH)/crypto/Makefile.maskedaes
+
+else ifeq ($(CRYPTO_TARGET),HWAES)
+  CFLAGS += -DHWCRYPTO=1
+  CPPFLAGS += -DHWCRYPTO=1
+  SRC += aes-independant.c
+
+else ifeq ($(CRYPTO_TARGET),MICROECC)
+  include $(FIRMWAREPATH)/crypto/Makefile.micro-ecc
+
+else ifeq ($(CRYPTO_TARGET),NONE)
+  #Nothing to do :)
+
+else
+ ${error Unknown or blank CRYPTO_TARGET: $(CRYPTO_TARGET). If supposed to be blank set to NONE to continue}
+endif

--- a/hardware/victims/firmware/numicro8051/crypto/Makefile.tinyaes128c
+++ b/hardware/victims/firmware/numicro8051/crypto/Makefile.tinyaes128c
@@ -1,0 +1,6 @@
+########
+CRYPTO_LIB = tiny-AES128-C
+SRC += aes.c aes-independant.c
+CDEFS += -DTINYAES128C
+VPATH += :$(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)
+EXTRAINCDIRS += $(FIRMWAREPATH)/crypto/$(CRYPTO_LIB)

--- a/hardware/victims/firmware/numicro8051/crypto/aes-independant.c
+++ b/hardware/victims/firmware/numicro8051/crypto/aes-independant.c
@@ -1,0 +1,458 @@
+/*
+    This file is part of the AESExplorer Example Targets
+    Copyright (C) 2012 Colin O'Flynn <coflynn@newae.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aes-independant.h"
+#include "hal.h"
+
+#if HWCRYPTO
+
+void aes_indep_init(void)
+{
+    HW_AES128_Init();
+}
+
+void aes_indep_key(uint8_t * key)
+{
+    HW_AES128_LoadKey(key);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    HW_AES128_Enc_pretrigger(pt);
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    HW_AES128_Enc_posttrigger(pt);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+    HW_AES128_Enc(pt);
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(AVRCRYPTOLIB)
+#include "aes128_enc.h"
+#include "aes_keyschedule.h"
+
+aes128_ctx_t ctx;
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	aes128_init(key, &ctx);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	aes128_enc(pt, &ctx); /* encrypting the data block */
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(SIMPLEAES)
+
+uint8_t enckey[16];
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	for(uint8_t i=0; i < 16; i++){
+		enckey[i] = key[i];
+	}
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	uint8_t * result = aes(pt, enckey);
+	for(uint8_t i=0; i < 16; i++){
+		pt[i] = result[i];
+	}
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(DPAV4)
+
+#include "aes.h"
+#include "aes_enc.h"
+
+/*  This is the AES RSM 256 encryption function that call the generic AES RSM encryption core*/
+void aes256_enc(uint8_t* j, void* buffer, aes256_ctx_t* ctx,uint8_t rng){
+	aes_encrypt_core(j,buffer, (aes_genctx_t*)ctx, 14,(uint8_t)rng);
+}
+
+aes256_ctx_t ctx;
+
+void aes_indep_init(void)
+{
+    ;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	aes256_init(key, &ctx);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	static uint8_t j[0];
+
+	//Encryption with trigger enabled
+	aes256_enc(j, pt, &ctx, 1);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(TINYAES128C)
+
+#include "aes.h"
+
+uint8_t __data enckey[16];
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+    AES128_ECB_indp_setkey(key);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	AES128_ECB_indp_crypto(pt);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(MBEDTLS)
+#include "mbedtls/aes.h"
+
+mbedtls_aes_context ctx;
+
+void aes_indep_init(void)
+{
+	mbedtls_aes_init(&ctx);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	mbedtls_aes_setkey_enc(&ctx, key, 128);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_ENCRYPT, pt, pt); /* encrypting the data block */
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(MASKEDAES)
+
+#if defined(ANSSI_AVR)
+
+#include "aesTables.h"
+#include "maskedAES128enc.h"
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    secret[i] = key[i];
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  asm_maskedAES128enc();
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+  int i;
+  for (i = 0; i < AESInputSize; i++)
+    input[i] = pt[i];
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    int i;
+  for (i = 0; i < AESOutputSize; i++)
+    pt[i] = input[i];
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+  int i;
+  for (i = 0; i < AESMaskSize; i++)
+    mask[i] = m[i];
+}
+
+#elif defined(ANSSI_CM4)
+
+#include "platform.h"
+#include "string.h"
+#include "aes.h"
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#define AESKeySize 16
+#define AESMaskSize 19
+#define AESBlockSize 16
+
+STRUCT_AES aes_ctx;
+uint8_t key_mask[AESMaskSize];
+uint8_t aes_mask[AESMaskSize];
+uint8_t temp_key[AESKeySize];
+uint8_t mask_modes;
+
+void aes_indep_init(void)
+{
+  local_memset(&aes_ctx, 0, sizeof(aes_ctx));
+  mask_modes = 0;
+}
+
+void aes_indep_key(uint8_t* key)
+{
+#ifdef TRIG_BEFORE_KS
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    temp_key[i] = key[i];
+#else
+  aes(MODE_KEYINIT | mask_modes, &aes_ctx, key,
+      NULL /* plaintext */, NULL /* encrypted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t* pt)
+{
+#ifdef TRIG_BEFORE_KS
+  aes(MODE_KEYINIT | MODE_AESINIT_ENC | MODE_ENC | mask_modes,
+      &aes_ctx, temp_key,
+      pt /* plaintext */, pt /* encrypted text */,
+      aes_mask, key_mask);
+#else
+  aes(MODE_AESINIT_ENC | MODE_ENC | mask_modes, &aes_ctx, NULL /* key */,
+      pt /* plaintext */, pt /* encryted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_mask(uint8_t* m, uint8_t len)
+{
+  int i;
+  if (len >= AESMaskSize) {
+    for (i = 0; i < AESMaskSize; i++)
+      key_mask[i] = m[i];
+    mask_modes |= MODE_RANDOM_KEY_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_KEY_EXT;
+  }
+
+  if (len == (2 * AESMaskSize)) {
+    for (i = 0; i < AESMaskSize; i++)
+      aes_mask[i] = m[i + AESMaskSize];
+    mask_modes |= MODE_RANDOM_AES_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_AES_EXT;
+  }
+}
+
+#elif defined(RIOUBSAES)
+
+#include "secure_aes_pbs.h"
+
+uint8_t encKey[16];
+
+bitslice_t get_random_bitslice(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  sec_aes128_enc_packed_bitslice_wrapper(pt, pt, encKey);
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(KNARFRANKBSAES)
+
+#include "masked_combined.h"
+
+uint8_t encKey[16];
+
+int rand(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  uint8_t result[16];
+  Encrypt(result, pt, encKey);
+  for (uint8_t i = 0; i < 16; i++) {
+    pt[i] = result[i];
+  }
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#else
+
+#error "Unsupported MASKEDAES implementation"
+
+#endif // MASKEDAES
+
+#else
+
+#error "No Crypto Lib Defined?"
+
+#endif
+
+

--- a/hardware/victims/firmware/numicro8051/crypto/aes-independant.h
+++ b/hardware/victims/firmware/numicro8051/crypto/aes-independant.h
@@ -1,0 +1,51 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef AES_INDEPENDANT_
+#define AES_INDEPENDANT_
+
+#include <stdint.h>
+
+#ifdef DPAV4
+#define KEY_LENGTH 32
+//DPAv4 Default Key
+#define DEFAULT_KEY 0x6c,0xec,0xc6,0x7f,0x28,0x7d,0x08,0x3d, \
+		0xeb,0x87,0x66,0xf0,0x73,0x8b,0x36,0xcf, \
+		0x16,0x4e,0xd9,0xb2,0x46,0x95,0x10,0x90, \
+		0x86,0x9d,0x08,0x28,0x5d,0x2e,0x19,0x3b
+
+//Some Other Key
+/*
+#define DEFAULT_KEY 0x1f,0x3e,0xa0,0x47,0x76,0x30,0xce,0x21, \
+        0xa2,0xce,0x33,0x4a,0xa7,0x46,0xc2,0xcd, \
+        0xc7,0x82,0xdc,0x4c,0x09,0x8c,0x66,0xcb, \
+        0xd9,0xcd,0x27,0xd8,0x25,0x68,0x2c,0x81
+*/
+
+#else
+#define KEY_LENGTH 16
+#define DEFAULT_KEY 0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c
+#endif
+
+void aes_indep_init(void);
+void aes_indep_key(uint8_t * key);
+void aes_indep_enc(uint8_t * pt);
+void aes_indep_enc_pretrigger(uint8_t * pt);
+void aes_indep_enc_posttrigger(uint8_t * pt);
+void aes_indep_mask(uint8_t * m, uint8_t len);
+
+#endif

--- a/hardware/victims/firmware/numicro8051/crypto/tiny-AES128-C/aes.c
+++ b/hardware/victims/firmware/numicro8051/crypto/tiny-AES128-C/aes.c
@@ -1,0 +1,547 @@
+/* This AES-128 comes from https://github.com/kokke/tiny-AES128-C which is released into public domain */
+
+/*
+
+This is an implementation of the AES128 algorithm, specifically ECB and CBC mode.
+
+The implementation is verified against the test vectors in:
+  National Institute of Standards and Technology Special Publication 800-38A 2001 ED
+
+ECB-AES128
+----------
+
+  plain-text:
+    6bc1bee22e409f96e93d7e117393172a
+    ae2d8a571e03ac9c9eb76fac45af8e51
+    30c81c46a35ce411e5fbc1191a0a52ef
+    f69f2445df4f9b17ad2b417be66c3710
+
+  key:
+    2b7e151628aed2a6abf7158809cf4f3c
+
+  resulting cipher
+    3ad77bb40d7a3660a89ecaf32466ef97 
+    f5d3d58503b9699de785895a96fdbaaf 
+    43b1cd7f598ece23881b00e3ed030688 
+    7b0c785e27e8ad3f8223207104725dd4 
+
+
+NOTE:   String length must be evenly divisible by 16byte (str_len % 16 == 0)
+        You should pad the end of the string with zeros if this is not the case.
+
+*/
+
+
+/*****************************************************************************/
+/* Includes:                                                                 */
+/*****************************************************************************/
+#include <stdint.h>
+#include <string.h> // CBC mode, for memset
+#include "aes.h"
+#include "hal.h"
+
+/*****************************************************************************/
+/* Defines:                                                                  */
+/*****************************************************************************/
+// The number of columns comprising a state in AES. This is a constant in AES. Value=4
+#define Nb 4
+// The number of 32 bit words in a key.
+#define Nk 4
+// Key length in bytes [128 bit]
+#define KEYLEN 16
+// The number of rounds in AES Cipher.
+#define Nr 10
+
+// jcallan@github points out that declaring Multiply as a function 
+// reduces code size considerably with the Keil ARM compiler.
+// See this link for more information: https://github.com/kokke/tiny-AES128-C/pull/3
+#ifndef MULTIPLY_AS_A_FUNCTION
+  #define MULTIPLY_AS_A_FUNCTION 0
+#endif
+
+/*****************************************************************************/
+/* Private variables:                                                        */
+/*****************************************************************************/
+// state - array holding the intermediate results during decryption.
+typedef uint8_t __data state_t[4][4];
+static state_t* state;
+
+// The array that stores the round keys.
+static uint8_t __xdata RoundKey[176];
+
+static uint8_t __data input_save[16];
+
+// The Key input to the AES Program
+static uint8_t* __data Key;
+
+// The lookup-tables are marked const so they can be placed in read-only storage instead of RAM
+// The numbers below can be computed dynamically trading ROM for RAM - 
+// This can be useful in (embedded) bootloader applications, where ROM is often limited.
+AES_CONST_VAR uint8_t __code sbox[256] =   {
+  //0     1    2      3     4    5     6     7      8    9     A      B    C     D     E     F
+  0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+  0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+  0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+  0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+  0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+  0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+  0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+  0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+  0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+  0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+  0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+  0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+  0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+  0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+  0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+  0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16 };
+
+AES_CONST_VAR uint8_t __code rsbox[256] =
+{ 0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81, 0xf3, 0xd7, 0xfb,
+  0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e, 0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb,
+  0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23, 0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e,
+  0x08, 0x2e, 0xa1, 0x66, 0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25,
+  0x72, 0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65, 0xb6, 0x92,
+  0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46, 0x57, 0xa7, 0x8d, 0x9d, 0x84,
+  0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a, 0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06,
+  0xd0, 0x2c, 0x1e, 0x8f, 0xca, 0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b,
+  0x3a, 0x91, 0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6, 0x73,
+  0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8, 0x1c, 0x75, 0xdf, 0x6e,
+  0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f, 0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b,
+  0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2, 0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4,
+  0x1f, 0xdd, 0xa8, 0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
+  0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93, 0xc9, 0x9c, 0xef,
+  0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb, 0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61,
+  0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d };
+
+
+// The round constant word array, Rcon[i], contains the values given by 
+// x to th e power (i-1) being powers of x (x is denoted as {02}) in the field GF(2^8)
+// Note that i starts at 1, not 0).
+AES_CONST_VAR uint8_t __code Rcon[11] = {
+  0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36
+};
+
+
+/*****************************************************************************/
+/* Private functions:                                                        */
+/*****************************************************************************/
+static uint8_t getSBoxValue(uint8_t num)
+{
+  return sbox[num];
+}
+
+static uint8_t getSBoxInvert(uint8_t num)
+{
+  return rsbox[num];
+}
+
+// This function produces Nb(Nr+1) round keys. The round keys are used in each round to decrypt the states. 
+static void KeyExpansion(void)
+{
+  uint32_t i, j, k;
+  uint8_t tempa[4]; // Used for the column/row operations
+  
+  // The first round key is the key itself.
+  for(i = 0; i < Nk; ++i)
+  {
+    RoundKey[(i * 4) + 0] = Key[(i * 4) + 0];
+    RoundKey[(i * 4) + 1] = Key[(i * 4) + 1];
+    RoundKey[(i * 4) + 2] = Key[(i * 4) + 2];
+    RoundKey[(i * 4) + 3] = Key[(i * 4) + 3];
+  }
+
+  // All other round keys are found from the previous round keys.
+  for(; (i < (Nb * (Nr + 1))); ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      tempa[j]=RoundKey[(i-1) * 4 + j];
+    }
+    if (i % Nk == 0)
+    {
+      // This function rotates the 4 bytes in a word to the left once.
+      // [a0,a1,a2,a3] becomes [a1,a2,a3,a0]
+
+      // Function RotWord()
+      {
+        k = tempa[0];
+        tempa[0] = tempa[1];
+        tempa[1] = tempa[2];
+        tempa[2] = tempa[3];
+        tempa[3] = k;
+      }
+
+      // SubWord() is a function that takes a four-byte input word and 
+      // applies the S-box to each of the four bytes to produce an output word.
+
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+
+      tempa[0] =  tempa[0] ^ Rcon[i/Nk];
+    }
+    else if (Nk > 6 && i % Nk == 4)
+    {
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+    }
+    RoundKey[i * 4 + 0] = RoundKey[(i - Nk) * 4 + 0] ^ tempa[0];
+    RoundKey[i * 4 + 1] = RoundKey[(i - Nk) * 4 + 1] ^ tempa[1];
+    RoundKey[i * 4 + 2] = RoundKey[(i - Nk) * 4 + 2] ^ tempa[2];
+    RoundKey[i * 4 + 3] = RoundKey[(i - Nk) * 4 + 3] ^ tempa[3];
+  }
+}
+
+// This function adds the round key to state.
+// The round key is added to the state by an XOR function.
+static void AddRoundKey(uint8_t round)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      (*state)[i][j] ^= RoundKey[round * Nb * 4 + i * Nb + j];
+    }
+  }
+}
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void SubBytes(void)
+{
+  uint8_t i, j;
+  for(i = 0; i < 4; ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      #ifdef JITTER_2
+      if (input_save[4*i+j] & 0x01) {
+        volatile int i = 1;
+        i+=1;
+      }
+      #endif
+      #ifdef JITTER_2
+      if (input_save[4*i+j] & 0x02) {
+        volatile int i = 1;
+        i+=1;
+      }
+      #endif
+      (*state)[j][i] = getSBoxValue((*state)[j][i]);
+    }
+  }
+}
+
+// The ShiftRows() function shifts the rows in the state to the left.
+// Each row is shifted with different offset.
+// Offset = Row number. So the first row is not shifted.
+static void ShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to left  
+      #ifdef JITTER_2
+      if (input_save[1] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[2] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  temp           = (*state)[0][1];
+  (*state)[0][1] = (*state)[1][1];
+  (*state)[1][1] = (*state)[2][1];
+  (*state)[2][1] = (*state)[3][1];
+  (*state)[3][1] = temp;
+
+  // Rotate second row 2 columns to left  
+      #ifdef JITTER_2
+      if (input_save[4] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[10] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  temp           = (*state)[0][2];
+  (*state)[0][2] = (*state)[2][2];
+  (*state)[2][2] = temp;
+  // Rotate second row 2 columns to left  
+  #ifdef JITTER_2
+  #endif
+      #ifdef JITTER_2
+      if (input_save[5] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[8] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+
+  temp       = (*state)[1][2];
+  (*state)[1][2] = (*state)[3][2];
+  (*state)[3][2] = temp;
+
+  // Rotate second row 2 columns to left  
+      #ifdef JITTER_2
+      if (input_save[0] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[3] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  // Rotate third row 3 columns to left
+  temp       = (*state)[0][3];
+  (*state)[0][3] = (*state)[3][3];
+  (*state)[3][3] = (*state)[2][3];
+  (*state)[2][3] = (*state)[1][3];
+  (*state)[1][3] = temp;
+}
+
+static uint8_t xtime(uint8_t x)
+{
+  return ((x<<1) ^ (((x>>7) & 1) * 0x1b));
+}
+
+// MixColumns function mixes the columns of the state matrix
+static void MixColumns(void)
+{
+  uint8_t i;
+  uint8_t Tmp,Tm,t;
+  for(i = 0; i < 4; ++i)
+  {  
+      #ifdef JITTER_2
+      if (input_save[4*i] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[4*i] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+    t   = (*state)[i][0];
+    Tmp = (*state)[i][0] ^ (*state)[i][1] ^ (*state)[i][2] ^ (*state)[i][3] ;
+    Tm  = (*state)[i][0] ^ (*state)[i][1] ; Tm = xtime(Tm);  (*state)[i][0] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][1] ^ (*state)[i][2] ; Tm = xtime(Tm);  (*state)[i][1] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][2] ^ (*state)[i][3] ; Tm = xtime(Tm);  (*state)[i][2] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][3] ^ t ;        Tm = xtime(Tm);  (*state)[i][3] ^= Tm ^ Tmp ;
+  }
+}
+
+// Multiply is used to multiply numbers in the field GF(2^8)
+#if MULTIPLY_AS_A_FUNCTION
+static uint8_t Multiply(uint8_t x, uint8_t y)
+{
+  return (((y & 1) * x) ^
+       ((y>>1 & 1) * xtime(x)) ^
+       ((y>>2 & 1) * xtime(xtime(x))) ^
+       ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^
+       ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))));
+  }
+#else
+#define Multiply(x, y)                                \
+      (  ((y & 1) * x) ^                              \
+      ((y>>1 & 1) * xtime(x)) ^                       \
+      ((y>>2 & 1) * xtime(xtime(x))) ^                \
+      ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^         \
+      ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))))   \
+
+#endif
+
+// MixColumns function mixes the columns of the state matrix.
+// The method used to multiply may be difficult to understand for the inexperienced.
+// Please use the references to gain more information.
+static void InvMixColumns(void)
+{
+  int i;
+  uint8_t a,b,c,d;
+  for(i=0;i<4;++i)
+  { 
+    a = (*state)[i][0];
+    b = (*state)[i][1];
+    c = (*state)[i][2];
+    d = (*state)[i][3];
+
+    (*state)[i][0] = Multiply(a, 0x0e) ^ Multiply(b, 0x0b) ^ Multiply(c, 0x0d) ^ Multiply(d, 0x09);
+    (*state)[i][1] = Multiply(a, 0x09) ^ Multiply(b, 0x0e) ^ Multiply(c, 0x0b) ^ Multiply(d, 0x0d);
+    (*state)[i][2] = Multiply(a, 0x0d) ^ Multiply(b, 0x09) ^ Multiply(c, 0x0e) ^ Multiply(d, 0x0b);
+    (*state)[i][3] = Multiply(a, 0x0b) ^ Multiply(b, 0x0d) ^ Multiply(c, 0x09) ^ Multiply(d, 0x0e);
+  }
+}
+
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void InvSubBytes(void)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j=0;j<4;++j)
+    {
+      (*state)[j][i] = getSBoxInvert((*state)[j][i]);
+    }
+  }
+}
+
+static void InvShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to right  
+  temp=(*state)[3][1];
+  (*state)[3][1]=(*state)[2][1];
+  (*state)[2][1]=(*state)[1][1];
+  (*state)[1][1]=(*state)[0][1];
+  (*state)[0][1]=temp;
+
+  // Rotate second row 2 columns to right 
+  temp=(*state)[0][2];
+  (*state)[0][2]=(*state)[2][2];
+  (*state)[2][2]=temp;
+
+  temp=(*state)[1][2];
+  (*state)[1][2]=(*state)[3][2];
+  (*state)[3][2]=temp;
+
+  // Rotate third row 3 columns to right
+  temp=(*state)[0][3];
+  (*state)[0][3]=(*state)[1][3];
+  (*state)[1][3]=(*state)[2][3];
+  (*state)[2][3]=(*state)[3][3];
+  (*state)[3][3]=temp;
+}
+
+
+// Cipher is the main function that encrypts the PlainText.
+static void Cipher(void)
+{
+  uint8_t round = 0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(0); 
+  
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round = 1; round < Nr; ++round)
+  {
+    SubBytes();
+    ShiftRows();
+    MixColumns();
+    AddRoundKey(round);
+  }
+  
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  SubBytes();
+  ShiftRows();
+  AddRoundKey(Nr);
+}
+
+static void InvCipher(void)
+{
+  uint8_t round=0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(Nr); 
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round=Nr-1;round>0;round--)
+  {
+    InvShiftRows();
+    InvSubBytes();
+    AddRoundKey(round);
+    InvMixColumns();
+  }
+  
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  InvShiftRows();
+  InvSubBytes();
+  AddRoundKey(0);
+}
+
+static void BlockCopy(uint8_t* output, const uint8_t* input)
+{
+  uint8_t i;
+  for (i=0;i<KEYLEN;++i)
+  {
+    output[i] = input[i];
+  }
+}
+
+
+
+/*****************************************************************************/
+/* Public functions:                                                         */
+/*****************************************************************************/
+
+void AES128_ECB_indp_setkey(uint8_t* key)
+{
+  Key = key;
+  KeyExpansion();
+}
+
+void AES128_ECB_indp_crypto(uint8_t* input)
+{
+  state = (state_t*)input;
+  BlockCopy(input_save, input);
+  Cipher();
+}
+
+void AES128_ECB_encrypt(uint8_t* input, uint8_t* key, uint8_t* output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  Key = key;
+  KeyExpansion();
+
+  // The next function call encrypts the PlainText with the Key using AES algorithm.
+  Cipher();
+}
+
+void AES128_ECB_decrypt(uint8_t* input, uint8_t* key, uint8_t *output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  // The KeyExpansion routine must be called before encryption.
+  Key = key;
+  KeyExpansion();
+
+  InvCipher();
+}
+
+

--- a/hardware/victims/firmware/numicro8051/crypto/tiny-AES128-C/aes.h
+++ b/hardware/victims/firmware/numicro8051/crypto/tiny-AES128-C/aes.h
@@ -1,0 +1,22 @@
+/* This AES-128 comes from https://github.com/kokke/tiny-AES128-C which is released into public domain */
+
+#ifndef _AES_H_
+#define _AES_H_
+
+#include <stdint.h>
+
+#ifndef AES_CONST_VAR
+#define AES_CONST_VAR static const
+// #define AES_CONST_VAR
+#endif
+
+
+void AES128_ECB_encrypt(uint8_t* input, uint8_t* key, uint8_t *output);
+void AES128_ECB_decrypt(uint8_t* input, uint8_t* key, uint8_t *output);
+
+void AES128_ECB_indp_setkey(uint8_t* key);
+void AES128_ECB_indp_crypto(uint8_t* input);
+
+
+
+#endif //_AES_H_

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -11,7 +11,7 @@
 // 230400 will be closer to 250000
 // The `target.baud` setting must be set to account for this
 #ifndef BAUD_RATE
-#define BAUD_RATE 230400
+#define BAUD_RATE 115200
 #endif
 
 #if BAUD_RATE > 230400 && F_CPU <= 16600000

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -11,13 +11,13 @@
 // 115200 will be closer to 111111 
 // 230400 will be closer to 250000
 // The `target.baud` setting must be set to account for this
-#ifndef BAUD_RATE
+#if (!defined(BAUD_RATE) || (BAUD_RATE == 0))
 #define BAUD_RATE 115200
 #endif
 
-#if BAUD_RATE > 230400 && F_CPU <= 16600000
-#error "Baud rate too high for 16.0Mhz clock"
-#endif
+volatile uint32_t __data thing = DIV_ROUND_CLOSEST_UNSIGNED(DIV_ROUND_CLOSEST_UNSIGNED(F_CPU, 16), BAUD_RATE);
+STATIC_ASSERT(DIV_ROUND_CLOSEST_UNSIGNED(DIV_ROUND_CLOSEST_UNSIGNED(F_CPU, 16), BAUD_RATE) > 0, 
+                "F_CPU / 16 / BAUD_RATE must be greater than 0");
 
 int putchar(int c)
 {

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -1,0 +1,89 @@
+
+#include <stdint.h>
+#include "numicro_8051.h"
+#include "Common.h"
+#include "Delay.h"
+#include "clock.h"
+#include "isp_uart0.h"
+
+// NOTE: When using FOSC_160000, the actual baud rate as processed will be closer to 111111 (see N76E003 datasheet, section 13.5). 
+// The `target.baud` setting must be set to account for this
+#define BAUD_RATE 115200
+
+int putchar(int c)
+{
+    Send_Data_To_UART0(c);
+    return c;
+}
+
+int getchar(void)
+{
+    int c;
+    while (!RI)
+        ;
+    c = SBUF;
+    RI = 0;
+    return (c);
+}
+
+void init_uart(void)
+{
+    // setting pushpull mode for LED1, LED2, and LED3 because they sometimes do not have enough voltage
+    P03_PUSHPULL_MODE;
+    P12_PUSHPULL_MODE;
+    P05_PUSHPULL_MODE;
+
+    // set LED 1 to on
+    P03 = 1;
+    P12 = 0;
+    P05 = 0;
+
+    InitialUART0_Timer3(BAUD_RATE);
+}
+
+void putch(char c)
+{
+    putchar(c);
+}
+char getch(void)
+{
+    return (char)getchar();
+}
+
+void trigger_setup(void)
+{
+    P04 = 0;
+    P04_QUASI_MODE;
+}
+
+void trigger_low(void)
+{
+    P04 = 0;
+}
+void trigger_high(void)
+{
+    P04 = 1;
+}
+
+void platform_init(void)
+{
+#if USE_EXTERNAL_CLOCK
+    use_external_clock();
+#else // use internal clock
+    use_internal_clock();
+    enable_output_clock();
+#endif
+    set_BODCON1_LPBOD1; // set BOD to only turn on every 25 ms
+    set_BODCON1_LPBOD0; // set BOD to only turn on every 25 ms
+    clr_BODCON0_BODEN;  // disable brown-out detector
+    clr_IE_EBOD;        // disable brown-out detector interrupt
+    clr_BODCON0_BORST;  // disable brown-out reset
+}
+
+// void led_error(unsigned int status){
+//     P05 = status;
+
+// }
+// void led_ok(unsigned int status){
+//     P12 = status;
+// }

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -14,6 +14,10 @@
 #define BAUD_RATE 230400
 #endif
 
+#if BAUD_RATE > 230400 && F_CPU <= 16600000
+#error "Baud rate too high for 16.0Mhz clock"
+#endif
+
 int putchar(int c)
 {
     Send_Data_To_UART0(c);

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -6,10 +6,12 @@
 #include "clock.h"
 #include "isp_uart0.h"
 
-// NOTE: When using FOSC_160000, the actual baud rate as processed will be closer to 111111 (see N76E003 datasheet, section 13.5). 
+// NOTE: When using 16.0Mhz, the actual baud rate as processed will have a high deviation when >38400 (see N76E003 datasheet, section 13.5).
+// 115200 will be closer to 111111 
+// 230400 will be closer to 250000
 // The `target.baud` setting must be set to account for this
 #ifndef BAUD_RATE
-#define BAUD_RATE 115200
+#define BAUD_RATE 230400
 #endif
 
 int putchar(int c)

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -8,7 +8,9 @@
 
 // NOTE: When using FOSC_160000, the actual baud rate as processed will be closer to 111111 (see N76E003 datasheet, section 13.5). 
 // The `target.baud` setting must be set to account for this
+#ifndef BAUD_RATE
 #define BAUD_RATE 115200
+#endif
 
 int putchar(int c)
 {

--- a/hardware/victims/firmware/numicro8051/hal/hal.c
+++ b/hardware/victims/firmware/numicro8051/hal/hal.c
@@ -5,6 +5,7 @@
 #include "Delay.h"
 #include "clock.h"
 #include "isp_uart0.h"
+#include "hal.h"
 
 // NOTE: When using 16.0Mhz, the actual baud rate as processed will have a high deviation when >38400 (see N76E003 datasheet, section 13.5).
 // 115200 will be closer to 111111 
@@ -34,17 +35,19 @@ int getchar(void)
     return (c);
 }
 
+
+
 void init_uart(void)
 {
     // setting pushpull mode for LED1, LED2, and LED3 because they sometimes do not have enough voltage
-    P03_PUSHPULL_MODE;
-    P12_PUSHPULL_MODE;
-    P05_PUSHPULL_MODE;
+    PIN_LED_STATUS_PUSHPULL_MODE;
+    PIN_LED_OK_PUSHPULL_MODE;
+    PIN_LED_ERROR_PUSHPULL_MODE;
 
     // set LED 1 to on
-    P03 = 1;
-    P12 = 0;
-    P05 = 0;
+    PIN_LED_STATUS = 1;
+    PIN_LED_OK = 0;
+    PIN_LED_ERROR = 0;
 
     InitialUART0_Timer3(BAUD_RATE);
 }
@@ -60,17 +63,17 @@ char getch(void)
 
 void trigger_setup(void)
 {
-    P04 = 0;
-    P04_QUASI_MODE;
+    PIN_TRIGGER = 0;
+    PIN_TRIGGER_QUASI_MODE;
 }
 
 void trigger_low(void)
 {
-    P04 = 0;
+    PIN_TRIGGER = 0;
 }
 void trigger_high(void)
 {
-    P04 = 1;
+    PIN_TRIGGER = 1;
 }
 
 void platform_init(void)

--- a/hardware/victims/firmware/numicro8051/hal/hal.h
+++ b/hardware/victims/firmware/numicro8051/hal/hal.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "numicro_8051.h"
+
+void platform_init(void);
+void init_uart(void);
+void putch(char c);
+char getch(void);
+
+void trigger_setup(void);
+void trigger_low(void);
+void trigger_high(void);
+
+#define set_trigger(val) P04 = val
+#define led_error(status) P05 = status
+#define led_ok(status) P12 = status

--- a/hardware/victims/firmware/numicro8051/hal/hal.h
+++ b/hardware/victims/firmware/numicro8051/hal/hal.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "numicro_8051.h"
+#include "pin_defines.h"
 
 void platform_init(void);
 void init_uart(void);
@@ -10,6 +11,6 @@ void trigger_setup(void);
 void trigger_low(void);
 void trigger_high(void);
 
-#define set_trigger(val) P04 = val
-#define led_error(status) P05 = status
-#define led_ok(status) P12 = status
+#define set_trigger(val) PIN_LED_STATUS = val
+#define led_error(status) PIN_LED_ERROR = status
+#define led_ok(status) PIN_LED_OK = status

--- a/hardware/victims/firmware/numicro8051/inc/LICENSE.txt
+++ b/hardware/victims/firmware/numicro8051/inc/LICENSE.txt
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/function_define_ms51_16k.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/function_define_ms51_16k.h
@@ -1,0 +1,853 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  function_define_ms51_16k.h                                                          */
+/*  All IP function define for Nuvoton                                                  */
+/*  MS51FB9AE / MS51XB9AE / MS51XB9BE                                                   */
+/*--------------------------------------------------------------------------------------*/
+
+#ifdef __CDT_PARSER__         /* For __SDCC__ */
+  #define __data
+  #define __near
+  #define __idata
+  #define __xdata
+  #define __far
+  #define __pdata
+  #define __code
+  #define __bit
+  #define __sfr
+  #define __sbit
+  #define __critical
+  #define __at(x)             /* use "__at (0xab)" instead of "__at 0xab" */
+  #define __using(x)
+  #define __interrupt(x)
+  #define __naked
+#endif
+
+typedef unsigned char         UINT8;
+typedef unsigned int          UINT16;
+typedef unsigned long         UINT32;
+typedef signed char           INT8;
+typedef signed int            INT16;
+typedef signed long           INT32;
+
+#if defined __C51__
+typedef bit                   BIT;
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __ICC8051__
+#define BIT __no_init bool __bit
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __SDCC__
+typedef __bit                 BIT;
+#endif
+
+#define Disable  0
+#define Enable   1
+
+#define DISABLE  0
+#define ENABLE   1 
+
+#define TRUE     1  
+#define FALSE    0  
+                    
+#define FAIL     1  
+#define PASS     0  
+                  
+//16 --> 8 x 2
+#define HIBYTE(v1)              ((uint8_t)((v1)>>8))                      //v1 is uint16_t
+#define LOBYTE(v1)              ((uint8_t)((v1)&0xFF))
+//8 x 2 --> 16
+#define MAKEWORD(v1,v2)         ((((uint16_t)(v1))<<8)+(uint16_t)(v2))      //v1,v2 is uint8_t
+//8 x 4 --> 32
+#define MAKELONG(v1,v2,v3,v4)   (uint32_t)((v1<<32)+(v2<<16)+(v3<<8)+v4)  //v1,v2,v3,v4 is uint8_t
+//32 --> 16 x 2
+#define YBYTE1(v1)              ((uint16_t)((v1)>>16))                    //v1 is uint32_t
+#define YBYTE0(v1)              ((uint16_t)((v1)&0xFFFF))
+//32 --> 8 x 4
+#define TBYTE3(v1)              ((uint8_t)((v1)>>24))                     //v1 is uint32_t
+#define TBYTE2(v1)              ((uint8_t)((v1)>>16))
+#define TBYTE1(v1)              ((uint8_t)((v1)>>8)) 
+#define TBYTE0(v1)              ((uint8_t)((v1)&0xFF))
+
+#define SET_BIT0        0x01
+#define SET_BIT1        0x02
+#define SET_BIT2        0x04
+#define SET_BIT3        0x08
+#define SET_BIT4        0x10
+#define SET_BIT5        0x20
+#define SET_BIT6        0x40
+#define SET_BIT7        0x80
+
+#define CLR_BIT0        0xFE
+#define CLR_BIT1        0xFD
+#define CLR_BIT2        0xFB
+#define CLR_BIT3        0xF7
+#define CLR_BIT4        0xEF
+#define CLR_BIT5        0xDF
+#define CLR_BIT6        0xBF
+#define CLR_BIT7        0x7F
+
+/*****************************************************************************/
+/*   Stack and NOP                                                           */
+/*****************************************************************************/
+#if defined __C51__
+#define   nop                                  _nop_()
+#define   CALL_NOP                             _nop_()
+#define   PUSH_SFRS                            _push_(SFRS)
+#define   POP_SFRS                             _pop_(SFRS)
+#elif defined __ICC8051__
+#define _nop_()                                asm("nop") 
+#define nop                                    asm("nop")
+#define CALL_NOP                               asm("nop")
+#define PUSH_SFRS                              asm(" PUSH 0x91")
+#define POP_SFRS                               asm(" POP 0x91")
+#define _push_(SFRS)                           asm(" PUSH 0x91")
+#define _pop_(SFRS)                            asm(" POP 0x91")
+#elif defined __SDCC__
+#define _nop_()                                __asm__("nop;")
+#define nop                                    __asm__("nop;")
+#define CALL_NOP                               __asm__("nop;")
+#define PUSH_SFRS                              __asm__(" PUSH 0x91;")
+#define POP_SFRS                               __asm__(" POP 0x91;")
+#define _push_(SFRS)                           __asm__(" PUSH 0x91;")
+#define _pop_(SFRS)                            __asm__(" POP 0x91;")
+#endif
+
+/*****************************************************************************/
+/*   sfr page select                                                          */
+/*****************************************************************************/
+#define    ENABLE_SFR_PAGE1                    set_SFRS_SFRPAGE
+#define    ENABLE_SFR_PAGE0                    clr_SFRS_SFRPAGE
+
+/*****************************************************************************/
+/*   Software reset                                                          */
+/*****************************************************************************/
+#define    ENABLE_SOFTWARE_RESET_TO_APROM      clr_CHPCON_BS;set_CHPCON_SWRST
+#define    ENABLE_SOFTWARE_RESET_TO_LDROM      set_CHPCON_BS;set_CHPCON_SWRST
+
+/*****************************************************************************/
+/*   Power down / idle mode define                                           */
+/*****************************************************************************/
+#define    ENABLE_POWERDOWN_MODE               set_PCON_PD
+#define    ENABLE_IDLE_MODE                    set_PCON_IDLE
+
+/*****************************************************************************/
+/*   BOD Define                                                              */
+/*****************************************************************************/
+#define    BOD_ENABLE               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    BOD_RESET_ENABLE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    BOD_DISABLE              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+ /****/
+#define    ENABLE_BOD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    ENABLE_BOD_RESET         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    DISABLE_BOD              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+
+/*****************************************************************************/
+/*    IAP function process                                                   */ 
+/*****************************************************************************/
+#define    PAGE_SIZE               128
+
+#define    READ_CID                0x0B
+#define    READ_DID                0x0C
+#define    READ_UID                0x04
+
+#define    PAGE_ERASE_APROM        0x22
+#define    BYTE_READ_APROM         0x00
+#define    BYTE_PROGRAM_APROM      0x21
+
+#define    PAGE_ERASE_LDROM        0x62
+#define    BYTE_READ_LDROM         0x40
+#define    BYTE_PROGRAM_LDROM      0x61
+
+#define    ENABLE_SPROM            set_IAPUEN_SPMEN
+#define    PAGE_ERASE_SPROM        0xA2
+#define    BYTE_READ_SPROM         0x80
+#define    BYTE_PROGRAM_SPROM      0xA1
+
+#define    PAGE_ERASE_CONFIG       0xE2
+#define    BYTE_READ_CONFIG        0xC0
+#define    BYTE_PROGRAM_CONFIG     0xE1
+
+#define    CID_READ                0x0B
+#define    DID_READ                0x0C
+
+/*****************************************************************************/
+/*    interrupt function process                                             */ 
+/*****************************************************************************/
+#define    ENABLE_GLOBAL_INTERRUPT       set_IE_EA
+#define    DISABLE_GLOBAL_INTERRUPT      clr_IE_EA
+
+/*Enable Interrupt*/
+#define    ENABLE_ADC_INTERRUPT          set_IE_EADC
+#define    ENABLE_BOD_INTERRUPT          set_IE_EBOD
+#define    ENABLE_UART0_INTERRUPT        set_IE_ES
+#define    ENABLE_TIMER1_INTERRUPT       set_IE_ET1
+#define    ENABLE_INT1_INTERRUPT         set_IE_EX1
+#define    ENABLE_TIMER0_INTERRUPT       set_IE_ET0
+#define    ENABLE_INT0_INTERRUPT         set_IE_EX0
+
+#define    ENABLE_TIMER2_INTERRUPT       set_EIE_ET2
+#define    ENABLE_SPI0_INTERRUPT         set_EIE_ESPI
+#define    ENABLE_PWM0_FB_INTERRUPT      set_EIE_EFB0
+#define    ENABLE_WDT_INTERRUPT          set_EIE_EWDT
+#define    ENABLE_PWM0_INTERRUPT         set_EIE_EPWM
+#define    ENABLE_CAPTURE_INTERRUPT      set_EIE_ECAP
+#define    ENABLE_PIN_INTERRUPT          set_EIE_EPI
+#define    ENABLE_I2C_INTERRUPT          set_EIE_EI2C
+
+#define    ENABLE_WKT_INTERRUPT          set_EIE1_EWKT
+#define    ENABLE_TIMER3_INTERRUPT       set_EIE1_ET3
+#define    ENABLE_UART1_INTERRUPT        set_EIE1_ES_1
+
+/*Disable Interrupt*/ 
+#define    DISABLE_ADC_INTERRUPT         clr_IE_EADC
+#define    DISABLE_BOD_INTERRUPT         clr_IE_EBOD
+#define    DISABLE_UART0_INTERRUPT       clr_IE_ES
+#define    DISABLE_TIMER1_INTERRUPT      clr_IE_ET1
+#define    DISABLE_INT1_INTERRUPT        clr_IE_EX1
+#define    DISABLE_TIMER0_INTERRUPT      clr_IE_ET0
+#define    DISABLE_INT0_INTERRUPT        clr_IE_EX0
+
+#define    DISABLE_TIMER2_INTERRUPT      clr_EIE_ET2
+#define    DISABLE_SPI0_INTERRUPT        clr_EIE_ESPI
+#define    DISABLE_PWM0_FB_INTERRUPT     clr_EIE_EFB0
+#define    DISABLE_WDT_INTERRUPT         clr_EIE_EWDT
+#define    DISABLE_PWM0_INTERRUPT        clr_EIE_EPWM
+#define    DISABLE_CAPTURE_INTERRUPT     clr_EIE_ECAP
+#define    DISABLE_PIN_INTERRUPT         clr_EIE_EPI
+#define    DISABLE_I2C_INTERRUPT         clr_EIE_EI2C
+
+#define    DISABLE_WKT_INTERRUPT         clr_EIE1_EWKT
+#define    DISABLE_TIMER3_INTERRUPT      clr_EIE1_ET3
+#define    DISABLE_UART1_INTERRUPT       clr_EIE1_ES_1
+
+/* Setting Interrupt Priority */
+#define   SET_INT_INT0_LEVEL0          clr_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL1          clr_IP_PX0; set_IPH_PX0H
+#define   SET_INT_INT0_LEVEL2          set_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL3          set_IP_PX0; set_IPH_PX0H
+
+#define   SET_INT_BOD_LEVEL0           clr_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL1           clr_IP_PBOD; set_IPH_PBODH
+#define   SET_INT_BOD_LEVEL2           set_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL3           set_IP_PBOD; set_IPH_PBODH
+
+#define   SET_INT_WDT_LEVEL0           clr_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL1           clr_EIP_PWDT; set_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL2           set_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL3           set_EIP_PWDT; set_EIPH_PWDTH
+
+#define   SET_INT_TIMER0_LEVEL0        clr_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL1        clr_IP_PT0; set_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL2        set_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL3        set_IP_PT0; set_IPH_PT0H
+
+#define   SET_INT_I2C0_LEVEL0          clr_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL1          clr_EIP_PI2C; set_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL2          set_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL3          set_EIP_PI2C; set_EIPH_PI2CH
+
+#define   SET_INT_ADC_LEVEL0           clr_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL1           clr_IP_PADC; set_IPH_PADCH
+#define   SET_INT_ADC_LEVEL2           set_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL3           set_IP_PADC; set_IPH_PADCH
+
+#define   SET_INT_INT1_LEVEL0          clr_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL1          clr_IP_PX1; set_IPH_PX1H
+#define   SET_INT_INT1_LEVEL2          set_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL3          set_IP_PX1; set_IPH_PX1H
+
+#define   SET_INT_PIT_LEVEL0           clr_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL1           clr_EIP_PPI; set_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL2           set_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL3           set_EIP_PPI; set_EIPH_PPIH
+
+#define   SET_INT_Timer1_LEVEL0        clr_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL1        clr_IP_PT1; set_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL2        set_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL3        set_IP_PT1; set_IPH_PT1H
+
+#define   SET_INT_UART0_LEVEL0         clr_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL1         clr_IP_PS; set_IPH_PSH
+#define   SET_INT_UART0_LEVEL2         set_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL3         set_IP_PS; set_IPH_PSH
+
+#define   SET_INT_PWM0_BRAKE_LEVEL0    clr_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL1    clr_EIP_PFB; set_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL2    set_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL3    set_EIP_PFB; set_EIPH_PFBH
+
+#define   SET_INT_SPI_LEVEL0           clr_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL1           clr_EIP_PSPI; set_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL2           set_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL3           set_EIP_PSPI; set_EIPH_PSPIH
+
+#define   SET_INT_Timer2_LEVEL0        clr_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL1        clr_EIP_PT2; set_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL2        set_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL3        set_EIP_PT2; set_EIPH_PT2H
+
+#define   SET_INT_CAPTURE_LEVEL0       clr_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL1       clr_EIP_PCAP; set_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL2       set_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL3       set_EIP_PCAP; set_EIPH_PCAPH
+
+#define   SET_INT_PWM_LEVEL0           clr_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL1           clr_EIP_PPWM; set_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL2           set_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL3           set_EIP_PPWM; set_EIPH_PPWMH
+
+#define   SET_INT_UART1_LEVEL0         clr_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL1         clr_EIP1_PS_1; set_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL2         set_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL3         set_EIP1_PS_1; set_EIPH1_PSH_1
+
+#define   SET_INT_Timer3_LEVEL0        clr_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL1        clr_EIP1_PT3; set_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL2        set_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL3        set_EIP1_PT3; set_EIPH1_PT3H
+
+#define   SET_INT_WKT_LEVEL0           clr_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL1           clr_EIP1_PWKT; set_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL2           set_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL3           set_EIP1_PWKT; set_EIPH1_PWKTH
+
+/* Clear Interrupt Flag */
+#define    CLEAR_ADC_INTERRUPT_FLAG          clr_ADCCON0_ADCF
+#define    CLEAR_BOD_INTERRUPT_FLAG          clr_BODCON0_BOF
+#define    CLEAR_BOD_RESET_FLAG              clr_BODCON0_BORF
+#define    CLEAR_UART0_INTERRUPT_TX_FLAG     clr_SCON_TI
+#define    CLEAR_UART0_INTERRUPT_RX_FLAG     clr_SCON_RI
+#define    CLEAR_TIMER1_INTERRUPT_FLAG       clr_TCON_TF1
+#define    CLEAR_INT1_INTERRUPT_FLAG         clr_TCON_IE1
+#define    CLEAR_TIMER0_INTERRUPT_FLAG       clr_TCON_TF0
+#define    CLEAR_INT0_INTERRUPT_FLAG         clr_TCON_IE0
+#define    CLEAR_TIMER2_INTERRUPT_FLAG       clr_T2CON_TF2
+#define    CLEAR_SPI0_INTERRUPT_FLAG         clr_SPSR_SPIF
+#define    CLEAR_PWM0_FB_INTERRUPT_FLAG      clr_PWM0FBD_FBF
+#define    CLEAR_WDT_INTERRUPT_FLAG          clr_WDCON_WDTF
+#define    CLEAR_PWM0_INTERRUPT_FLAG         clr_PWM1CON0_PWMF
+#define    CLEAR_CAPTURE_INTERRUPT_IC0_FLAG  clr_CAPCON0_CAPF0
+#define    CLEAR_CAPTURE_INTERRUPT_IC1_FLAG  clr_CAPCON0_CAPF1
+#define    CLEAR_CAPTURE_INTERRUPT_IC2_FLAG  clr_CAPCON0_CAPF2
+#define    CLEAR_PIN_INTERRUPT_PIT0_FLAG     clr_PIF_PIF0
+#define    CLEAR_PIN_INTERRUPT_PIT1_FLAG     clr_PIF_PIF1
+#define    CLEAR_PIN_INTERRUPT_PIT2_FLAG     clr_PIF_PIF2
+#define    CLEAR_PIN_INTERRUPT_PIT3_FLAG     clr_PIF_PIF3
+#define    CLEAR_PIN_INTERRUPT_PIT4_FLAG     clr_PIF_PIF4
+#define    CLEAR_PIN_INTERRUPT_PIT5_FLAG     clr_PIF_PIF5
+#define    CLEAR_PIN_INTERRUPT_PIT6_FLAG     clr_PIF_PIF6
+#define    CLEAR_PIN_INTERRUPT_PIT7_FLAG     clr_PIF_PIF7
+#define    CLEAR_I2C_TIMEOUT_INTERRUPT_FLAG  clr_I2TOC_I2TOF
+#define    CLEAR_WKT_INTERRUPT_FLAG          clr_WKCON_WKTF
+#define    CLEAR_TIMER3_INTERRUPT_FLAG       clr_T3CON_TF3
+#define    CLEAR_UART1_INTERRUPT_FLAG        clr_EIE1_ES_1 
+
+/*****************************************************************************/
+/*    For GPIO Mode setting                                                  */ 
+/*****************************************************************************/
+#define    P00_QUASI_MODE            P0M1&=0xFE;P0M2&=0xFE
+#define    P01_QUASI_MODE            P0M1&=0xFD;P0M2&=0xFD
+#define    P02_QUASI_MODE            P0M1&=0xFB;P0M2&=0xFB
+#define    P03_QUASI_MODE            P0M1&=0xF7;P0M2&=0xF7
+#define    P04_QUASI_MODE            P0M1&=0xEF;P0M2&=0xEF
+#define    P05_QUASI_MODE            P0M1&=0xDF;P0M2&=0xDF
+#define    P06_QUASI_MODE            P0M1&=0xBF;P0M2&=0xBF
+#define    P07_QUASI_MODE            P0M1&=0x7F;P0M2&=0x7F
+#define    P10_QUASI_MODE            P1M1&=0xFE;P1M2&=0xFE
+#define    P11_QUASI_MODE            P1M1&=0xFD;P1M2&=0xFD
+#define    P12_QUASI_MODE            P1M1&=0xFB;P1M2&=0xFB
+#define    P13_QUASI_MODE            P1M1&=0xF7;P1M2&=0xF7
+#define    P14_QUASI_MODE            P1M1&=0xEF;P1M2&=0xEF
+#define    P15_QUASI_MODE            P1M1&=0xDF;P1M2&=0xDF
+#define    P16_QUASI_MODE            P1M1&=0xBF;P1M2&=0xBF
+#define    P17_QUASI_MODE            P1M1&=0x7F;P1M2&=0x7F
+#define    P30_QUASI_MODE            P3M1&=0xFE;P3M2&=0xFE
+#define    ALL_GPIO_QUASI_MODE       P0M1=0;P0M2=0;P1M1=0;P1M2=0;P3M1=0;P3M2=0
+
+#define    P00_PUSHPULL_MODE         P0M1&=0xFE;P0M2|=0x01
+#define    P01_PUSHPULL_MODE         P0M1&=0xFD;P0M2|=0x02
+#define    P02_PUSHPULL_MODE         P0M1&=0xFB;P0M2|=0x04
+#define    P03_PUSHPULL_MODE         P0M1&=0xF7;P0M2|=0x08
+#define    P04_PUSHPULL_MODE         P0M1&=0xEF;P0M2|=0x10
+#define    P05_PUSHPULL_MODE         P0M1&=0xDF;P0M2|=0x20
+#define    P06_PUSHPULL_MODE         P0M1&=0xBF;P0M2|=0x40
+#define    P07_PUSHPULL_MODE         P0M1&=0x7F;P0M2|=0x80
+#define    P10_PUSHPULL_MODE         P1M1&=0xFE;P1M2|=0x01
+#define    P11_PUSHPULL_MODE         P1M1&=0xFD;P1M2|=0x02
+#define    P12_PUSHPULL_MODE         P1M1&=0xFB;P1M2|=0x04
+#define    P13_PUSHPULL_MODE         P1M1&=0xF7;P1M2|=0x08
+#define    P14_PUSHPULL_MODE         P1M1&=0xEF;P1M2|=0x10
+#define    P15_PUSHPULL_MODE         P1M1&=0xDF;P1M2|=0x20
+#define    P16_PUSHPULL_MODE         P1M1&=0xBF;P1M2|=0x40
+#define    P17_PUSHPULL_MODE         P1M1&=0x7F;P1M2|=0x80
+#define    P30_PUSHPULL_MODE         P3M1&=0xFE;P3M2|=0x01
+#define    ALL_GPIO_PUSHPULL_MODE    P0M1=0;P0M2=0xFF;P1M1=0;P1M2=0xFF;P3M1=0;P3M2=0xFF
+
+#define    P00_INPUT_MODE            P0M1|=0x01;P0M2&=0xFE
+#define    P01_INPUT_MODE            P0M1|=0x02;P0M2&=0xFD
+#define    P02_INPUT_MODE            P0M1|=0x04;P0M2&=0xFB
+#define    P03_INPUT_MODE            P0M1|=0x08;P0M2&=0xF7
+#define    P04_INPUT_MODE            P0M1|=0x10;P0M2&=0xEF
+#define    P05_INPUT_MODE            P0M1|=0x20;P0M2&=0xDF
+#define    P06_INPUT_MODE            P0M1|=0x40;P0M2&=0xBF
+#define    P07_INPUT_MODE            P0M1|=0x80;P0M2&=0x7F
+#define    P10_INPUT_MODE            P1M1|=0x01;P1M2&=0xFE
+#define    P11_INPUT_MODE            P1M1|=0x02;P1M2&=0xFD
+#define    P12_INPUT_MODE            P1M1|=0x04;P1M2&=0xFB
+#define    P13_INPUT_MODE            P1M1|=0x08;P1M2&=0xF7
+#define    P14_INPUT_MODE            P1M1|=0x10;P1M2&=0xEF
+#define    P15_INPUT_MODE            P1M1|=0x20;P1M2&=0xDF
+#define    P16_INPUT_MODE            P1M1|=0x40;P1M2&=0xBF
+#define    P17_INPUT_MODE            P1M1|=0x80;P1M2&=0x7F
+#define    P30_INPUT_MODE            P3M1|=0x01;P3M2&=0xFE
+#define    ALL_GPIO_INPUT_MODE       P0M1=0xFF;P0M2=0;P1M1=0xFF;P1M2=0;P3M1=0xFF;P3M2=0
+
+#define    P00_OPENDRAIN_MODE        P0M1|=0x01;P0M2|=0x01
+#define    P01_OPENDRAIN_MODE        P0M1|=0x02;P0M2|=0x02
+#define    P02_OPENDRAIN_MODE        P0M1|=0x04;P0M2|=0x04
+#define    P03_OPENDRAIN_MODE        P0M1|=0x08;P0M2|=0x08
+#define    P04_OPENDRAIN_MODE        P0M1|=0x10;P0M2|=0x10
+#define    P05_OPENDRAIN_MODE        P0M1|=0x20;P0M2|=0x20
+#define    P06_OPENDRAIN_MODE        P0M1|=0x40;P0M2|=0x40
+#define    P07_OPENDRAIN_MODE        P0M1|=0x80;P0M2|=0x80
+#define    P10_OPENDRAIN_MODE        P1M1|=0x01;P1M2|=0x01
+#define    P11_OPENDRAIN_MODE        P1M1|=0x02;P1M2|=0x02
+#define    P12_OPENDRAIN_MODE        P1M1|=0x04;P1M2|=0x04
+#define    P13_OPENDRAIN_MODE        P1M1|=0x08;P1M2|=0x08
+#define    P14_OPENDRAIN_MODE        P1M1|=0x10;P1M2|=0x10
+#define    P15_OPENDRAIN_MODE        P1M1|=0x20;P1M2|=0x20
+#define    P16_OPENDRAIN_MODE        P1M1|=0x40;P1M2|=0x40
+#define    P17_OPENDRAIN_MODE        P1M1|=0x80;P1M2|=0x80
+#define    P30_OPENDRAIN_MODE        P3M1|=0x01;P3M2|=0x01
+#define    ALL_GPIO_OPENDRAIN_MODE   P0M1=0xFF;P0M2=0xFF;P1M1=0xFF;P1M2=0xFF;P3M1=0xFF;P3M2=0xFF
+
+/*****************************************************************************/
+/*    For GPIO Schmitt Trig / TTL Type Seetting                              */ 
+/*****************************************************************************/
+#define    ENABLE_P00_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_ST_MODE        ENABLE_SFR_PAGE1;P2S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_ST_MODE        ENABLE_SFR_PAGE1;P3S|=0x01;ENABLE_SFR_PAGE0
+
+#define    ENABLE_P00_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_TTL_MODE       ENABLE_SFR_PAGE1;P2S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_TTL_MODE       ENABLE_SFR_PAGE1;P3S&=0xFE;ENABLE_SFR_PAGE0
+
+/*****************************************************************************/
+/*    Enable GPIO Pin Interrupt port 0~3                                     */ 
+/*****************************************************************************/
+#define    ENABLE_INT_PORT0               PICON &= 0xFB;
+#define    ENABLE_INT_PORT1               PICON |= 0x01;
+#define    ENABLE_INT_PORT2               PICON |= 0x02;
+#define    ENABLE_INT_PORT3               PICON |= 0x03;
+/*    Bit low level trig mode   */
+#define    ENABLE_BIT7_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_LOWLEVEL_TRIG      PICON&=0xDF;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_LOWLEVEL_TRIG      PICON&=0xEF;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_LOWLEVEL_TRIG      PICON&=0xF7;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_LOWLEVEL_TRIG      PICON&=0xFD;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit high level trig mode    */
+#define    ENABLE_BIT7_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_HIGHLEVEL_TRIG     PICON&=0xDF;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_HIGHLEVEL_TRIG     PICON&=0xEF;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_HIGHLEVEL_TRIG     PICON&=0xF7;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_HIGHLEVEL_TRIG     PICON&=0xFD;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit falling edge trig mode   */
+#define    ENABLE_BIT7_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_FALLINGEDGE_TRIG   PICON|=0x20;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_FALLINGEDGE_TRIG   PICON|=0x10;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_FALLINGEDGE_TRIG   PICON|=0x08;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_FALLINGEDGE_TRIG   PICON|=0x04;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit rising edge trig mode    */
+#define    ENABLE_BIT7_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_RISINGEDGE_TRIG    PICON|=0x20;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_RISINGEDGE_TRIG    PICON|=0x10;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_RISINGEDGE_TRIG    PICON|=0x08;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_RISINGEDGE_TRIG    PICON|=0x04;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit both edge trig mode    */
+#define    ENABLE_BIT7_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x80;PIPEN|=0x80
+#define    ENABLE_BIT6_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x40;PIPEN|=0x40
+#define    ENABLE_BIT5_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x20;PIPEN|=0x20
+#define    ENABLE_BIT4_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x10;PIPEN|=0x10
+#define    ENABLE_BIT3_BOTHEDGE_TRIG      PICON|=0x20;PINEN|=0x08;PIPEN|=0x08
+#define    ENABLE_BIT2_BOTHEDGE_TRIG      PICON|=0x10;PINEN|=0x04;PIPEN|=0x04
+#define    ENABLE_BIT1_BOTHEDGE_TRIG      PICON|=0x08;PINEN|=0x02;PIPEN|=0x02
+#define    ENABLE_BIT0_BOTHEDGE_TRIG      PICON|=0x04;PINEN|=0x01;PIPEN|=0x01
+
+/*****************************************************************************/
+/*    TIMER Function Define                                                  */ 
+/*****************************************************************************/
+#define    ENABLE_CLOCK_OUT              set_CKCON_CLOEN;
+/*    Timer0 basic define  */
+#define    ENABLE_TIMER0_MODE0           TMOD&=0xF0
+#define    ENABLE_TIMER0_MODE1           TMOD&=0xF0;TMOD|=0x01
+#define    ENABLE_TIMER0_MODE2           TMOD&=0xF0;TMOD|=0x02
+#define    ENABLE_TIMER0_MODE3           TMOD&=0xF0;TMOD|=0x03
+#define    TIMER0_FSYS                   set_CKCON_T0M
+#define    TIMER0_FSYS_DIV12             clr_CKCON_T0M
+#define    TIMER0_MODE0_ENABLE           TMOD&=0xF0
+#define    TIMER0_MODE1_ENABLE           TMOD&=0xF0;TMOD|=0x01
+#define    TIMER0_MODE2_ENABLE           TMOD&=0xF0;TMOD|=0x02
+#define    TIMER0_MODE3_ENABLE           TMOD&=0xF0;TMOD|=0x03
+/*    Timer1 basic define  */
+#define    ENABLE_TIMER1_MODE0           TMOD&=0x0F
+#define    ENABLE_TIMER1_MODE1           TMOD&=0x0F;TMOD|=0x10
+#define    ENABLE_TIMER1_MODE2           TMOD&=0x0F;TMOD|=0x20
+#define    ENABLE_TIMER1_MODE3           TMOD&=0x0F;TMOD|=0x30
+#define    TIMER1_FSYS                   set_CKCON_T1M
+#define    TIMER1_FSYS_DIV12             clr_CKCON_T1M
+#define    TIMER1_MODE0_ENABLE           TMOD&=0x0F
+#define    TIMER1_MODE1_ENABLE           TMOD&=0x0F;TMOD|=0x10
+#define    TIMER1_MODE2_ENABLE           TMOD&=0x0F;TMOD|=0x20
+#define    TIMER1_MODE3_ENABLE           TMOD&=0x0F;TMOD|=0x30
+/*    Timer3 basic define  */
+#define    TIMER3_DIV_2                  T3CON&=0xF1;T3CON|=0x01
+#define    TIMER3_DIV_4                  T3CON&=0xF1;T3CON|=0x02
+#define    TIMER3_DIV_8                  T3CON&=0xF1;T3CON|=0x03
+#define    TIMER3_DIV_16                 T3CON&=0xF1;T3CON|=0x04
+#define    TIMER3_DIV_32                 T3CON&=0xF1;T3CON|=0x05
+#define    TIMER3_DIV_64                 T3CON&=0xF1;T3CON|=0x06
+#define    TIMER3_DIV_128                T3CON&=0xF1;T3CON|=0x07
+/*    Timer2 function define  */
+#define    TIMER2_DIV_4                  T2MOD|=0x10;T2MOD&=0x9F
+#define    TIMER2_DIV_16                 T2MOD|=0x20;T2MOD&=0xAF
+#define    TIMER2_DIV_32                 T2MOD|=0x30;T2MOD&=0xBF
+#define    TIMER2_DIV_64                 T2MOD|=0x40;T2MOD&=0xCF
+#define    TIMER2_DIV_128                T2MOD|=0x50;T2MOD&=0xDF
+#define    TIMER2_DIV_256                T2MOD|=0x60;T2MOD&=0xEF
+#define    TIMER2_DIV_512                T2MOD|=0x70
+#define    TIMER2_AUTO_RELOAD_DELAY_MODE T2CON&=0xFE;T2MOD|=0x80;T2MOD|=0x08
+#define    TIMER2_COMPARE_CAPTURE_MODE   T2CON|=0x01;T2MOD&=0x7F;T2MOD|=0x04
+#define    TIMER2_CAP0_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x89
+#define    TIMER2_CAP1_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8A
+#define    TIMER2_CAP2_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8B
+#define    DISABLE_TIMER2_CAP0           CAPCON0&=0xBF
+#define    DISABLE_TIMER2_CAP1           CAPCON0&=0xDF
+#define    DISABLE_TIMER2_CAP2           CAPCON0&=0xEF
+/*    Timer2 Capture define  */
+#define    IC0_P12_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON0|=0x20
+#define    IC2_P10_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x10;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x20;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x30;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x40;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x50;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x60;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x70;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x80;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+/*****************************************************************************/
+/*     For PWM setting                                                       */
+/*****************************************************************************/
+/*     PMW0 clock source select define    */
+#define    PWM0_CLOCK_FSYS                   CKCON&=0xBF
+#define    PWM0_CLOCK_TIMER1                 CKCON|=0x40
+/*     PWM type define    */
+#define    PWM0_EDGE_TYPE                    PWMCON1&=0xEF
+#define    PWM0_CENTER_TYPE                  PWMCON1|=0x10      
+/*      PWM mode define   */
+#define    PWM0_IMDEPENDENT_MODE             PWMCON1&=0x3F
+#define    PWM0_COMPLEMENTARY_MODE           PWMCON1&=0x3F;PWMCON1|=0x40 
+#define    PWM0_SYNCHRONIZED_MODE            PWMCON1&=0x3F;PWMCON1|=0x80 
+#define    PWM0_GP_MODE_ENABLE               PWMCON1|=0x20
+#define    PWM0_GP_MODE_DISABLE              PWMCON1&=0xDF
+/*      PWM0 clock devide define    */
+#define    PWM0_CLOCK_DIV_1                  PWMCON1&=0xF8;PWMCON1|=0x00
+#define    PWM0_CLOCK_DIV_2                  PWMCON1&=0xF8;PWMCON1|=0x01
+#define    PWM0_CLOCK_DIV_4                  PWMCON1&=0xF8;PWMCON1|=0x02
+#define    PWM0_CLOCK_DIV_8                  PWMCON1&=0xF8;PWMCON1|=0x03
+#define    PWM0_CLOCK_DIV_16                 PWMCON1&=0xF8;PWMCON1|=0x04
+#define    PWM0_CLOCK_DIV_32                 PWMCON1&=0xF8;PWMCON1|=0x05
+#define    PWM0_CLOCK_DIV_64                 PWMCON1&=0xF8;PWMCON1|=0x06
+#define    PWM0_CLOCK_DIV_128                PWMCON1&=0xF8;PWMCON1|=0x07
+/*      PWM0 I/O select define    */
+#define    ENABLE_PWM0_CH5_P15_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x20;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output enable 
+#define    ENABLE_PWM0_CH5_P03_OUTPUT        PIOCON0|=0x20                                                                                 //P0.3 as PWM5               
+#define    ENABLE_PWM0_CH4_P01_OUTPUT        PIOCON0|=0x10                                                                                 //P0.1 as PWM4 output enable 
+#define    ENABLE_PWM0_CH3_P04_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x08;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output enable 
+#define    ENABLE_PWM0_CH3_P00_OUTPUT        PIOCON0|=0x08                                                                                 //P0.0 as PWM3               
+#define    ENABLE_PWM0_CH2_P05_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x04;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output enable 
+#define    ENABLE_PWM0_CH2_P10_OUTPUT        PIOCON0|=0x04                                                                                 //P1.0 as PWM2               
+#define    ENABLE_PWM0_CH1_P14_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x02;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output enable 
+#define    ENABLE_PWM0_CH1_P11_OUTPUT        PIOCON0|=0x02                                                                                 //P1.1 as PWM1               
+#define    ENABLE_PWM0_CH0_P12_OUTPUT        PIOCON0|=0x01                                                                                 //P1.2 as PWM0 output enable 
+#define    ENABLE_ALL_PWM0_OUTPUT            PIOCON0=0xFF;PIOCON1=0xFF
+
+#define    DISABLE_PWM0_CH5_P15_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xDF;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output disable
+#define    DISABLE_PWM0_CH5_P03_OUTPUT       PIOCON0&=0xDF                                                                                 //P0.3 as PWM5               
+#define    DISABLE_PWM0_CH4_P01_OUTPUT       PIOCON0&=0xEF                                                                                 //P0.1 as PWM4 output disable
+#define    DISABLE_PWM0_CH3_P04_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xF7;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output disable
+#define    DISABLE_PWM0_CH3_P00_OUTPUT       PIOCON0&=0xF7                                                                                 //P0.0 as PWM3               
+#define    DISABLE_PWM0_CH2_P05_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFB;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output disable
+#define    DISABLE_PWM0_CH2_P10_OUTPUT       PIOCON0&=0xFB                                                                                 //P1.0 as PWM2               
+#define    DISABLE_PWM0_CH1_P14_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFD;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output disable
+#define    DISABLE_PWM0_CH1_P11_OUTPUT       PIOCON0&=0xFD                                                                                 //P1.1 as PWM1               
+#define    DISABLE_PWM0_CH0_P12_OUTPUT       PIOCON0&=0xFE                                                                                 //P1.2 as PWM0 output disable
+#define    DISABLE_ALL_PWM0_OUTPUT           PIOCON0=0x00;PIOCON1=0x00
+/*       PWM0 I/O Polarity Control     */
+#define    PWM0_CH5_OUTPUT_INVERSE           PNP|=0x20
+#define    PWM0_CH4_OUTPUT_INVERSE           PNP|=0x10
+#define    PWM0_CH3_OUTPUT_INVERSE           PNP|=0x08
+#define    PWM0_CH2_OUTPUT_INVERSE           PNP|=0x04
+#define    PWM0_CH1_OUTPUT_INVERSE           PNP|=0x02
+#define    PWM0_CH0_OUTPUT_INVERSE           PNP|=0x01
+#define    PWM0_OUTPUT_ALL_INVERSE           PNP|=0xFF
+#define    PWM0_CH5_OUTPUT_NORMAL            PNP&=0xDF
+#define    PWM0_CH4_OUTPUT_NORMAL            PNP&=0xEF
+#define    PWM0_CH3_OUTPUT_NORMAL            PNP&=0xF7
+#define    PWM0_CH2_OUTPUT_NORMAL            PNP&=0xFB
+#define    PWM0_CH1_OUTPUT_NORMAL            PNP&=0xFD
+#define    PWM0_CH0_OUTPUT_NORMAL            PNP&=0xFE
+#define    PWM0_OUTPUT_ALL_NORMAL            PNP&=0x00
+/*      PMW0 interrupt setting     */
+#define    PWM0_FALLING_INT                  ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_RISING_INT                   ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x10;ENABLE_SFR_PAGE0
+#define    PWM0_CENTRAL_POINT_INT            ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x20;ENABLE_SFR_PAGE0
+#define    PWM0_PERIOD_END_INT               ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x30;ENABLE_SFR_PAGE0
+/*      PWM0 interrupt pin select    */
+#define    PWM0_INT_PWM0                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM1                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x01;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM2                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x02;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM3                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x03;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM4                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x04;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM5                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x05;ENABLE_SFR_PAGE0
+/*      PWM0 Dead time setting     */
+#define    ENABLE_PWM0_CH45_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define    ENABLE_PWM0_CH23_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define    ENABLE_PWM0_CH01_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+
+/*****************************************************************************/
+/*     For ADC INIT setting                                                  */
+/*****************************************************************************/
+#define    ENABLE_ADC                        set_ADCCON1_ADCEN
+#define    DISABLE_ADC                       clr_ADCCON1_ADCEN
+
+#define    ENABLE_ADC_BANDGAP                DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x08;ADCCON0&=0xF8;ENABLE_ADC  
+#define    ENABLE_ADC_AIN0                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_AIN1                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_AIN2                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_AIN3                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_AIN4                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC    //P05
+#define    ENABLE_ADC_AIN5                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_AIN6                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_AIN7                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+
+#define    ENABLE_ADC_CH0                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_CH1                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_CH2                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_CH3                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_CH4                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC   //P05
+#define    ENABLE_ADC_CH5                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_CH6                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_CH7                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+/*      GPIO trig ADC start define*/
+#define    P04_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P13_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1|=0x40;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P04_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    P13_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xF7;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+/*      PWM trig ADC start define */ 
+#define    PWM0_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM2_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM4_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM2_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM4_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM2_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM4_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM2_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM4_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+#define    PWM0_CH0_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH2_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH4_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH0_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH2_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH4_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x06;ADCCON1|=0x02
+#define    PWM0_CH0_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH2_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH4_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH0_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH2_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH4_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+/*****************************************************************************/
+/*     For SPI INIT setting                                                  */
+/*****************************************************************************/
+#define    SPICLK_FSYS_DIV2                  SPCR&=0xFC
+#define    SPICLK_FSYS_DIV4                  SPCR&=0xFC;SPCR|=0x01
+#define    SPICLK_FSYS_DIV8                  SPCR&=0xFC;SPCR|=0x02
+#define    SPICLK_FSYS_DIV16                 SPCR&=0xFC;SPCR|=0x03
+#define    SS    P15
+/*****************************************************************************/
+/*     For UART0 and UART1 and printf funcion                                */
+/*****************************************************************************/
+#define    ENABLE_UART0_PRINTF                set_SCON_TI;PRINTFG=1            //For printf function must setting TI = 1
+#define    DISABLE_UART0_PRINTF               clr_SCON_TI;PRINTFG=0
+#define    ENABLE_UART1_PRINTF                set_SCON_1_TI_1;PRINTFG=1
+#define    DISABLE_UART1_PRINTF               clr_SCON_1_TI_1;PRINTFG=0
+/*****************************************************************************/
+/*     INT0 setting                                                          */
+/*****************************************************************************/
+#define    INT0_FALLING_EDGE_TRIG             set_TCON_IT0
+#define    INT0_LOW_LEVEL_TRIG                clr_TCON_IT0
+/*****************************************************************************/
+/*     INT1 setting                                                          */
+/*****************************************************************************/
+#define    INT1_FALLING_EDGE_TRIG             set_TCON_IT1
+#define    INT1_LOW_LEVEL_TRIG                clr_TCON_IT1
+
+/*****************************************************************************/
+/*     WDT setting                                                           */
+/*****************************************************************************/
+#define    WDT_TIMEOUT_6MS                    TA=0xAA;TA=0x55;WDCON&=0xF8
+#define    WDT_TIMEOUT_25MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x01
+#define    WDT_TIMEOUT_50MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x02
+#define    WDT_TIMEOUT_100MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x03
+#define    WDT_TIMEOUT_200MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x04
+#define    WDT_TIMEOUT_400MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x05
+#define    WDT_TIMEOUT_800MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x06
+#define    WDT_TIMEOUT_1_6S                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x07
+
+#define    WDT_RUN_IN_POWERDOWN_ENABLE        set_WDCON_WIDPD
+#define    WDT_RUN_IN_POWERDOWN_DISABLE       clr_WDCON_WIDPD
+#define    WDT_COUNTER_CLEAR                  set_WDCON_WDCLR
+#define    WDT_COUNTER_RUN                    set_WDCON_WDTR
+
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_iar.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_iar.h
@@ -1,0 +1,530 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  ms51_16k_iar.h                                                                  */
+/*  Header file of Nuvoton                                                              */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE                                       */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_ms51_16k.h"
+
+/*  BYTE Registers  */
+/*  SFR page 0      */
+__sfr __no_init volatile union
+{
+  unsigned char P0; /* Port 0 */
+  struct /* Port 0 */
+  { 
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P0_bit;
+} @ 0x80;
+__sfr __no_init volatile unsigned char  SP          @ 0x81;
+__sfr __no_init volatile unsigned char  DPL         @ 0x82;
+__sfr __no_init volatile unsigned char  DPH         @ 0x83;
+__sfr __no_init volatile unsigned char  RCTRIM0     @ 0x84;
+__sfr __no_init volatile unsigned char  RCTRIM1     @ 0x85;  
+__sfr __no_init volatile unsigned char  RWK         @ 0x86;
+__sfr __no_init volatile unsigned char  PCON        @ 0x87;
+
+__sfr __no_init volatile union
+{
+  unsigned char TCON; /* Timer Control */
+  struct /* Timer Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } TCON_bit;
+} @ 0x88;                            
+__sfr __no_init volatile unsigned char  TMOD        @ 0x89;
+__sfr __no_init volatile unsigned char  TL0         @ 0x8A;
+__sfr __no_init volatile unsigned char  TL1         @ 0x8B;
+__sfr __no_init volatile unsigned char  TH0         @ 0x8C;
+__sfr __no_init volatile unsigned char  TH1         @ 0x8D;
+__sfr __no_init volatile unsigned char  CKCON       @ 0x8E;
+__sfr __no_init volatile unsigned char  WKCON       @ 0x8F;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char P1; /* Port 1 */
+  struct /* Port 1 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } P1_bit;
+} @ 0x90;
+__sfr __no_init volatile unsigned char SFRS        @ 0x91; //TA Protection
+__sfr __no_init volatile unsigned char CAPCON0     @ 0x92;
+__sfr __no_init volatile unsigned char CAPCON1     @ 0x93;
+__sfr __no_init volatile unsigned char CAPCON2     @ 0x94;
+__sfr __no_init volatile unsigned char CKDIV       @ 0x95;
+__sfr __no_init volatile unsigned char CKSWT       @ 0x96; //TA Protection
+__sfr __no_init volatile unsigned char CKEN        @ 0x97; //TA Protection
+
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON; /* Serial Control */
+  struct /* Serial Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_bit;
+} @ 0x98;
+__sfr __no_init volatile unsigned char SBUF        @ 0x99;
+__sfr __no_init volatile unsigned char SBUF_1      @ 0x9A;
+__sfr __no_init volatile unsigned char EIE         @ 0x9B;
+__sfr __no_init volatile unsigned char EIE1        @ 0x9C;
+__sfr __no_init volatile unsigned char CHPCON      @ 0x9F; //TA Protection
+   
+__sfr __no_init volatile union
+{
+  unsigned char P2; /* Port 2 */
+  struct /* Port 2 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P2_bit;
+} @ 0xA0;
+__sfr __no_init volatile unsigned char AUXR1       @ 0xA2;
+__sfr __no_init volatile unsigned char BODCON0     @ 0xA3; //TA Protection
+__sfr __no_init volatile unsigned char IAPTRG      @ 0xA4; //TA Protection
+__sfr __no_init volatile unsigned char IAPUEN      @ 0xA5;  //TA Protection
+__sfr __no_init volatile unsigned char IAPAL       @ 0xA6;
+__sfr __no_init volatile unsigned char IAPAH       @ 0xA7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IE; /* Interrupt Enable */
+  struct /* Interrupt Enable */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IE_bit;
+} @ 0xA8;
+__sfr __no_init volatile unsigned char SADDR       @ 0xA9;
+__sfr __no_init volatile unsigned char WDCON       @ 0xAA; //TA Protection
+__sfr __no_init volatile unsigned char BODCON1     @ 0xAB; //TA Protection
+__sfr __no_init volatile unsigned char P3M1        @ 0xAC;
+__sfr __no_init volatile unsigned char P3S         @ 0xAC; //Page1
+__sfr __no_init volatile unsigned char P3M2        @ 0xAD;
+__sfr __no_init volatile unsigned char P3SR        @ 0xAD; //Page1
+__sfr __no_init volatile unsigned char IAPFD       @ 0xAE;
+__sfr __no_init volatile unsigned char IAPCN       @ 0xAF;
+
+__sfr __no_init volatile union
+{
+  unsigned char P3; /* Port 3 */
+  struct /* Port 3 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P3_bit;
+} @ 0xB0;
+__sfr __no_init volatile unsigned char P0M1        @ 0xB1;
+__sfr __no_init volatile unsigned char P0S         @ 0xB1; //Page1
+__sfr __no_init volatile unsigned char P0M2        @ 0xB2;
+__sfr __no_init volatile unsigned char P0SR        @ 0xB2; //Page1
+__sfr __no_init volatile unsigned char P1M1        @ 0xB3;
+__sfr __no_init volatile unsigned char P1S         @ 0xB3; //Page1
+__sfr __no_init volatile unsigned char P1M2        @ 0xB4;
+__sfr __no_init volatile unsigned char P1SR        @ 0xB4; //Page1
+__sfr __no_init volatile unsigned char P2S         @ 0xB5; 
+__sfr __no_init volatile unsigned char IPH         @ 0xB7;
+__sfr __no_init volatile unsigned char PWMINTC     @ 0xB7;  //Page1
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IP; /* IP  */
+  struct /* IP  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IP_bit;
+} @ 0xB8;
+__sfr __no_init volatile unsigned char SADEN       @ 0xB9;
+__sfr __no_init volatile unsigned char SADEN_1     @ 0xBA;
+__sfr __no_init volatile unsigned char SADDR_1     @ 0xBB;
+__sfr __no_init volatile unsigned char I2DAT       @ 0xBC;
+__sfr __no_init volatile unsigned char I2STAT      @ 0xBD;
+__sfr __no_init volatile unsigned char I2CLK       @ 0xBE;
+__sfr __no_init volatile unsigned char I2TOC       @ 0xBF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char I2CON; /* I2CON  */
+  struct /* I2CON  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } I2CON_bit;
+} @ 0xC0;
+__sfr __no_init volatile unsigned char I2ADDR      @ 0xC1;
+__sfr __no_init volatile unsigned char ADCRL       @ 0xC2;
+__sfr __no_init volatile unsigned char ADCRH       @ 0xC3;
+__sfr __no_init volatile unsigned char T3CON       @ 0xC4;
+__sfr __no_init volatile unsigned char PWM4H       @ 0xC4; //Page1
+__sfr __no_init volatile unsigned char RL3         @ 0xC5;
+__sfr __no_init volatile unsigned char PWM5H       @ 0xC5;  //Page1
+__sfr __no_init volatile unsigned char RH3         @ 0xC6;
+__sfr __no_init volatile unsigned char PIOCON1     @ 0xC6; //Page1
+__sfr __no_init volatile unsigned char TA          @ 0xC7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char T2CON; /* Timer 2 Control */
+  struct /* Timer 2 Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } T2CON_bit;
+} @ 0xC8;
+__sfr __no_init volatile unsigned char T2MOD       @ 0xC9;
+__sfr __no_init volatile unsigned char RCMP2L      @ 0xCA;
+__sfr __no_init volatile unsigned char RCMP2H      @ 0xCB;
+__sfr __no_init volatile unsigned char TL2         @ 0xCC; 
+__sfr __no_init volatile unsigned char PWM4L       @ 0xCC; //Page1
+__sfr __no_init volatile unsigned char TH2         @ 0xCD;
+__sfr __no_init volatile unsigned char PWM5L       @ 0xCD; //Page1
+__sfr __no_init volatile unsigned char ADCMPL      @ 0xCE;
+__sfr __no_init volatile unsigned char ADCMPH      @ 0xCF;
+
+__sfr __no_init volatile union
+{
+  unsigned char PSW; /* Program Status Word */
+  struct /* Program Status Word */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PSW_bit;
+} @ 0xD0;
+__sfr __no_init volatile unsigned char PWMPH        @ 0xD1;
+__sfr __no_init volatile unsigned char PWM0H        @ 0xD2;
+__sfr __no_init volatile unsigned char PWM1H        @ 0xD3;
+__sfr __no_init volatile unsigned char PWM2H        @ 0xD4;
+__sfr __no_init volatile unsigned char PWM3H        @ 0xD5;
+__sfr __no_init volatile unsigned char PNP          @ 0xD6;
+__sfr __no_init volatile unsigned char FBD          @ 0xD7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char PWMCON0; /* PWMCON0  */
+  struct /* PWMCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PWMCON0_bit;
+} @ 0xD8;
+__sfr __no_init volatile unsigned char PWMPL        @ 0xD9;
+__sfr __no_init volatile unsigned char PWM0L        @ 0xDA;
+__sfr __no_init volatile unsigned char PWM1L        @ 0xDB;
+__sfr __no_init volatile unsigned char PWM2L        @ 0xDC;
+__sfr __no_init volatile unsigned char PWM3L        @ 0xDD;
+__sfr __no_init volatile unsigned char PIOCON0      @ 0xDE;
+__sfr __no_init volatile unsigned char PWMCON1      @ 0xDF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ACC; /* Accumulator */
+  struct /* Accumulator */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } ACC_bit;
+} @ 0xE0;
+__sfr __no_init volatile unsigned char ADCCON1     @ 0xE1;
+__sfr __no_init volatile unsigned char ADCCON2     @ 0xE2;
+__sfr __no_init volatile unsigned char ADCDLY      @ 0xE3;
+__sfr __no_init volatile unsigned char C0L         @ 0xE4;
+__sfr __no_init volatile unsigned char C0H         @ 0xE5;
+__sfr __no_init volatile unsigned char C1L         @ 0xE6;
+__sfr __no_init volatile unsigned char C1H         @ 0xE7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ADCCON0; /* ADCCON0  */
+  struct /* ADCCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } ADCCON0_bit;
+} @ 0xE8;
+__sfr __no_init volatile unsigned char PICON       @ 0xE9;
+__sfr __no_init volatile unsigned char PINEN       @ 0xEA;
+__sfr __no_init volatile unsigned char PIPEN       @ 0xEB;
+__sfr __no_init volatile unsigned char PIF         @ 0xEC;
+__sfr __no_init volatile unsigned char C2L         @ 0xED;
+__sfr __no_init volatile unsigned char C2H         @ 0xEE;
+__sfr __no_init volatile unsigned char EIP         @ 0xEF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char B; /* B Register */
+  struct /* B Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } B_bit;
+} @ 0xF0;
+__sfr __no_init volatile unsigned char CAPCON3      @ 0xF1;
+__sfr __no_init volatile unsigned char CAPCON4      @ 0xF2;
+__sfr __no_init volatile unsigned char SPCR         @ 0xF3;
+__sfr __no_init volatile unsigned char SPCR2        @ 0xF3; //Page1
+__sfr __no_init volatile unsigned char SPSR         @ 0xF4;
+__sfr __no_init volatile unsigned char SPDR         @ 0xF5;
+__sfr __no_init volatile unsigned char AINDIDS      @ 0xF6;
+__sfr __no_init volatile unsigned char EIPH         @ 0xF7;
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON_1 ; /* SCON_1  Register */
+  struct /* SCON_1  Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_1_bit;
+} @ 0xF8;
+__sfr __no_init volatile unsigned char PDTEN       @ 0xF9; //TA Protection
+__sfr __no_init volatile unsigned char PDTCNT      @ 0xFA; //TA Protection
+__sfr __no_init volatile unsigned char PMEN        @ 0xFB;
+__sfr __no_init volatile unsigned char PMD         @ 0xFC;
+__sfr __no_init volatile unsigned char EIP1        @ 0xFE;
+__sfr __no_init volatile unsigned char EIPH1       @ 0xFF;
+
+/*  BIT Registers  */
+/*  BIT Registers  */
+/*  P0  */
+#define P07         P0_bit.BIT7
+#define P06         P0_bit.BIT6
+#define P05         P0_bit.BIT5
+#define P04         P0_bit.BIT4
+#define P03         P0_bit.BIT3
+#define P02         P0_bit.BIT2
+#define P01         P0_bit.BIT1
+#define P00         P0_bit.BIT0
+
+/*  TCON  */
+#define TF1         TCON_bit.BIT7
+#define TR1         TCON_bit.BIT6
+#define TF0         TCON_bit.BIT5
+#define TR0         TCON_bit.BIT4
+#define IE1         TCON_bit.BIT3
+#define IT1         TCON_bit.BIT2
+#define IE0         TCON_bit.BIT1
+#define IT0         TCON_bit.BIT0
+                    
+/*  P1  */
+#define P17         P1_bit.BIT7
+#define P16         P1_bit.BIT6
+#define P15         P1_bit.BIT5
+#define P14         P1_bit.BIT4
+#define P13         P1_bit.BIT3
+#define P12         P1_bit.BIT2
+#define P11         P1_bit.BIT1
+#define P10         P1_bit.BIT0
+
+/*  SCON  */
+#define SM0         SCON_bit.BIT7 
+#define FE          SCON_bit.BIT7 
+#define SM1         SCON_bit.BIT6 
+#define SM2         SCON_bit.BIT5 
+#define REN         SCON_bit.BIT4 
+#define TB8         SCON_bit.BIT3 
+#define RB8         SCON_bit.BIT2 
+#define TI          SCON_bit.BIT1 
+#define RI          SCON_bit.BIT0 
+
+/*  P2  */ 
+#define P20         P2_bit.BIT0
+
+/*  IE  */
+#define EA          IE_bit.BIT7
+#define EADC        IE_bit.BIT6
+#define EBOD        IE_bit.BIT5
+#define ES          IE_bit.BIT4
+#define ET1         IE_bit.BIT3
+#define EX1         IE_bit.BIT2
+#define ET0         IE_bit.BIT1
+#define EX0         IE_bit.BIT0
+
+/*  P3  */  
+#define P30	    P3_bit.BIT0
+
+/*  IP  */
+#define PADC        IP_bit.BIT6
+#define PBOD        IP_bit.BIT5
+#define PS          IP_bit.BIT4
+#define PT1         IP_bit.BIT3
+#define PX1         IP_bit.BIT2
+#define PT0         IP_bit.BIT1
+#define PX0         IP_bit.BIT0
+
+/*  I2CON  */
+#define I2CEN       I2CON_bit.BIT6
+#define STA         I2CON_bit.BIT5
+#define STO         I2CON_bit.BIT4
+#define SI          I2CON_bit.BIT3
+#define AA          I2CON_bit.BIT2
+#define I2CPX	    I2CON_bit.BIT0
+
+/*  T2CON  */
+#define TF2         T2CON_bit.BIT7
+#define TR2         T2CON_bit.BIT2
+#define CM_RL2      T2CON_bit.BIT0
+
+/*  PSW */
+#define CY          PSW.BIT7
+#define AC          PSW.BIT6
+#define F0          PSW.BIT5
+#define RS1         PSW.BIT4
+#define RS0         PSW.BIT3
+#define OV          PSW.BIT2
+#define P           PSW.BIT0
+
+/*  PWMCON0  */
+#define PWMRUN      PWMCON0_bit.BIT7
+#define LOAD        PWMCON0_bit.BIT6
+#define PWMF        PWMCON0_bit.BIT5
+#define CLRPWM      PWMCON0_bit.BIT4
+
+/*  ADCCON0  */
+#define ADCF        ADCCON0_bit.BIT7
+#define ADCS        ADCCON0_bit.BIT6
+#define ETGSEL1     ADCCON0_bit.BIT5
+#define ETGSEL0     ADCCON0_bit.BIT4
+#define ADCHS3      ADCCON0_bit.BIT3
+#define ADCHS2      ADCCON0_bit.BIT2
+#define ADCHS1      ADCCON0_bit.BIT1
+#define ADCHS0      ADCCON0_bit.BIT0
+
+/*  SCON_1  */
+#define SM0_1       SCON_1_bit.BIT7
+#define FE_1        SCON_1_bit.BIT7 
+#define SM1_1       SCON_1_bit.BIT6 
+#define SM2_1       SCON_1_bit.BIT5 
+#define REN_1       SCON_1_bit.BIT4 
+#define TB8_1       SCON_1_bit.BIT3 
+#define RB8_1       SCON_1_bit.BIT2 
+#define TI_1        SCON_1_bit.BIT1 
+#define RI_1        SCON_1_bit.BIT0
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_keil.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_keil.h
@@ -1,0 +1,305 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  ms51_16k_keil.h                                                                 */
+/*  Header file of Nuvoton                                                              */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE                                       */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_ms51_16k.h"
+
+
+sfr P0          = 0x80;
+sfr SP          = 0x81;
+sfr DPL         = 0x82;
+sfr DPH         = 0x83;
+sfr RCTRIM0     = 0x84;
+sfr RCTRIM1     = 0x85;  
+sfr RWK         = 0x86;
+sfr PCON        = 0x87;
+
+sfr TCON        = 0x88;
+sfr TMOD        = 0x89;
+sfr TL0         = 0x8A;
+sfr TL1         = 0x8B;
+sfr TH0         = 0x8C;
+sfr TH1         = 0x8D;
+sfr CKCON       = 0x8E;
+sfr WKCON       = 0x8F;
+
+sfr P1          = 0x90;
+sfr SFRS        = 0x91; //TA Protection
+sfr CAPCON0     = 0x92;
+sfr CAPCON1     = 0x93;
+sfr CAPCON2     = 0x94;
+sfr CKDIV       = 0x95;
+sfr CKSWT       = 0x96; //TA Protection
+sfr CKEN        = 0x97; //TA Protection
+
+sfr SCON        = 0x98;
+sfr SBUF        = 0x99;
+sfr SBUF_1      = 0x9A;
+sfr EIE         = 0x9B;
+sfr EIE1        = 0x9C;
+sfr CHPCON      = 0x9F; //TA Protection
+
+sfr P2          = 0xA0;
+sfr AUXR1       = 0xA2;
+sfr BODCON0     = 0xA3; //TA Protection
+sfr IAPTRG      = 0xA4; //TA Protection
+sfr IAPUEN      = 0xA5;  //TA Protection
+sfr IAPAL       = 0xA6;
+sfr IAPAH       = 0xA7;
+
+sfr IE          = 0xA8;
+sfr SADDR       = 0xA9;
+sfr WDCON       = 0xAA; //TA Protection
+sfr BODCON1     = 0xAB; //TA Protection
+sfr P3M1        = 0xAC;
+sfr P3S         = 0xAC; //Page1
+sfr P3M2        = 0xAD;
+sfr P3SR        = 0xAD; //Page1
+sfr IAPFD       = 0xAE;
+sfr IAPCN       = 0xAF;
+
+sfr P3          = 0xB0;
+sfr P0M1        = 0xB1;
+sfr P0S         = 0xB1; //Page1
+sfr P0M2        = 0xB2;
+sfr P0SR        = 0xB2; //Page1
+sfr P1M1        = 0xB3;
+sfr P1S         = 0xB3; //Page1
+sfr P1M2        = 0xB4;
+sfr P1SR        = 0xB4; //Page1
+sfr P2S         = 0xB5; 
+sfr IPH         = 0xB7;
+sfr PWMINTC     = 0xB7; //Page1
+
+sfr IP          = 0xB8;
+sfr SADEN       = 0xB9;
+sfr SADEN_1     = 0xBA;
+sfr SADDR_1     = 0xBB;
+sfr I2DAT       = 0xBC;
+sfr I2STAT      = 0xBD;
+sfr I2CLK       = 0xBE;
+sfr I2TOC       = 0xBF;
+
+sfr I2CON       = 0xC0;
+sfr I2ADDR      = 0xC1;
+sfr ADCRL       = 0xC2;
+sfr ADCRH       = 0xC3;
+sfr T3CON       = 0xC4;
+sfr PWM4H       = 0xC4; //Page1
+sfr RL3         = 0xC5;
+sfr PWM5H       = 0xC5; //Page1
+sfr RH3         = 0xC6;
+sfr PIOCON1     = 0xC6; //Page1
+sfr TA          = 0xC7;
+
+sfr T2CON       = 0xC8;
+sfr T2MOD       = 0xC9;
+sfr RCMP2L      = 0xCA;
+sfr RCMP2H      = 0xCB;
+sfr TL2         = 0xCC; 
+sfr PWM4L       = 0xCC; //Page1
+sfr TH2         = 0xCD;
+sfr PWM5L       = 0xCD; //Page1
+sfr ADCMPL      = 0xCE;
+sfr ADCMPH      = 0xCF;
+
+sfr PSW         = 0xD0;
+sfr PWMPH       = 0xD1;
+sfr PWM0H       = 0xD2;
+sfr PWM1H       = 0xD3;
+sfr PWM2H       = 0xD4;
+sfr PWM3H       = 0xD5;
+sfr PNP         = 0xD6;
+sfr FBD         = 0xD7;
+
+sfr PWMCON0     = 0xD8;
+sfr PWMPL       = 0xD9;
+sfr PWM0L       = 0xDA;
+sfr PWM1L       = 0xDB;
+sfr PWM2L       = 0xDC;
+sfr PWM3L       = 0xDD;
+sfr PIOCON0     = 0xDE;
+sfr PWMCON1     = 0xDF;
+
+sfr ACC         = 0xE0;
+sfr ADCCON1     = 0xE1;
+sfr ADCCON2     = 0xE2;
+sfr ADCDLY      = 0xE3;
+sfr C0L         = 0xE4;
+sfr C0H         = 0xE5;
+sfr C1L         = 0xE6;
+sfr C1H         = 0xE7;
+
+sfr ADCCON0     = 0xE8;
+sfr PICON       = 0xE9;
+sfr PINEN       = 0xEA;
+sfr PIPEN       = 0xEB;
+sfr PIF         = 0xEC;
+sfr C2L         = 0xED;
+sfr C2H         = 0xEE;
+sfr EIP         = 0xEF;
+
+sfr B           = 0xF0;
+sfr CAPCON3     = 0xF1;
+sfr CAPCON4     = 0xF2;
+sfr SPCR        = 0xF3;
+sfr SPCR2       = 0xF3; //Page1
+sfr SPSR        = 0xF4;
+sfr SPDR        = 0xF5;
+sfr AINDIDS     = 0xF6;
+sfr EIPH        = 0xF7;
+
+sfr SCON_1      = 0xF8;
+sfr PDTEN       = 0xF9; //TA Protection
+sfr PDTCNT      = 0xFA; //TA Protection
+sfr PMEN        = 0xFB;
+sfr PMD         = 0xFC;
+sfr EIP1        = 0xFE;
+sfr EIPH1       = 0xFF;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+sbit SM0_1      = SCON_1^7;
+sbit FE_1       = SCON_1^7; 
+sbit SM1_1      = SCON_1^6; 
+sbit SM2_1      = SCON_1^5; 
+sbit REN_1      = SCON_1^4; 
+sbit TB8_1      = SCON_1^3; 
+sbit RB8_1      = SCON_1^2; 
+sbit TI_1       = SCON_1^1; 
+sbit RI_1       = SCON_1^0; 
+
+/*  ADCCON0  */
+sbit ADCF       = ADCCON0^7;
+sbit ADCS       = ADCCON0^6;
+sbit ETGSEL1    = ADCCON0^5;
+sbit ETGSEL0    = ADCCON0^4;
+sbit ADCHS3     = ADCCON0^3;
+sbit ADCHS2     = ADCCON0^2;
+sbit ADCHS1     = ADCCON0^1;
+sbit ADCHS0     = ADCCON0^0;
+
+/*  PWMCON0  */
+sbit PWMRUN     = PWMCON0^7;
+sbit LOAD       = PWMCON0^6;
+sbit PWMF       = PWMCON0^5;
+sbit CLRPWM     = PWMCON0^4;
+
+
+/*  PSW */
+sbit CY         = PSW^7;
+sbit AC         = PSW^6;
+sbit F0         = PSW^5;
+sbit RS1        = PSW^4;
+sbit RS0        = PSW^3;
+sbit OV         = PSW^2;
+sbit P          = PSW^0;
+
+/*  T2CON  */
+sbit TF2        = T2CON^7;
+sbit TR2        = T2CON^2;
+sbit CM_RL2     = T2CON^0;
+ 
+/*  I2CON  */
+sbit I2CEN      = I2CON^6;
+sbit STA        = I2CON^5;
+sbit STO        = I2CON^4;
+sbit SI         = I2CON^3;
+sbit AA         = I2CON^2;
+sbit I2CPX      = I2CON^0;
+
+/*  IP  */  
+sbit PADC       = IP^6;
+sbit PBOD       = IP^5;
+sbit PS         = IP^4;
+sbit PT1        = IP^3;
+sbit PX1        = IP^2;
+sbit PT0        = IP^1;
+sbit PX0        = IP^0;
+
+/*  P3  */  
+sbit P30        = P3^0;
+
+
+/*  IE  */
+sbit EA         = IE^7;
+sbit EADC       = IE^6;
+sbit EBOD       = IE^5;
+sbit ES         = IE^4;
+sbit ET1        = IE^3;
+sbit EX1        = IE^2;
+sbit ET0        = IE^1;
+sbit EX0        = IE^0;
+
+/*  P2  */ 
+sbit P20        = P2^0;
+
+/*  SCON  */
+sbit SM0        = SCON^7;
+sbit FE         = SCON^7; 
+sbit SM1        = SCON^6; 
+sbit SM2        = SCON^5; 
+sbit REN        = SCON^4; 
+sbit TB8        = SCON^3; 
+sbit RB8        = SCON^2; 
+sbit TI         = SCON^1; 
+sbit RI         = SCON^0; 
+
+/*  P1  */     
+sbit P17        = P1^7;
+sbit P16        = P1^6;
+sbit TXD_1      = P1^6; 
+sbit P15        = P1^5;
+sbit P14        = P1^4;
+sbit SDA        = P1^4;    
+sbit P13        = P1^3;
+sbit SCL        = P1^3;  
+sbit P12        = P1^2; 
+sbit P11        = P1^1;
+sbit P10        = P1^0;
+
+/*  TCON  */
+sbit TF1        = TCON^7;
+sbit TR1        = TCON^6;
+sbit TF0        = TCON^5;
+sbit TR0        = TCON^4;
+sbit IE1        = TCON^3;
+sbit IT1        = TCON^2;
+sbit IE0        = TCON^1;
+sbit IT0        = TCON^0;
+
+/*  P0  */  
+
+sbit P07        = P0^7;
+sbit RXD        = P0^7;
+sbit P06        = P0^6;
+sbit TXD        = P0^6;
+sbit P05        = P0^5;
+sbit P04        = P0^4;
+sbit STADC      = P0^4;
+sbit P03        = P0^3;
+sbit P02        = P0^2;
+sbit RXD_1      = P0^2;
+sbit P01        = P0^1;
+sbit MISO       = P0^1;
+sbit P00        = P0^0;
+sbit MOSI       = P0^0;
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_sdcc.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_sdcc.h
@@ -163,6 +163,7 @@ __sfr  __at  (0xF9) PDTEN     ; //TA Protection
 __sfr  __at  (0xFA) PDTCNT    ; //TA Protection
 __sfr  __at  (0xFB) PMEN      ;
 __sfr  __at  (0xFC) PMD       ;
+__sfr  __at  (0xFD) PORDIS    ; //TA Protection
 __sfr  __at  (0xFE) EIP1      ;
 __sfr  __at  (0xFF) EIPH1     ;
 

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_sdcc.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/ms51_16k_sdcc.h
@@ -1,0 +1,295 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  ms51_16k_sdcc.h                                                                 */
+/*  Header file of Nuvoton                                                              */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE                                       */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_ms51_16k.h"
+
+/******************************************************************************/
+/*                         Macro define header files                          */
+/******************************************************************************/
+__sfr __at   (0x80) P0        ;
+__sfr __at   (0x81) SP        ;
+__sfr __at   (0x82) DPL       ;
+__sfr __at   (0x83) DPH       ;
+__sfr __at   (0x84) RCTRIM0   ;
+__sfr __at   (0x85) RCTRIM1   ;
+__sfr __at   (0x86) RWK       ;
+__sfr __at   (0x87) PCON      ;
+
+__sfr  __at  (0x88)TCON       ;
+__sfr  __at  (0x89)TMOD       ;
+__sfr  __at  (0x8A)TL0        ;
+__sfr  __at  (0x8B)TL1        ;
+__sfr  __at  (0x8C)TH0        ;
+__sfr  __at  (0x8D)TH1        ;
+__sfr  __at  (0x8E)CKCON      ;
+__sfr  __at  (0x8F)WKCON      ;
+
+__sfr  __at  (0x90)P1         ;
+__sfr  __at  (0x91)SFRS       ; //TA Protection
+__sfr  __at  (0x92)CAPCON0    ;
+__sfr  __at  (0x93)CAPCON1    ;
+__sfr  __at  (0x94)CAPCON2    ;
+__sfr  __at  (0x95)CKDIV      ;
+__sfr  __at  (0x96)CKSWT      ; //TA Protection
+__sfr  __at  (0x97)CKEN       ; //TA Protection
+
+__sfr  __at  (0x98) SCON      ;
+__sfr  __at  (0x99) SBUF      ;
+__sfr  __at  (0x9A) SBUF_1    ;
+__sfr  __at  (0x9B) EIE       ;
+__sfr  __at  (0x9C) EIE1      ;
+__sfr  __at  (0x9F) CHPCON    ; //TA Protection
+
+__sfr  __at  (0xA0) P2        ;
+__sfr  __at  (0xA2) AUXR1     ;
+__sfr  __at  (0xA3) BODCON0   ; //TA Protection
+__sfr  __at  (0xA4) IAPTRG    ; //TA Protection
+__sfr  __at  (0xA5) IAPUEN    ; //TA Protection
+__sfr  __at  (0xA6) IAPAL     ;
+__sfr  __at  (0xA7) IAPAH     ;
+
+__sfr  __at  (0xA8) IE        ;
+__sfr  __at  (0xA9) SADDR     ;
+__sfr  __at  (0xAA) WDCON     ; //TA Protection
+__sfr  __at  (0xAB) BODCON1   ; //TA Protection
+__sfr  __at  (0xAC) P3M1      ;
+__sfr  __at  (0xAC) P3S       ; //Page1
+__sfr  __at  (0xAD) P3M2      ;
+__sfr  __at  (0xAD) P3SR      ; //Page1
+__sfr  __at  (0xAE) IAPFD     ;
+__sfr  __at  (0xAF) IAPCN     ;
+
+__sfr  __at  (0xB0) P3        ;
+__sfr  __at  (0xB1) P0M1      ;
+__sfr  __at  (0xB1) P0S       ; //Page1
+__sfr  __at  (0xB2) P0M2      ;
+__sfr  __at  (0xB2) P0SR      ; //Page1
+__sfr  __at  (0xB3) P1M1      ;
+__sfr  __at  (0xB3) P1S       ; //Page1
+__sfr  __at  (0xB4) P1M2      ;
+__sfr  __at  (0xB4) P1SR      ; //Page1
+__sfr  __at  (0xB5) P2S       ; 
+__sfr  __at  (0xB7) IPH       ;
+__sfr  __at  (0xB7) PWMINTC   ;  //Page1
+
+__sfr  __at  (0xB8) IP        ;
+__sfr  __at  (0xB9) SADEN     ;
+__sfr  __at  (0xBA) SADEN_1   ;
+__sfr  __at  (0xBB) SADDR_1   ;
+__sfr  __at  (0xBC) I2DAT     ;
+__sfr  __at  (0xBD) I2STAT    ;
+__sfr  __at  (0xBE) I2CLK     ;
+__sfr  __at  (0xBF) I2TOC     ;
+
+__sfr  __at  (0xC0) I2CON     ;
+__sfr  __at  (0xC1) I2ADDR    ;
+__sfr  __at  (0xC2) ADCRL     ;
+__sfr  __at  (0xC3) ADCRH     ;
+__sfr  __at  (0xC4) T3CON     ;
+__sfr  __at  (0xC4) PWM4H     ; //Page1
+__sfr  __at  (0xC5) RL3       ;
+__sfr  __at  (0xC5) PWM5H     ;  //Page1
+__sfr  __at  (0xC6) RH3       ;
+__sfr  __at  (0xC6) PIOCON1   ; //Page1
+__sfr  __at  (0xC7) TA        ;
+
+__sfr  __at  (0xC8) T2CON     ;
+__sfr  __at  (0xC9) T2MOD     ;
+__sfr  __at  (0xCA) RCMP2L    ;
+__sfr  __at  (0xCB) RCMP2H    ;
+__sfr  __at  (0xCC) TL2       ; 
+__sfr  __at  (0xCC) PWM4L     ; //Page1
+__sfr  __at  (0xCD) TH2       ;
+__sfr  __at  (0xCD) PWM5L     ; //Page1
+__sfr  __at  (0xCE) ADCMPL    ;
+__sfr  __at  (0xCF) ADCMPH    ;
+
+__sfr  __at  (0xD0) PSW       ;
+__sfr  __at  (0xD1) PWMPH     ;
+__sfr  __at  (0xD2) PWM0H     ;
+__sfr  __at  (0xD3) PWM1H     ;
+__sfr  __at  (0xD4) PWM2H     ;
+__sfr  __at  (0xD5) PWM3H     ;
+__sfr  __at  (0xD6) PNP       ;
+__sfr  __at  (0xD7) FBD       ;
+
+__sfr  __at  (0xD8) PWMCON0   ;
+__sfr  __at  (0xD9) PWMPL     ;
+__sfr  __at  (0xDA) PWM0L     ;
+__sfr  __at  (0xDB) PWM1L     ;
+__sfr  __at  (0xDC) PWM2L     ;
+__sfr  __at  (0xDD) PWM3L     ;
+__sfr  __at  (0xDE) PIOCON0   ;
+__sfr  __at  (0xDF) PWMCON1   ;
+
+__sfr  __at  (0xE0) ACC       ;
+__sfr  __at  (0xE1) ADCCON1   ;
+__sfr  __at  (0xE2) ADCCON2   ;
+__sfr  __at  (0xE3) ADCDLY    ;
+__sfr  __at  (0xE4) C0L       ;
+__sfr  __at  (0xE5) C0H       ;
+__sfr  __at  (0xE6) C1L       ;
+__sfr  __at  (0xE7) C1H       ;
+
+__sfr  __at  (0xE8) ADCCON0   ;
+__sfr  __at  (0xE9) PICON     ;
+__sfr  __at  (0xEA) PINEN     ;
+__sfr  __at  (0xEB) PIPEN     ;
+__sfr  __at  (0xEC) PIF       ;
+__sfr  __at  (0xED) C2L       ;
+__sfr  __at  (0xEE) C2H       ;
+__sfr  __at  (0xEF) EIP       ;
+
+__sfr  __at  (0xF0) B         ;
+__sfr  __at  (0xF1) CAPCON3   ;
+__sfr  __at  (0xF2) CAPCON4   ;
+__sfr  __at  (0xF3) SPCR      ;
+__sfr  __at  (0xF3) SPCR2     ; //Page1
+__sfr  __at  (0xF4) SPSR      ;
+__sfr  __at  (0xF5) SPDR      ;
+__sfr  __at  (0xF6) AINDIDS   ;
+__sfr  __at  (0xF7) EIPH      ;
+
+__sfr  __at  (0xF8) SCON_1    ;
+__sfr  __at  (0xF9) PDTEN     ; //TA Protection
+__sfr  __at  (0xFA) PDTCNT    ; //TA Protection
+__sfr  __at  (0xFB) PMEN      ;
+__sfr  __at  (0xFC) PMD       ;
+__sfr  __at  (0xFE) EIP1      ;
+__sfr  __at  (0xFF) EIPH1     ;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+__sbit  __at (0xF8+7) SM0_1   ; //SCON_1^7;
+__sbit  __at (0xF8+7) FE_1    ; //SCON_1^7
+__sbit  __at (0xF8+6) SM1_1   ; //SCON_1^6
+__sbit  __at (0xF8+5) SM2_1   ; //SCON_1^5
+__sbit  __at (0xF8+4) REN_1   ; //SCON_1^4
+__sbit  __at (0xF8+3) TB8_1   ; //SCON_1^3
+__sbit  __at (0xF8+2) RB8_1   ; //SCON_1^2
+__sbit  __at (0xF8+1) TI_1    ; //SCON_1^1
+__sbit  __at (0xF8+0) RI_1    ; //SCON_1^0
+
+/*  ADCCON0  */
+__sbit  __at (0xE8+7) ADCF    ; //ADCCON0^7
+__sbit  __at (0xE8+6) ADCS    ; //ADCCON0^6
+__sbit  __at (0xE8+5) ETGSEL1 ; //ADCCON0^5
+__sbit  __at (0xE8+4) ETGSEL0 ; //ADCCON0^4
+__sbit  __at (0xE8+3) ADCHS3  ; //ADCCON0^3
+__sbit  __at (0xE8+2) ADCHS2  ; //ADCCON0^2
+__sbit  __at (0xE8+1) ADCHS1  ; //ADCCON0^1
+__sbit  __at (0xE8+0) ADCHS0  ; //ADCCON0^0
+
+/*  PWMCON0  */
+__sbit  __at (0xD8+7) PWMRUN  ; //PWMCON0^7
+__sbit  __at (0xD8+6) LOAD    ; //PWMCON0^6
+__sbit  __at (0xD8+5) PWMF    ; //PWMCON0^5
+__sbit  __at (0xD8+4) CLRPWM  ; //PWMCON0^4
+
+
+/*  PSW */
+__sbit  __at (0xD0+7) CY       ; //PSW^7
+__sbit  __at (0xD0+6) AC       ; //PSW^6
+__sbit  __at (0xD0+5) F0       ; //PSW^5
+__sbit  __at (0xD0+4) RS1      ; //PSW^4
+__sbit  __at (0xD0+3) RS0      ; //PSW^3
+__sbit  __at (0xD0+2) OV       ; //PSW^2
+__sbit  __at (0xD0+0) P        ; //PSW^0
+
+/*  T2CON  */
+__sbit  __at (0xC8+7) TF2      ; //T2CON^7
+__sbit  __at (0xC8+2) TR2      ; //T2CON^2
+__sbit  __at (0xC8+0) CM_RL2   ; //T2CON^0
+ 
+/*  I2CON  */
+__sbit  __at (0xC0+6) I2CEN    ; //I2CON^6
+__sbit  __at (0xC0+5) STA      ; //I2CON^5
+__sbit  __at (0xC0+4) STO      ; //I2CON^4
+__sbit  __at (0xC0+3) SI       ; //I2CON^3
+__sbit  __at (0xC0+2) AA       ; //I2CON^2
+__sbit  __at (0xC0+0) I2CPX    ; //I2CON^0
+
+/*  IP  */  
+__sbit  __at (0xB8+6) PADC     ; //IP^6
+__sbit  __at (0xB8+5) PBOD     ; //IP^5
+__sbit  __at (0xB8+4) PS       ; //IP^4
+__sbit  __at (0xB8+3) PT1      ; //IP^3
+__sbit  __at (0xB8+2) PX1      ; //IP^2
+__sbit  __at (0xB8+1) PT0      ; //IP^1
+__sbit  __at (0xB8+0) PX0      ; //IP^0
+
+/*  P3  */  
+__sbit  __at (0xB0+0) P30      ; //P3^0
+
+
+/*  IE  */
+__sbit  __at (0xA8+7) EA       ; //IE^7
+__sbit  __at (0xA8+6) EADC     ; //IE^6
+__sbit  __at (0xA8+5) EBOD     ; //IE^5
+__sbit  __at (0xA8+4) ES       ; //IE^4
+__sbit  __at (0xA8+3) ET1      ; //IE^3
+__sbit  __at (0xA8+2) EX1      ; //IE^2
+__sbit  __at (0xA8+1) ET0      ; //IE^1
+__sbit  __at (0xA8+0) EX0      ; //IE^0
+
+/*  P2  */ 
+__sbit  __at (0xA0+0) P20      ; //P2^0
+
+/*  SCON  */
+__sbit  __at (0x98+7) SM0      ; //SCON^7
+__sbit  __at (0x98+7) FE       ; //SCON^7
+__sbit  __at (0x98+6) SM1      ; //SCON^6
+__sbit  __at (0x98+5) SM2      ; //SCON^5
+__sbit  __at (0x98+4) REN      ; //SCON^4
+__sbit  __at (0x98+3) TB8      ; //SCON^3
+__sbit  __at (0x98+2) RB8      ; //SCON^2
+__sbit  __at (0x98+1) TI       ; //SCON^1
+__sbit  __at (0x98+0) RI       ; //SCON^0
+
+/*  P1  */     
+__sbit  __at (0x90+7) P17      ; //P1^7
+__sbit  __at (0x90+6) P16      ; //P1^6
+__sbit  __at (0x90+6) TXD_1    ; //P1^6
+__sbit  __at (0x90+5) P15      ; //P1^5
+__sbit  __at (0x90+4) P14      ; //P1^4
+__sbit  __at (0x90+4) SDA      ; //P1^4
+__sbit  __at (0x90+3) P13      ; //P1^3
+__sbit  __at (0x90+3) SCL      ; //P1^3
+__sbit  __at (0x90+2) P12      ; //P1^2
+__sbit  __at (0x90+1) P11      ; //P1^1
+__sbit  __at (0x90+0) P10      ; //P1^0
+
+/*  TCON  */
+__sbit  __at (0x88+7) TF1      ; //TCON^7
+__sbit  __at (0x88+6) TR1      ; //TCON^6
+__sbit  __at (0x88+5) TF0      ; //TCON^5
+__sbit  __at (0x88+4) TR0      ; //TCON^4
+__sbit  __at (0x88+3) IE1      ; //TCON^3
+__sbit  __at (0x88+2) IT1      ; //TCON^2
+__sbit  __at (0x88+1) IE0      ; //TCON^1
+__sbit  __at (0x88+0) IT0      ; //TCON^0
+
+/*  P0  */  
+__sbit  __at (0x80+7) P07      ; //P0^7
+__sbit  __at (0x80+7) RXD      ; //P0^7
+__sbit  __at (0x80+6) P06      ; //P0^6
+__sbit  __at (0x80+6) TXD      ; //P0^6
+__sbit  __at (0x80+5) P05      ; //P0^5
+__sbit  __at (0x80+4) P04      ; //P0^4
+__sbit  __at (0x80+4) STADC    ; //P0^4
+__sbit  __at (0x80+3) P03      ; //P0^3
+__sbit  __at (0x80+2) P02      ; //P0^2
+__sbit  __at (0x80+2) RXD_1    ; //P0^2
+__sbit  __at (0x80+1) P01      ; //P0^1
+__sbit  __at (0x80+1) MISO     ; //P0^1
+__sbit  __at (0x80+0) P00      ; //P0^0
+__sbit  __at (0x80+0) MOSI     ; //P0^0
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/numicro_8051.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/numicro_8051.h
@@ -1,0 +1,14 @@
+
+/* for Keil */
+#if defined __C51__
+#include "ms51_16k_keil.h"
+
+/* for IAR */
+#elif defined __ICC8051__
+#include "ms51_16k_iar.h"
+
+/* for SDCC */
+#elif defined __SDCC__
+#include "ms51_16k_sdcc.h"
+
+#endif

--- a/hardware/victims/firmware/numicro8051/inc/MS5116K/sfr_macro_ms51_16k.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5116K/sfr_macro_ms51_16k.h
@@ -1,0 +1,2268 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  sfr_macro_ms51_16k.h                                                                */
+/*  SFR Macro define for Nuvoton                                                        */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE /                                     */
+/*--------------------------------------------------------------------------------------*/
+#if defined __C51__
+#include <stdio.h>
+#include <string.h>
+#include <absacc.h>
+#include <intrins.h>
+
+#elif defined __ICC8051__
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+
+#elif defined __SDCC__
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <float.h>
+
+#endif
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "function_define_ms51_16k.h"
+
+#ifdef INC_STD_DRIVER
+#include "adc.h"
+#include "bod.h"
+#include "capture.h"
+#include "common.h"
+#include "delay.h"
+#include "eeprom_sprom.h"
+#include "eeprom.h"
+#include "i2c.h"
+#include "iap_sprom.h"
+#include "iap.h"
+#include "isr.h"
+#include "pwm.h"
+#include "spi.h"
+#include "sys.h"
+#include "timer.h"
+#include "uart.h"
+#include "wdt.h"
+#include "wkt.h"
+#endif
+/********************************************************************/
+/*  <Macro define                                                   */
+/********************************************************************/
+
+/**** SP   81H ****/
+/**** DPH  82H ****/
+/**** DPL  83H ****/
+/**** RWK  86H ****/
+
+/**** PCON  87H ****/
+#define set_PCON_SMOD            PCON|=0x80
+#define set_PCON_SMOD0           PCON|=0x40
+#define set_PCON_POF             PCON|=0x10
+#define set_PCON_GF1             PCON|=0x08
+#define set_PCON_GF0             PCON|=0x04 
+#define set_PCON_PD              PCON|=0x02
+#define set_PCON_IDLE            PCON|=0x01
+                                    
+#define clr_PCON_SMOD            PCON&=0x7F
+#define clr_PCON_SMOD0           PCON&=0xBF
+#define clr_PCON_POF             PCON&=0xEF
+#define clr_PCON_GF1             PCON&=0xF7
+#define clr_PCON_GF0             PCON&=0xFB 
+#define clr_PCON_PD              PCON&=0xFD
+#define clr_PCON_IDLE            PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TCON_TF1             TF1=1
+#define set_TCON_TR1             TR1=1
+#define set_TCON_TF0             TF0=1
+#define set_TCON_TR0             TR0=1
+#define set_TCON_IE1             IE1=1
+#define set_TCON_IT1             IT1=1
+#define set_TCON_IE0             IE0=1
+#define set_TCON_IT0             IT0=1
+                                 
+#define clr_TCON_TF1             TF1=0
+#define clr_TCON_TR1             TR1=0
+#define clr_TCON_TF0             TF0=0
+#define clr_TCON_TR0             TR0=0
+#define clr_TCON_IE1             IE1=0
+#define clr_TCON_IT1             IT1=0
+#define clr_TCON_IE0             IE0=0
+#define clr_TCON_IT0             IT0=0
+
+/**** TMOD    89H ****/
+#define set_TMOD_GATE_T1         TMOD|=0x80
+#define set_TMOD_CT_T1           TMOD|=0x40
+#define set_TMOD_M1_T1           TMOD|=0x20
+#define set_TMOD_M0_T1           TMOD|=0x10
+#define set_TMOD_GATE_T0         TMOD|=0x08
+#define set_TMOD_CT_T0           TMOD|=0x04
+#define set_TMOD_M1_T0           TMOD|=0x02
+#define set_TMOD_M0_T0           TMOD|=0x01
+                                  
+#define clr_TMOD_GATE_T1         TMOD&=0x7F
+#define clr_TMOD_CT_T1           TMOD&=0xBF
+#define clr_TMOD_M1_T1           TMOD&=0xDF
+#define clr_TMOD_M0_T1           TMOD&=0xEF
+#define clr_TMOD_GATE_T0         TMOD&=0xF7
+#define clr_TMOD_CT_T0           TMOD&=0xFB
+#define clr_TMOD_M1_T0           TMOD&=0xFD
+#define clr_TMOD_M0_T0           TMOD&=0xFE
+
+/**** TH1    8AH ****/
+/**** TH0    8BH ****/
+/**** TL1    8CH  ****/ 
+/**** TL0    8DH ****/
+
+/**** CKCON  8EH ****/
+#define set_CKCON_PWMCKS         CKCON|=0x40
+#define set_CKCON_T1M            CKCON|=0x10
+#define set_CKCON_T0M            CKCON|=0x08
+#define set_CKCON_CLOEN          CKCON|=0x02
+                                   
+#define clr_CKCON_PWMCKS         CKCON&=0xBF
+#define clr_CKCON_T1M            CKCON&=0xEF
+#define clr_CKCON_T0M            CKCON&=0xF7
+#define clr_CKCON_CLOEN          CKCON&=0xFD
+                                 
+/**** WKCON  8FH ****/          
+#define set_WKCON_WKTCK          WKCON|=0x20
+#define set_WKCON_WKTF           WKCON|=0x10
+#define set_WKCON_WKTR           WKCON|=0x08
+#define set_WKCON_WKPS2          WKCON|=0x04
+#define set_WKCON_WKPS1          WKCON|=0x02
+#define set_WKCON_WKPS0          WKCON|=0x01
+                                   
+#define clr_WKCON_WKTCK          WKCON&=0xDF
+#define clr_WKCON_WKTF           WKCON&=0xEF
+#define clr_WKCON_WKTR           WKCON&=0xF7
+#define clr_WKCON_WKPS2          WKCON&=0xFB
+#define clr_WKCON_WKPS1          WKCON&=0xFD
+#define clr_WKCON_WKPS0          WKCON&= 0xFE
+
+/****SFRS    91H ****/
+#define set_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPCON0_CAPEN2       CAPCON0|=0x40
+#define set_CAPCON0_CAPEN1       CAPCON0|=0x20
+#define set_CAPCON0_CAPEN0       CAPCON0|=0x10
+#define set_CAPCON0_CAPF2        CAPCON0|=0x04
+#define set_CAPCON0_CAPF1        CAPCON0|=0x02
+#define set_CAPCON0_CAPF0        CAPCON0|=0x01
+                                 
+#define clr_CAPCON0_CAPEN2       CAPCON0&=0xBF
+#define clr_CAPCON0_CAPEN1       CAPCON0&=0xDF
+#define clr_CAPCON0_CAPEN0       CAPCON0&=0xEF
+#define clr_CAPCON0_CAPF2        CAPCON0&=0xFB
+#define clr_CAPCON0_CAPF1        CAPCON0&=0xFD
+#define clr_CAPCON0_CAPF0        CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAPCON1_CAP2LS1      CAPCON1|=0x20
+#define set_CAPCON1_CAP2LS0      CAPCON1|=0x10
+#define set_CAPCON1_CAP1LS1      CAPCON1|=0x08
+#define set_CAPCON1_CAP1LS0      CAPCON1|=0x04
+#define set_CAPCON1_CAP0LS1      CAPCON1|=0x02
+#define set_CAPCON1_CAP0LS0      CAPCON1|=0x01
+                                 
+#define clr_CAPCON1_CAP2LS1      CAPCON1&=0xDF
+#define clr_CAPCON1_CAP2LS0      CAPCON1&=0xEF
+#define clr_CAPCON1_CAP1LS1      CAPCON1&=0xF7
+#define clr_CAPCON1_CAP1LS0      CAPCON1&=0xFB
+#define clr_CAPCON1_CAP0LS1      CAPCON1&=0xFD
+#define clr_CAPCON1_CAP0LS0      CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_CAPCON2_ENF2         CAPCON2|=0x40
+#define set_CAPCON2_ENF1         CAPCON2|=0x20
+#define set_CAPCON2_ENF0         CAPCON2|=0x10
+                                   
+#define clr_CAPCON2_ENF2         CAPCON2&=0xBF
+#define clr_CAPCON2_ENF1         CAPCON2&=0xDF
+#define clr_CAPCON2_ENF0         CAPCON2&=0xEF
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H   TA protect register ****/
+#define set_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+
+#define clr_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/ 
+#define set_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+
+#define clr_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_SCON_FE              FE =1
+#define set_SCON_SM1             SM1=1
+#define set_SCON_SM2             SM2=1
+#define set_SCON_REN             REN=1
+#define set_SCON_TB8             TB8=1
+#define set_SCON_RB8             RB8=1
+#define set_SCON_TI              TI =1
+#define set_SCON_RI              RI =1
+                                 
+#define clr_SCON_FE              FE =0
+#define clr_SCON_SM1             SM1=0
+#define clr_SCON_SM2             SM2=0
+#define clr_SCON_REN             REN=0
+#define clr_SCON_TB8             TB8=0
+#define clr_SCON_RB8             RB8=0
+#define clr_SCON_TI              TI =0
+#define clr_SCON_RI              RI =0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                     
+#define set_EIE_ET2              EIE|=0x80
+#define set_EIE_ESPI             EIE|=0x40
+#define set_EIE_EFB              EIE|=0x20
+#define set_EIE_EWDT             EIE|=0x10
+#define set_EIE_EPWM             EIE|=0x08
+#define set_EIE_ECAP             EIE|=0x04
+#define set_EIE_EPI              EIE|=0x02
+#define set_EIE_EI2C             EIE|=0x01
+                                    
+#define clr_EIE_ET2              EIE&=0x7F
+#define clr_EIE_ESPI             EIE&=0xBF
+#define clr_EIE_EFB              EIE&=0xDF
+#define clr_EIE_EWDT             EIE&=0xEF
+#define clr_EIE_EPWM             EIE&=0xF7
+#define clr_EIE_ECAP             EIE&=0xFB
+#define clr_EIE_EPI              EIE&=0xFD
+#define clr_EIE_EI2C             EIE&=0xFE
+
+/**** EIE1    9CH ****/                     
+#define set_EIE1_EWKT            EIE1|=0x04
+#define set_EIE1_ET3             EIE1|=0x02
+#define set_EIE1_ES_1            EIE1|=0x01
+                                    
+#define clr_EIE1_EWKT            EIE1&=0xFB
+#define clr_EIE1_ET3             EIE1&=0xFD
+#define clr_EIE1_ES_1            EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register  ****/
+#define set_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_AUXR1_SWRF           AUXR1|=0x80
+#define set_AUXR1_RSTPINF        AUXR1|=0x40
+#define set_AUXR1_HARDF          AUXR1|=0x20
+#define set_AUXR1_GF2            AUXR1|=0x08
+#define set_AUXR1_UART0PX        AUXR1|=0x04
+#define set_AUXR1_DPS            AUXR1|=0x01
+                                   
+#define clr_AUXR1_SWRF           AUXR1&=0x7F
+#define clr_AUXR1_RSTPINF        AUXR1&=0xBF
+#define clr_AUXR1_HARDF          AUXR1&=0xDF
+#define clr_AUXR1_GF2            AUXR1&=0xF7
+#define clr_AUXR1_UART0PX        AUXR1&=0xFB
+#define clr_AUXR1_DPS            AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BODCON0_BOV2         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define set_IAPTRG_IAPGO_WDCLR   BIT_TMP=EA;EA=0;set_WDCON_WDCLR;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define clr_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG&=0xFE;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/ 
+#define set_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x10;EA=BIT_TMP
+#define set_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x08;EA=BIT_TMP
+#define set_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                 
+#define clr_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xEF;EA=BIT_TMP
+#define clr_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xF7;EA=BIT_TMP
+#define clr_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_IE_EA                EA  =1
+#define set_IE_EADC              EADC=1
+#define set_IE_EBOD              EBOD=1
+#define set_IE_ES                ES  =1
+#define set_IE_ET1               ET1 =1
+#define set_IE_EX1               EX1 =1
+#define set_IE_ET0               ET0 =1
+#define set_IE_EX0               EX0 =1
+                                 
+#define clr_IE_EA                EA  =0
+#define clr_IE_EADC              EADC=0
+#define clr_IE_EBOD              EBOD=0
+#define clr_IE_ES                ES  =0
+#define clr_IE_ET1               ET1 =0
+#define clr_IE_EX1               EX1 =0
+#define clr_IE_ET0               ET0 =0
+#define clr_IE_EX0               EX0 =0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WDCON_WIDPD          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_IAPCN_FOEN           IAPN|=0x20
+#define set_IAPCN_FCEN           IAPN|=0x10
+#define set_IAPCN_FCTRL3         IAPN|=0x08
+#define set_IAPCN_FCTRL2         IAPN|=0x04
+#define set_IAPCN_FCTRL1         IAPN|=0x02
+#define set_IAPCN_FCTRL0         IAPN|=0x01
+                                   
+#define clr_IAPCN_FOEN           IAPN&=0xDF
+#define clr_IAPCN_FCEN           IAPN&=0xEF
+#define clr_IAPCN_FCTRL3         IAPN&=0xF7
+#define clr_IAPCN_FCTRL2         IAPN&=0xFB
+#define clr_IAPCN_FCTRL1         IAPN&=0xFD
+#define clr_IAPCN_FCTRL0         IAPN&=0xFE
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7               clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6               clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5               clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4               clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3               clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2               clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1               clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0               clr_SFRS_SFRPAGE;P0M1|=0x01
+                                 
+#define clr_P0M1_7               clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6               clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5               clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4               clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3               clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2               clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1               clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0               clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/
+#define set_P0S_7                set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6                set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5                set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4                set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3                set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2                set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1                set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0                set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7                set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6                set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5                set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4                set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3                set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2                set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1                set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0                set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7               clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6               clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5               clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4               clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3               clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2               clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1               clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0               clr_SFRS_SFRPAGE;P0M2|=0x01
+                                 
+#define clr_P0M2_7               clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6               clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5               clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4               clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3               clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2               clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1               clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0               clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7               set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6               set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5               set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4               set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3               set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2               set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1               set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0               set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7               set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6               set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5               set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4               set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3               set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2               set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1               set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0               set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7                set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6                set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5                set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4                set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3                set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2                set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1                set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0                set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1S_7                set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6                set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5                set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4                set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3                set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2                set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1                set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0                set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7               set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6               set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5               set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4               set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3               set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2               set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1               set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0               set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1SR_7               set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6               set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5               set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4               set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3               set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2               set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1               set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0               set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_P20UP            P2S|=0x80
+#define set_P2S_T1OE             P2S|=0x08
+#define set_P2S_T0OE             P2S|=0x04
+#define set_P2S_P2S0             P2S|=0x01
+                                 
+#define clr_P2S_P20UP            P2S&=0x7F
+#define clr_P2S_T1OE             P2S&=0xF7
+#define clr_P2S_T0OE             P2S&=0xFB
+#define clr_P2S_P2S0             P2S&=0xFE
+                                 
+/**** IPH    B7H PAGE0 ****/                     
+#define set_IPH_PADCH            clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_IPH_PBODH            clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_IPH_PSH              clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_IPH_PT1H             clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_IPH_PX1H             clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_IPH_PT0H             clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_IPH_PX0H             clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_IPH_PADCH            clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_IPH_PBODH            clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_IPH_PSH              clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_IPH_PT1H             clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_IPH_PX1H             clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_IPH_PT0H             clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_IPH_PX0H             clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/ 
+#define set_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+                                
+#define clr_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_IP_PADC              PADC=1
+#define set_IP_PBOD              PBOD=1
+#define set_IP_PS                PS  =1
+#define set_IP_PT1               PT1 =1
+#define set_IP_PX1               PX1 =1
+#define set_IP_PT0               PT0 =1
+#define set_IP_PX0               PX0 =1
+                                 
+#define clr_IP_PADC              PADC=0
+#define clr_IP_PBOD              PBOD=0
+#define clr_IP_PS                PS  =0
+#define clr_IP_PT1               PT1 =0
+#define clr_IP_PX1               PX1 =0
+#define clr_IP_PT0               PT0 =0
+#define clr_IP_PX0               PX0 =0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOC_I2TOCEN       I2TOC|=0x04
+#define set_I2TOC_DIV           I2TOC|=0x02
+#define set_I2TOC_I2TOF         I2TOC|=0x01
+                                
+#define clr_I2TOC_I2TOCEN       I2TOC&=0xFB
+#define clr_I2TOC_DIV           I2TOC&=0xFD
+#define clr_I2TOC_I2TOF         I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CON_I2CEN         I2CEN    = 1
+#define set_I2CON_STA           STA      = 1
+#define set_I2CON_STO           STO      = 1
+#define set_I2CON_SI            SI       = 1
+#define set_I2CON_AA            AA       = 1
+#define set_I2CON_I2CPX         I2CPX    = 1
+            
+#define clr_I2CON_I2CEN         I2CEN    = 0
+#define clr_I2CON_STA           STA      = 0
+#define clr_I2CON_STO           STO      = 0
+#define clr_I2CON_SI            SI       = 0
+#define clr_I2CON_AA            AA       = 0
+#define clr_I2CON_I2CPX         I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_I2ADDR_GC           I2ADDR|= 0x01
+#define clr_I2ADDR_GC           I2ADDR&= 0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON|=0x01
+
+#define clr_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_T2CON_TF2           TF2      = 1
+#define set_T2CON_TR2           TR2      = 1
+#define set_T2CON_CMRL2         CM_RL2   = 1
+                                
+#define clr_T2CON_TF2           TF2      = 0
+#define clr_T2CON_TR2           TR2      = 0
+#define clr_T2CON_CMRL2         CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_T2MOD_LDEN          T2MOD|=0x80
+#define set_T2MOD_T2DIV2        T2MOD|=0x40
+#define set_T2MOD_T2DIV1        T2MOD|=0x20
+#define set_T2MOD_T2DIV0        T2MOD|=0x10
+#define set_T2MOD_CAPCR         T2MOD|=0x08
+#define set_T2MOD_CMPCR         T2MOD|=0x04
+#define set_T2MOD_LDTS1         T2MOD|=0x02
+#define set_T2MOD_LDTS0         T2MOD|=0x01
+                                       
+#define clr_T2MOD_LDEN          T2MOD&=0x7F
+#define clr_T2MOD_T2DIV2        T2MOD&=0xBF
+#define clr_T2MOD_T2DIV1        T2MOD&=0xDF
+#define clr_T2MOD_T2DIV0        T2MOD&=0xEF
+#define clr_T2MOD_CAPCR         T2MOD&=0xF7
+#define clr_T2MOD_CMPCR         T2MOD&=0xFB
+#define clr_T2MOD_LDTS1         T2MOD&=0xFD
+#define clr_T2MOD_LDTS0         T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L  CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_PSW_CY              CY  = 1
+#define set_PSW_AC              AC  = 1
+#define set_PSW_F0              F0  = 1 
+#define set_PSW_RS1             RS1 = 1
+#define set_PSW_RS0             RS0 = 1
+#define set_PSW_OV              OV   = 1
+#define set_PSW_P               P    = 1
+                                
+#define clr_PSW_CY              CY  = 0
+#define clr_PSW_AC              AC  = 0
+#define clr_PSW_F0              F0  = 0 
+#define clr_PSW_RS1             RS1 = 0
+#define clr_PSW_RS0             RS0 = 0
+#define clr_PSW_OV              OV   = 0
+#define clr_PSW_P               P    = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** FBD    D7H ****/
+#define set_FBD_FBF             FBD|=0x80
+#define set_FBD_FBINLS          FBD|=0x40
+#define set_FBD_FBD5            FBD|=0x20
+#define set_FBD_FBD4            FBD|=0x10
+#define set_FBD_FBD3            FBD|=0x08
+#define set_FBD_FBD2            FBD|=0x04
+#define set_FBD_FBD1            FBD|=0x02
+#define set_FBD_FBD0            FBD|=0x01
+                                
+#define clr_FBD_FBF             FBD&=0x7F
+#define clr_FBD_FBINLS          FBD&=0xBF
+#define clr_FBD_FBD5            FBD&=0xDF
+#define clr_FBD_FBD4            FBD&=0xEF
+#define clr_FBD_FBD3            FBD&=0xF7
+#define clr_FBD_FBD2            FBD&=0xFB
+#define clr_FBD_FBD1            FBD&=0xFD
+#define clr_FBD_FBD0            FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMCON0_PWMRUN      PWMRUN   = 1
+#define set_PWMCON0_LOAD        LOAD     = 1
+#define set_PWMCON0_PWMF        PWMF     = 1
+#define set_PWMCON0_CLRPWM      CLRPWM   = 1
+                                
+#define clr_PWMCON0_PWMRUN      PWMRUN   = 0
+#define clr_PWMCON0_LOAD        LOAD     = 0
+#define clr_PWMCON0_PWMF        PWMF     = 0 
+#define clr_PWMCON0_CLRPWM      CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIOCON0_PIO05       PIOCON0|=0x20
+#define set_PIOCON0_PIO04       PIOCON0|=0x10
+#define set_PIOCON0_PIO03       PIOCON0|=0x08
+#define set_PIOCON0_PIO02       PIOCON0|=0x04
+#define set_PIOCON0_PIO01       PIOCON0|=0x02
+#define set_PIOCON0_PIO00       PIOCON0|=0x01
+                                
+#define clr_PIOCON0_PIO05       PIOCON0&=0xDF
+#define clr_PIOCON0_PIO04       PIOCON0&=0xEF
+#define clr_PIOCON0_PIO03       PIOCON0&=0xF7
+#define clr_PIOCON0_PIO02       PIOCON0&=0xFB
+#define clr_PIOCON0_PIO01       PIOCON0&=0xFD
+#define clr_PIOCON0_PIO00       PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMCON1_PWMMOD1     PWMCON1|=0x80
+#define set_PWMCON1_PWMMOD0     PWMCON1|=0x40
+#define set_PWMCON1_GP          PWMCON1|=0x20
+#define set_PWMCON1_PWMTYP      PWMCON1|=0x10
+#define set_PWMCON1_FBINEN      PWMCON1|=0x08
+#define set_PWMCON1_PWMDIV2     PWMCON1|=0x04 
+#define set_PWMCON1_PWMDIV1     PWMCON1|=0x02
+#define set_PWMCON1_PWMDIV0     PWMCON1|=0x01
+                                
+#define clr_PWMCON1_PWMMOD1     PWMCON1&=0x7F
+#define clr_PWMCON1_PWMMOD0     PWMCON1&=0xBF
+#define clr_PWMCON1_GP          PWMCON1&=0xDF
+#define clr_PWMCON1_PWMTYP      PWMCON1&=0xEF
+#define clr_PWMCON1_FBINEN      PWMCON1&=0xF7
+#define clr_PWMCON1_PWMDIV2     PWMCON1&=0xFB 
+#define clr_PWMCON1_PWMDIV1     PWMCON1&=0xFD
+#define clr_PWMCON1_PWMDIV0     PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1|=0x40
+#define set_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1|=0x08
+#define set_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1|=0x04
+#define set_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1|=0x02
+#define set_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1|=0x01
+
+#define clr_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1&=0xBF
+#define clr_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1&=0xF7
+#define clr_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1&=0xFB                                                   
+#define clr_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1&=0xFD
+#define clr_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/                    
+#define set_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2|=0x80
+#define set_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2|=0x40
+#define set_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2|=0x20
+#define set_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2|=0x10
+
+#define clr_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2&=0x7F
+#define clr_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2&=0xBF
+#define clr_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2&=0xDF
+#define clr_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=1
+#define set_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=1
+#define set_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=1
+#define set_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=1
+#define set_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=1
+#define set_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=1
+#define set_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=1
+#define set_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=1
+
+#define clr_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=0
+#define clr_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=0
+#define clr_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=0
+#define clr_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=0
+#define clr_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=0
+#define clr_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=0
+#define clr_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=0
+#define clr_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=0
+
+/**** PICON  E9H ****/
+#define set_PICON_PIT67         PICON|=0x80
+#define set_PICON_PIT45         PICON|=0x40
+#define set_PICON_PIT3          PICON|=0x20
+#define set_PICON_PIT2          PICON|=0x10
+#define set_PICON_PIT1          PICON|=0x08
+#define set_PICON_PIT0          PICON|=0x04
+#define set_PICON_PIPS1         PICON|=0x02
+#define set_PICON_PIPS0         PICON|=0x01
+                                  
+#define clr_PICON_PIT67         PICON&=0x7F
+#define clr_PICON_PIT45         PICON&=0xBF
+#define clr_PICON_PIT3          PICON&=0xDF
+#define clr_PICON_PIT2          PICON&=0xEF
+#define clr_PICON_PIT1          PICON&=0xF7
+#define clr_PICON_PIT0          PICON&=0xFB
+#define clr_PICON_PIPS1         PICON&=0xFD
+#define clr_PICON_PIPS0         PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN_PINEN7        PINEN|=0x80
+#define set_PINEN_PINEN6        PINEN|=0x40
+#define set_PINEN_PINEN5        PINEN|=0x20
+#define set_PINEN_PINEN4        PINEN|=0x10
+#define set_PINEN_PINEN3        PINEN|=0x08
+#define set_PINEN_PINEN2        PINEN|=0x04
+#define set_PINEN_PINEN1        PINEN|=0x02
+#define set_PINEN_PINEN0        PINEN|=0x01
+                                  
+#define clr_PINEN_PINEN7        PINEN&=0x7F
+#define clr_PINEN_PINEN6        PINEN&=0xBF
+#define clr_PINEN_PINEN5        PINEN&=0xDF
+#define clr_PINEN_PINEN4        PINEN&=0xEF
+#define clr_PINEN_PINEN3        PINEN&=0xF7
+#define clr_PINEN_PINEN2        PINEN&=0xFB
+#define clr_PINEN_PINEN1        PINEN&=0xFD
+#define clr_PINEN_PINEN0        PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN_PIPEN7        PIPEN|=0x80
+#define set_PIPEN_PIPEN6        PIPEN|=0x40
+#define set_PIPEN_PIPEN5        PIPEN|=0x20
+#define set_PIPEN_PIPEN4        PIPEN|=0x10
+#define set_PIPEN_PIPEN3        PIPEN|=0x08
+#define set_PIPEN_PIPEN2        PIPEN|=0x04
+#define set_PIPEN_PIPEN1        PIPEN|=0x02
+#define set_PIPEN_PIPEN0        PIPEN|=0x01
+                                  
+#define clr_PIPEN_PIPEN7        PIPEN&=0x7F
+#define clr_PIPEN_PIPEN6        PIPEN&=0xBF
+#define clr_PIPEN_PIPEN5        PIPEN&=0xDF
+#define clr_PIPEN_PIPEN4        PIPEN&=0xEF
+#define clr_PIPEN_PIPEN3        PIPEN&=0xF7
+#define clr_PIPEN_PIPEN2        PIPEN&=0xFB
+#define clr_PIPEN_PIPEN1        PIPEN&=0xFD
+#define clr_PIPEN_PIPEN0        PIPEN&=0xFE
+
+/**** PIF ECH ****/
+#define set_PIF_PIF7             PIF|=0x80
+#define set_PIF_PIF6             PIF|=0x40
+#define set_PIF_PIF5             PIF|=0x20
+#define set_PIF_PIF4             PIF|=0x10
+#define set_PIF_PIF3             PIF|=0x08
+#define set_PIF_PIF2             PIF|=0x04
+#define set_PIF_PIF1             PIF|=0x02
+#define set_PIF_PIF0             PIF|=0x01
+                                 
+#define clr_PIF_PIF7             PIF&=0x7F
+#define clr_PIF_PIF6             PIF&=0xBF
+#define clr_PIF_PIF5             PIF&=0xDF
+#define clr_PIF_PIF4             PIF&=0xEF
+#define clr_PIF_PIF3             PIF&=0xF7
+#define clr_PIF_PIF2             PIF&=0xFB
+#define clr_PIF_PIF1             PIF&=0xFD
+#define clr_PIF_PIF0             PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_EIP_PT2             EIP|=0x80
+#define set_EIP_PSPI            EIP|=0x40
+#define set_EIP_PFB             EIP|=0x20
+#define set_EIP_PWDT            EIP|=0x10
+#define set_EIP_PPWM            EIP|=0x08
+#define set_EIP_PCAP            EIP|=0x04
+#define set_EIP_PPI             EIP|=0x02
+#define set_EIP_PI2C            EIP|=0x01
+                                   
+#define clr_EIP_PT2             EIP&=0x7F
+#define clr_EIP_PSPI            EIP&=0xBF
+#define clr_EIP_PFB             EIP&=0xDF
+#define clr_EIP_PWDT            EIP&=0xEF
+#define clr_EIP_PPWM            EIP&=0xF7
+#define clr_EIP_PCAP            EIP&=0xFB
+#define clr_EIP_PPI             EIP&=0xFD
+#define clr_EIP_PI2C            EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAPCON3_CAP13       CAPCON3|=0x80
+#define set_CAPCON3_CAP12       CAPCON3|=0x40
+#define set_CAPCON3_CAP11       CAPCON3|=0x20
+#define set_CAPCON3_CAP10       CAPCON3|=0x10
+#define set_CAPCON3_CAP03       CAPCON3|=0x08
+#define set_CAPCON3_CAP02       CAPCON3|=0x04
+#define set_CAPCON3_CAP01       CAPCON3|=0x02
+#define set_CAPCON3_CAP00       CAPCON3|=0x01
+                                
+#define clr_CAPCON3_CAP13       CAPCON3&=0x7F
+#define clr_CAPCON3_CAP12       CAPCON3&=0xBF
+#define clr_CAPCON3_CAP11       CAPCON3&=0xDF
+#define clr_CAPCON3_CAP10       CAPCON3&=0xEF
+#define clr_CAPCON3_CAP03       CAPCON3&=0xF7
+#define clr_CAPCON3_CAP02       CAPCON3&=0xFB
+#define clr_CAPCON3_CAP01       CAPCON3&=0xFD
+#define clr_CAPCON3_CAP00       CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAPCON4_CAP23       CAPCON4|=0x08
+#define set_CAPCON4_CAP22       CAPCON4|=0x04
+#define set_CAPCON4_CAP21       CAPCON4|=0x02
+#define set_CAPCON4_CAP20       CAPCON4|=0x01
+                                
+#define clr_CAPCON4_CAP23       CAPCON4&=0xF7
+#define clr_CAPCON4_CAP22       CAPCON4&=0xFB
+#define clr_CAPCON4_CAP21       CAPCON4&=0xFD
+#define clr_CAPCON4_CAP20       CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR|=0x01
+                                
+#define clr_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPSR_SPIF           SPSR|=0x80
+#define set_SPSR_WCOL           SPSR|=0x40
+#define set_SPSR_SPIOVF         SPSR|=0x20
+#define set_SPSR_MODF           SPSR|=0x10
+#define set_SPSR_DISMODF        SPSR|=0x08
+                                   
+#define clr_SPSR_SPIF           SPSR&=0x7F
+#define clr_SPSR_WCOL           SPSR&=0xBF
+#define clr_SPSR_SPIOVF         SPSR&=0xDF
+#define clr_SPSR_MODF           SPSR&=0xEF
+#define clr_SPSR_DISMODF        SPSR&=0xF7
+
+/**** SPDR    F5H PAGE0 ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                
+#define clr_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH|=0x01
+                                   
+#define clr_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_SCON_1_FE_1         FE_1  = 1
+#define set_SCON_1_SM1_1        SM1_1 = 1
+#define set_SCON_1_SM2_1        SM2_1 = 1
+#define set_SCON_1_REN_1        REN_1 = 1
+#define set_SCON_1_TB8_1        TB8_1 = 1
+#define set_SCON_1_RB8_1        RB8_1 = 1
+#define set_SCON_1_TI_1         TI_1  = 1
+#define set_SCON_1_RI_1         RI_1  = 1
+                                
+#define clr_SCON_1_FE_1         FE_1  = 0
+#define clr_SCON_1_SM1_1        SM1_1 = 0
+#define clr_SCON_1_SM2_1        SM2_1 = 0
+#define clr_SCON_1_REN_1        REN_1 = 0
+#define clr_SCON_1_TB8_1        TB8_1 = 0
+#define clr_SCON_1_RB8_1        RB8_1 = 0
+#define clr_SCON_1_TI_1         TI_1  = 0
+#define clr_SCON_1_RI_1         RI_1  = 0
+
+/**** PDTEN    F9H ****/
+#define set_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN_5               PMEN|=0x20
+#define set_PMEN_4               PMEN|=0x10
+#define set_PMEN_3               PMEN|=0x08
+#define set_PMEN_2               PMEN|=0x04
+#define set_PMEN_1               PMEN|=0x02
+#define set_PMEN_0               PMEN|=0x01
+                                    
+#define clr_PMEN_5               PMEN&=0xDF
+#define clr_PMEN_4               PMEN&=0xEF
+#define clr_PMEN_3               PMEN&=0xF7
+#define clr_PMEN_2               PMEN&=0xFB
+#define clr_PMEN_1               PMEN&=0xFD
+#define clr_PMEN_0               PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD_7                PMD|=0x80
+#define set_PMD_6                PMD|=0x40
+#define set_PMD_5                PMD|=0x20
+#define set_PMD_4                PMD|=0x10
+#define set_PMD_3                PMD|=0x08
+#define set_PMD_2                PMD|=0x04
+#define set_PMD_1                PMD|=0x02
+#define set_PMD_0                PMD|=0x01
+                                   
+#define clr_PMD_7                PMD&=0x7F
+#define clr_PMD_6                PMD&=0xBF
+#define clr_PMD_5                PMD&=0xDF
+#define clr_PMD_4                PMD&=0xEF
+#define clr_PMD_3                PMD&=0xF7
+#define clr_PMD_2                PMD&=0xFB
+#define clr_PMD_1                PMD&=0xFD
+#define clr_PMD_0                PMD&=0xFE
+
+/****  EIP1     FEH PAGE0 ****/                   
+#define set_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1|=0x01
+                                   
+#define clr_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1&=0xFE
+
+/**** EIPH1    FFH ****/                
+#define set_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                  
+#define clr_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1&=0xFE
+
+ /********************************************************/
+/*  <Define rule II> "set or clr _ register bit name     */
+/*********************************************************/
+/**** P0    80H ****/
+#define set_P00                 P00=1
+#define set_P01                 P01=1
+#define set_P02                 P02=1
+#define set_P03                 P03=1
+#define set_P04                 P04=1
+#define set_P05                 P05=1
+#define set_P06                 P06=1
+#define set_P07                 P07=1
+                                
+#define clr_P00                 P00=0
+#define clr_P01                 P01=0
+#define clr_P02                 P02=0
+#define clr_P03                 P03=0
+#define clr_P04                 P04=0
+#define clr_P05                 P05=0
+#define clr_P06                 P06=0
+#define clr_P07                 P07=0
+
+/**** SP    81H ****/ 
+/**** DPH  82H ****/ 
+/**** DPL  83H ****/ 
+/**** RWK  86H ****/ 
+
+/**** PCON  87H ****/
+#define set_SMOD                PCON|=0x80
+#define set_SMOD0               PCON|=0x40
+#define set_POF                 PCON|=0x10
+#define set_GF1                 PCON|=0x08
+#define set_GF0                 PCON|=0x04 
+#define set_PD                  PCON|=0x02
+#define set_IDL                 PCON|=0x01
+                                    
+#define clr_SMOD                PCON&=0x7F
+#define clr_SMOD0               PCON&=0xBF
+#define clr_POF                 PCON&=0xEF
+#define clr_GF1                 PCON&=0xF7
+#define clr_GF0                 PCON&=0xFB 
+#define clr_PD                  PCON&=0xFD
+#define clr_IDL                 PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TF1                 TF1=1
+#define set_TR1                 TR1=1
+#define set_TF0                 TF0=1
+#define set_TR0                 TR0=1
+#define set_IE1                 IE1=1
+#define set_IT1                 IT1=1
+#define set_IE0                 IE0=1
+#define set_IT0                 IT0=1
+                                
+#define clr_TF1                 TF1=0
+#define clr_TR1                 TR1=0
+#define clr_TF0                 TF0=0
+#define clr_TR0                 TR0=0
+#define clr_IE1                 IE1=0
+#define clr_IT1                 IT1=0
+#define clr_IE0                 IE0=0
+#define clr_IT0                 IT0=0
+
+/**** TMOD    89H ****/ 
+#define set_GATE_T1             TMOD|=0x80
+#define set_CT_T1               TMOD|=0x40
+#define set_M1_T1               TMOD|=0x20
+#define set_M0_T1               TMOD|=0x10
+#define set_GATE_T0             TMOD|=0x08
+#define set_CT_T0               TMOD|=0x04
+#define set_M1_T0               TMOD|=0x02
+#define set_M0_T0               TMOD|=0x01
+                                    
+#define clr_GATE_T1             TMOD&=0x7F
+#define clr_CT_T1               TMOD&=0xBF
+#define clr_M1_T1               TMOD&=0xDF
+#define clr_M0_T1               TMOD&=0xEF
+#define clr_GATE_T0             TMOD&=0xF7
+#define clr_CT_T0               TMOD&=0xFB
+#define clr_M1_T0               TMOD&=0xFD
+#define clr_M0_T0               TMOD&=0xFE
+
+/**** TH1    8AH ****/ 
+/**** TH0    8BH ****/ 
+/**** TL1    8CH ****/
+/**** TL0    8DH ****/ 
+
+/**** CKCON  8EH ****/
+#define set_PWMCKS              CKCON|=0x40
+#define set_T1M                 CKCON|=0x10
+#define set_T0M                 CKCON|=0x08
+#define set_CLOEN               CKCON|=0x02
+                                     
+#define clr_PWMCKS              CKCON&=0xBF
+#define clr_T1M                 CKCON&=0xEF
+#define clr_T0M                 CKCON&=0xF7
+#define clr_CLOEN               CKCON&=0xFD
+
+/**** WKCON  8FH ****/
+#define set_WKTCK               WKCON|=0x20
+#define set_WKTF                WKCON|=0x10
+#define set_WKTR                WKCON|=0x08
+#define set_WKPS2               WKCON|=0x04
+#define set_WKPS1               WKCON|=0x02
+#define set_WKPS0               WKCON|=0x01
+                                     
+#define clr_WKTCK               WKCON&=0xDF
+#define clr_WKTF                WKCON&=0xEF
+#define clr_WKTR                WKCON&=0xF7
+#define clr_WKPS2               WKCON&=0xFB
+#define clr_WKPS1               WKCON&=0xFD
+#define clr_WKPS0               WKCON&=0xFE
+
+/**** P1    90H ****/
+#define set_P10                 P10=1
+#define set_P11                 P11=1
+#define set_P12                 P12=1
+#define set_P13                 P13=1
+#define set_P14                 P14=1
+#define set_P15                 P15=1
+#define set_P16                 P16=1
+#define set_P17                 P17=1
+                                
+#define clr_P10                 P10=0
+#define clr_P11                 P11=0
+#define clr_P12                 P12=0
+#define clr_P13                 P13=0
+#define clr_P14                 P14=0
+#define clr_P15                 P15=0
+#define clr_P16                 P16=0
+#define clr_P17                 P17=0
+
+/****SFRS    91H ****/
+#define set_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPEN2              CAPCON0|=0x40
+#define set_CAPEN1              CAPCON0|=0x20
+#define set_CAPEN0              CAPCON0|=0x10
+#define set_CAPF2               CAPCON0|=0x04
+#define set_CAPF1               CAPCON0|=0x02
+#define set_CAPF0               CAPCON0|=0x01
+                                
+#define clr_CAPEN2              CAPCON0&=0xBF
+#define clr_CAPEN1              CAPCON0&=0xDF
+#define clr_CAPEN0              CAPCON0&=0xEF
+#define clr_CAPF2               CAPCON0&=0xFB
+#define clr_CAPF1               CAPCON0&=0xFD
+#define clr_CAPF0               CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAP2LS1             CAPCON1|=0x20
+#define set_CAP2LS0             CAPCON1|=0x10
+#define set_CAP1LS1             CAPCON1|=0x08
+#define set_CAP1LS0             CAPCON1|=0x04
+#define set_CAP0LS1             CAPCON1|=0x02
+#define set_CAP0LS0             CAPCON1|=0x01
+                                
+#define clr_CAP2LS1             CAPCON1&=0xDF
+#define clr_CAP2LS0             CAPCON1&=0xEF
+#define clr_CAP1LS1             CAPCON1&=0xF7
+#define clr_CAP1LS0             CAPCON1&=0xFB
+#define clr_CAP0LS1             CAPCON1&=0xFD
+#define clr_CAP0LS0             CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_ENF2                CAPCON2|=0x40
+#define set_ENF1                CAPCON2|=0x20
+#define set_ENF0                CAPCON2|=0x10
+                                       
+#define clr_ENF2                CAPCON2&=0xBF
+#define clr_ENF1                CAPCON2&=0xDF
+#define clr_ENF0                CAPCON2&=0xEF
+
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H ****/
+#define set_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+                                
+#define clr_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/
+#define set_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+                                
+#define clr_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_FE                  FE    = 1
+#define set_SM1                 SM1   = 1
+#define set_SM2                 SM2   = 1
+#define set_REN                 REN   = 1
+#define set_TB8                 TB8   = 1
+#define set_RB8                 RB8   = 1
+#define set_TI                  TI    = 1
+#define set_RI                  RI    = 1
+                                
+#define clr_FE                  FE    = 0
+#define clr_SM1                 SM1   = 0
+#define clr_SM2                 SM2   = 0
+#define clr_REN                 REN   = 0
+#define clr_TB8                 TB8   = 0
+#define clr_RB8                 RB8   = 0
+#define clr_TI                  TI    = 0
+#define clr_RI                  RI    = 0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                      
+#define set_ET2                 EIE|=0x80
+#define set_ESPI                EIE|=0x40
+#define set_EFB                 EIE|=0x20
+#define set_EWDT                EIE|=0x10
+#define set_EPWM                EIE|=0x08
+#define set_ECAP                EIE|=0x04
+#define set_EPI                 EIE|=0x02
+#define set_EI2C                EIE|=0x01
+                                   
+#define clr_ET2                 EIE&=0x7F
+#define clr_ESPI                EIE&=0xBF
+#define clr_EFB                 EIE&=0xDF
+#define clr_EWDT                EIE&=0xEF
+#define clr_EPWM                EIE&=0xF7
+#define clr_ECAP                EIE&=0xFB
+#define clr_EPI                 EIE&=0xFD
+#define clr_EI2C                EIE&=0xFE
+
+/**** EIE1    9CH ****/                      
+#define set_EWKT                EIE1|=0x04
+#define set_ET3                 EIE1|=0x02
+#define set_ES_1                EIE1|=0x01
+                                    
+#define clr_EWKT                EIE1&=0xFB
+#define clr_ET3                 EIE1&=0xFD
+#define clr_ES_1                EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register ****/
+#define set_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                
+#define clr_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_SWRF                AUXR1|=0x80
+#define set_RSTPINF             AUXR1|=0x40
+#define set_HARDF               AUXR1|=0x20
+#define set_GF2                 AUXR1|=0x08
+#define set_UART0PX             AUXR1|=0x04
+#define set_DPS                 AUXR1|=0x01
+                                     
+#define clr_SWRF                AUXR1&=0x7F
+#define clr_RSTPINF             AUXR1&=0xBF
+#define clr_HARDF               AUXR1&=0xDF
+#define clr_GF2                 AUXR1&=0xF7
+#define clr_UART0PX             AUXR1&=0xFB
+#define clr_DPS                 AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                
+#define clr_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BOV2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPGO               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/
+#define set_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                
+#define clr_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_EA                  EA       = 1
+#define set_EADC                EADC     = 1
+#define set_EBOD                EBOD     = 1
+#define set_ES                  ES       = 1
+#define set_ET1                 ET1      = 1
+#define set_EX1                 EX1      = 1
+#define set_ET0                 ET0      = 1
+#define set_EX0                 EX0      = 1
+                                
+#define clr_EA                  EA       = 0
+#define clr_EADC                EADC     = 0
+#define clr_EBOD                EBOD     = 0
+#define clr_ES                  ES       = 0
+#define clr_ET1                 ET1      = 0
+#define clr_EX1                 EX1      = 0
+#define clr_ET0                 ET0      = 0
+#define clr_EX0                 EX0      = 0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WIDPD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                
+#define clr_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                
+#define clr_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** P3M1    ACH PAGE0 ****/
+#define set_P3M1_0              clr_SFRS_SFRPAGE;P3M1|=0x01
+#define clr_P3M1_0              clr_SFRS_SFRPAGE;P3M1&=0xFE
+
+/**** P3S    ACH PAGE1 ****/ 
+#define set_P3S_0               set_SFRS_SFRPAGE;P3S|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3S_0               set_SFRS_SFRPAGE;P3S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P3M2    ADH PAGE0 ****/
+#define set_P3M2_0              clr_SFRS_SFRPAGE;P3M2|=0x01
+#define clr_P3M2_0              clr_SFRS_SFRPAGE;P3M2&=0xFE
+
+/**** P3SR    ADH PAGE1 ****/ 
+#define set_P3SR_0              set_SFRS_SFRPAGE;P3SR|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3SR_0              set_SFRS_SFRPAGE;P3SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_FOEN                IAPN|=0x20
+#define set_FCEN                IAPN|=0x10
+#define set_FCTRL3              IAPN|=0x08
+#define set_FCTRL2              IAPN|=0x04
+#define set_FCTRL1              IAPN|=0x02
+#define set_FCTRL0              IAPN|=0x01
+                                      
+#define clr_FOEN                IAPN&=0xDF
+#define clr_FCEN                IAPN&=0xEF
+#define clr_FCTRL3              IAPN&=0xF7
+#define clr_FCTRL2              IAPN&=0xFB
+#define clr_FCTRL1              IAPN&=0xFD
+#define clr_FCTRL0              IAPN&=0xFE
+
+/**** P3    B0H ****/
+#define set_P30                 P30= 1
+#define clr_P30                 P30= 0
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7              clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6              clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5              clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4              clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3              clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2              clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1              clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0              clr_SFRS_SFRPAGE;P0M1|=0x01
+                                
+#define clr_P0M1_7              clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6              clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5              clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4              clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3              clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2              clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1              clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0              clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/ 
+#define set_P0S_7               set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6               set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5               set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4               set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3               set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2               set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1               set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0               set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7               set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6               set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5               set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4               set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3               set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2               set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1               set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0               set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7              clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6              clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5              clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4              clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3              clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2              clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1              clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0              clr_SFRS_SFRPAGE;P0M2|=0x01
+                                
+#define clr_P0M2_7              clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6              clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5              clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4              clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3              clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2              clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1              clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0              clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7              set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6              set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5              set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4              set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3              set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2              set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1              set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0              set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7              set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6              set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5              set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4              set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3              set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2              set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1              set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0              set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M1  B3H PAGE0 ****/
+#define set_P1M1_7              clr_SFRS_SFRPAGE;P1M1|=0x80
+#define set_P1M1_6              clr_SFRS_SFRPAGE;P1M1|=0x40
+#define set_P1M1_5              clr_SFRS_SFRPAGE;P1M1|=0x20 
+#define set_P1M1_4              clr_SFRS_SFRPAGE;P1M1|=0x10
+#define set_P1M1_3              clr_SFRS_SFRPAGE;P1M1|=0x08
+#define set_P1M1_2              clr_SFRS_SFRPAGE;P1M1|=0x04
+#define set_P1M1_1              clr_SFRS_SFRPAGE;P1M1|=0x02
+#define set_P1M1_0              clr_SFRS_SFRPAGE;P1M1|=0x01
+                                
+#define clr_P1M1_7              clr_SFRS_SFRPAGE;P1M1&=0x7F
+#define clr_P1M1_6              clr_SFRS_SFRPAGE;P1M1&=0xBF
+#define clr_P1M1_5              clr_SFRS_SFRPAGE;P1M1&=0xDF
+#define clr_P1M1_4              clr_SFRS_SFRPAGE;P1M1&=0xEF
+#define clr_P1M1_3              clr_SFRS_SFRPAGE;P1M1&=0xF7
+#define clr_P1M1_2              clr_SFRS_SFRPAGE;P1M1&=0xFB
+#define clr_P1M1_1              clr_SFRS_SFRPAGE;P1M1&=0xFD
+#define clr_P1M1_0              clr_SFRS_SFRPAGE;P1M1&=0xFE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7               set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6               set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5               set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4               set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3               set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2               set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1               set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0               set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+         
+#define clr_P1S_7               set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6               set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5               set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4               set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3               set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2               set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1               set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0               set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M2    B4H PAGE0 ****/                      
+#define set_P12UP               clr_SFRS_SFRPAGE;P1M2|=0x04
+#define set_P1M2_1              clr_SFRS_SFRPAGE;P1M2|=0x02
+#define set_P1M2_0              clr_SFRS_SFRPAGE;P1M2|=0x01
+                                    
+#define clr_P12UP               clr_SFRS_SFRPAGE;P1M2&=0xFB
+#define clr_P1M2_1              clr_SFRS_SFRPAGE;P1M2&=0xFD
+#define clr_P1M2_0              clr_SFRS_SFRPAGE;P1M2&=0xFE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7              set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6              set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5              set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4              set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3              set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2              set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1              set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0              set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                                            
+#define clr_P1SR_7              set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6              set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5              set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4              set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3              set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2              set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1              set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0              set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_0               P2S|= 0x01
+#define clr_P2S_0               P2S&= 0xFE
+
+/**** IPH    B7H PAGE0 ****/                    
+#define set_PADCH               clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_PBODH               clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_PSH                 clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_PT1H                clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_PX11                clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_PT0H                clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_PX0H                clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_PADCH               clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_PBODH               clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_PSH                 clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_PT1H                clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_PX11                clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_PT0H                clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_PX0H                clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/  
+#define set_INTTYP1             set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_INTTYP0             set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_INTSEL2             set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_INTSEL1             set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_INTSEL0             set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_INTTYP1             set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_INTTYP0             set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_INTSEL2             set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_INTSEL1             set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_INTSEL0             set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_PADC                PADC     = 1
+#define set_PBOD                PBOD     = 1
+#define set_PS                  PS       = 1
+#define set_PT1                 PT1      = 1
+#define set_PX1                 PX1      = 1
+#define set_PT0                 PT0      = 1
+#define set_PX0                 PX0      = 1
+                                
+#define clr_PADC                PADC     = 0
+#define clr_PBOD                PBOD     = 0
+#define clr_PS                  PS       = 0
+#define clr_PT1                 PT1      = 0
+#define clr_PX1                 PX1      = 0
+#define clr_PT0                 PT0      = 0
+#define clr_PX0                 PX0      = 0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOCEN             I2TOC|=0x04
+#define set_DIV                 I2TOC|=0x02
+#define set_I2TOF               I2TOC|=0x01
+                                
+#define clr_I2TOCEN             I2TOC&=0xFB
+#define clr_DIV                 I2TOC&=0xFD
+#define clr_I2TOF               I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CEN               I2CEN    = 1
+#define set_STA                 STA      = 1
+#define set_STO                 STO      = 1
+#define set_SI                  SI       = 1
+#define set_AA                  AA       = 1
+#define set_I2CPX               I2CPX    = 1
+
+#define clr_I2CEN               I2CEN    = 0
+#define clr_STA                 STA      = 0
+#define clr_STO                 STO      = 0
+#define clr_SI                  SI       = 0
+#define clr_AA                  AA       = 0
+#define clr_I2CPX               I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_GC                  I2ADDR|=0x01
+#define clr_GC                  I2ADDR&=0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_SMOD_1              clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_SMOD0_1             clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_BRCK                clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_TF3                 clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_TR3                 clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3PS2               clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3PS1               clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3PS0               clr_SFRS_SFRPAGE;T3CON|=0x01
+                                     
+#define clr_SMOD_1              clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_SMOD0_1             clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_BRCK                clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_TF3                 clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_TR3                 clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3PS2               clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3PS1               clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3PS0               clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIO15               set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIO13               set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIO12               set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIO11               set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIO15               set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIO13               set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIO12               set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIO11               set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_TF2                 TF2      = 1
+#define set_TR2                 TR2      = 1
+#define set_CMRL2               CM_RL2   = 1
+                                
+#define clr_TF2                 TF2      = 0
+#define clr_TR2                 TR2      = 0
+#define clr_CMRL2               CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_LDEN                T2MOD|=0x80
+#define set_T2DIV2              T2MOD|=0x40
+#define set_T2DIV1              T2MOD|=0x20
+#define set_T2DIV0              T2MOD|=0x10
+#define set_CAPCR               T2MOD|=0x08
+#define set_CMPCR               T2MOD|=0x04
+#define set_LDTS1               T2MOD|=0x02
+#define set_LDTS0               T2MOD|=0x01
+                                     
+#define clr_LDEN                T2MOD&=0x7F
+#define clr_T2DIV2              T2MOD&=0xBF
+#define clr_T2DIV1              T2MOD&=0xDF
+#define clr_T2DIV0              T2MOD&=0xEF
+#define clr_CAPCR               T2MOD&=0xF7
+#define clr_CMPCR               T2MOD&=0xFB
+#define clr_LDTS1               T2MOD&=0xFD
+#define clr_LDTS0               T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L   CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_CY                   CY  = 1
+#define set_AC                   AC  = 1
+#define set_F0                   F0  = 1 
+#define set_RS1                  RS1 = 1
+#define set_RS0                  RS0 = 1
+#define set_OV                   OV  = 1
+#define set_P                    P   = 1
+                                 
+#define clr_CY                   CY  = 0
+#define clr_AC                   AC  = 0
+#define clr_F0                   F0  = 0 
+#define clr_RS1                  RS1 = 0
+#define clr_RS0                  RS0 = 0
+#define clr_OV                   OV  = 0
+#define clr_P                    P   = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** PNP      D6H ****/
+#define set_PNP5                 PNP|=0x20
+#define set_PNP4                 PNP|=0x10
+#define set_PNP3                 PNP|=0x08
+#define set_PNP2                 PNP|=0x04
+#define set_PNP1                 PNP|=0x02
+#define set_PNP0                 PNP|=0x01
+                                 
+#define clr_PNP5                 PNP&=0xDF
+#define clr_PNP4                 PNP&=0xEF
+#define clr_PNP3                 PNP&=0xF7
+#define clr_PNP2                 PNP&=0xFB
+#define clr_PNP1                 PNP&=0xFD
+#define clr_PNP0                 PNP&=0xFE
+
+/**** FBD    D7H ****/
+#define set_FBF                  FBD|=0x80
+#define set_FBINLS               FBD|=0x40
+#define set_FBD5                 FBD|=0x20
+#define set_FBD4                 FBD|=0x10
+#define set_FBD3                 FBD|=0x08
+#define set_FBD2                 FBD|=0x04
+#define set_FBD1                 FBD|=0x02
+#define set_FBD0                 FBD|=0x01
+                                 
+#define clr_FBF                  FBD&=0x7F
+#define clr_FBINLS               FBD&=0xBF
+#define clr_FBD5                 FBD&=0xDF
+#define clr_FBD4                 FBD&=0xEF
+#define clr_FBD3                 FBD&=0xF7
+#define clr_FBD2                 FBD&=0xFB
+#define clr_FBD1                 FBD&=0xFD
+#define clr_FBD0                 FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMRUN               PWMRUN   = 1
+#define set_LOAD                 LOAD     = 1
+#define set_PWMF                 PWMF     = 1
+#define set_CLRPWM               CLRPWM   = 1
+                                 
+#define clr_PWMRUN               PWMRUN   = 0
+#define clr_LOAD                 LOAD     = 0
+#define clr_PWMF                 PWMF     = 0 
+#define clr_CLRPWM               CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIO05                PIOCON0|=0x20
+#define set_PIO04                PIOCON0|=0x10
+#define set_PIO03                PIOCON0|=0x08
+#define set_PIO02                PIOCON0|=0x04
+#define set_PIO01                PIOCON0|=0x02
+#define set_PIO00                PIOCON0|=0x01
+                                 
+#define clr_PIO05                PIOCON0&=0xDF
+#define clr_PIO04                PIOCON0&=0xEF
+#define clr_PIO03                PIOCON0&=0xF7
+#define clr_PIO02                PIOCON0&=0xFB
+#define clr_PIO01                PIOCON0&=0xFD
+#define clr_PIO00                PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMMOD1              PWMCON1|=0x80
+#define set_PWMMOD0              PWMCON1|=0x40
+#define set_GP                   PWMCON1|=0x20
+#define set_PWMTYP               PWMCON1|=0x10
+#define set_FBINEN               PWMCON1|=0x08
+#define set_PWMDIV2              PWMCON1|=0x04 
+#define set_PWMDIV1              PWMCON1|=0x02
+#define set_PWMDIV0              PWMCON1|=0x01
+                                      
+#define clr_PWMMOD1              PWMCON1&=0x7F
+#define clr_PWMMOD0              PWMCON1&=0xBF
+#define clr_GP                   PWMCON1&=0xDF
+#define clr_PWMTYP               PWMCON1&=0xEF
+#define clr_FBINEN               PWMCON1&=0xF7
+#define clr_PWMDIV2              PWMCON1&=0xFB 
+#define clr_PWMDIV1              PWMCON1&=0xFD
+#define clr_PWMDIV0              PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_STADCPX              ADCCON1|=0x40
+#define set_ETGTYP1              ADCCON1|=0x08
+#define set_ETGTYP0              ADCCON1|=0x04
+#define set_ADCEX                ADCCON1|=0x02
+#define set_ADCEN                ADCCON1|=0x01
+                                 
+#define clr_STADCPX              ADCCON1&=0xBF
+#define clr_ETGTYP1              ADCCON1&=0xF7
+#define clr_ETGTYP0              ADCCON1&=0xFB
+#define clr_ADCEX                ADCCON1&=0xFD
+#define clr_ADCEN                ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/
+#define set_ADFBEN               ADCCON2|=0x80
+#define set_ADCMPOP              ADCCON2|=0x40
+#define set_ADCMPEN              ADCCON2|=0x20
+#define set_ADCMPO               ADCCON2|=0x10
+                                 
+#define clr_ADFBEN               ADCCON2&=0x7F
+#define clr_ADCMPOP              ADCCON2&=0xBF
+#define clr_ADCMPEN              ADCCON2&=0xDF
+#define clr_ADCMPO               ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 1
+#define set_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 1
+#define set_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 1
+#define set_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 1
+#define set_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 1
+#define set_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 1
+#define set_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 1
+#define set_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 1
+                                 
+#define clr_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 0
+#define clr_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 0
+#define clr_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 0
+#define clr_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 0
+#define clr_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 0
+#define clr_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 0
+#define clr_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 0
+#define clr_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 0
+
+/**** PICON  E9H ****/
+#define set_PIT67                PICON|=0x80
+#define set_PIT45                PICON|=0x40
+#define set_PIT3                 PICON|=0x20
+#define set_PIT2                 PICON|=0x10
+#define set_PIT1                 PICON|=0x08
+#define set_PIT0                 PICON|=0x04
+#define set_PIPS1                PICON|=0x02
+#define set_PIPS0                PICON|=0x01
+                                      
+#define clr_PIT67                PICON&=0x7F
+#define clr_PIT45                PICON&=0xBF
+#define clr_PIT3                 PICON&=0xDF
+#define clr_PIT2                 PICON&=0xEF
+#define clr_PIT1                 PICON&=0xF7
+#define clr_PIT0                 PICON&=0xFB
+#define clr_PIPS1                PICON&=0xFD
+#define clr_PIPS0                PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN7               PINEN|=0x80
+#define set_PINEN6               PINEN|=0x40
+#define set_PINEN5               PINEN|=0x20
+#define set_PINEN4               PINEN|=0x10
+#define set_PINEN3               PINEN|=0x08
+#define set_PINEN2               PINEN|=0x04
+#define set_PINEN1               PINEN|=0x02
+#define set_PINEN0               PINEN|=0x01
+                                      
+#define clr_PINEN7               PINEN&=0x7F
+#define clr_PINEN6               PINEN&=0xBF
+#define clr_PINEN5               PINEN&=0xDF
+#define clr_PINEN4               PINEN&=0xEF
+#define clr_PINEN3               PINEN&=0xF7
+#define clr_PINEN2               PINEN&=0xFB
+#define clr_PINEN1               PINEN&=0xFD
+#define clr_PINEN0               PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN7               PIPEN|=0x80
+#define set_PIPEN6               PIPEN|=0x40
+#define set_PIPEN5               PIPEN|=0x20
+#define set_PIPEN4               PIPEN|=0x10
+#define set_PIPEN3               PIPEN|=0x08
+#define set_PIPEN2               PIPEN|=0x04
+#define set_PIPEN1               PIPEN|=0x02
+#define set_PIPEN0               PIPEN|=0x01
+                                      
+#define clr_PIPEN7               PIPEN&=0x7F
+#define clr_PIPEN6               PIPEN&=0xBF
+#define clr_PIPEN5               PIPEN&=0xDF
+#define clr_PIPEN4               PIPEN&=0xEF
+#define clr_PIPEN3               PIPEN&=0xF7
+#define clr_PIPEN2               PIPEN&=0xFB
+#define clr_PIPEN1               PIPEN&=0xFD
+#define clr_PIPEN0               PIPEN&=0xFE
+   
+/**** PIF  ECH ****/
+#define set_PIF7                 PIF|=0x80
+#define set_PIF6                 PIF|=0x40
+#define set_PIF5                 PIF|=0x20
+#define set_PIF4                 PIF|=0x10
+#define set_PIF3                 PIF|=0x08
+#define set_PIF2                 PIF|=0x04
+#define set_PIF1                 PIF|=0x02
+#define set_PIF0                 PIF|=0x01
+                                 
+#define clr_PIF7                 PIF&=0x7F
+#define clr_PIF6                 PIF&=0xBF
+#define clr_PIF5                 PIF&=0xDF
+#define clr_PIF4                 PIF&=0xEF
+#define clr_PIF3                 PIF&=0xF7
+#define clr_PIF2                 PIF&=0xFB
+#define clr_PIF1                 PIF&=0xFD
+#define clr_PIF0                 PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_PT2                  clr_SFRS_SFRPAGE;EIP|=0x80
+#define set_PSPI                 clr_SFRS_SFRPAGE;EIP|=0x40
+#define set_PFB                  clr_SFRS_SFRPAGE;EIP|=0x20
+#define set_PWDT                 clr_SFRS_SFRPAGE;EIP|=0x10
+#define set_PPWM                 clr_SFRS_SFRPAGE;EIP|=0x08
+#define set_PCAP                 clr_SFRS_SFRPAGE;EIP|=0x04
+#define set_PPI                  clr_SFRS_SFRPAGE;EIP|=0x02
+#define set_PI2C                 clr_SFRS_SFRPAGE;EIP|=0x01
+                                    
+#define clr_PT2                  clr_SFRS_SFRPAGE;EIP&=0x7F
+#define clr_PSPI                 clr_SFRS_SFRPAGE;EIP&=0xBF
+#define clr_PFB                  clr_SFRS_SFRPAGE;EIP&=0xDF
+#define clr_PWDT                 clr_SFRS_SFRPAGE;EIP&=0xEF
+#define clr_PPWM                 clr_SFRS_SFRPAGE;EIP&=0xF7
+#define clr_PCAP                 clr_SFRS_SFRPAGE;EIP&=0xFB
+#define clr_PPI                  clr_SFRS_SFRPAGE;EIP&=0xFD
+#define clr_PI2C                 clr_SFRS_SFRPAGE;EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAP13                CAPCON3|=0x80
+#define set_CAP12                CAPCON3|=0x40
+#define set_CAP11                CAPCON3|=0x20
+#define set_CAP10                CAPCON3|=0x10
+#define set_CAP03                CAPCON3|=0x08
+#define set_CAP02                CAPCON3|=0x04
+#define set_CAP01                CAPCON3|=0x02
+#define set_CAP00                CAPCON3|=0x01
+                                 
+#define clr_CAP13                CAPCON3&=0x7F
+#define clr_CAP12                CAPCON3&=0xBF
+#define clr_CAP11                CAPCON3&=0xDF
+#define clr_CAP10                CAPCON3&=0xEF
+#define clr_CAP03                CAPCON3&=0xF7
+#define clr_CAP02                CAPCON3&=0xFB
+#define clr_CAP01                CAPCON3&=0xFD
+#define clr_CAP00                CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAP23                CAPCON4|=0x08
+#define set_CAP22                CAPCON4|=0x04
+#define set_CAP21                CAPCON4|=0x02
+#define set_CAP20                CAPCON4|=0x01
+                                 
+#define clr_CAP23                CAPCON4&=0xF7
+#define clr_CAP22                CAPCON4&=0xFB
+#define clr_CAP21                CAPCON4&=0xFD
+#define clr_CAP20                CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SSOE                 clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPIEN                clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_LSBFE                clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_MSTR                 clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_CPOL                 clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_CPHA                 clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPR1                 clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPR0                 clr_SFRS_SFRPAGE;SPCR|=0x01
+                                 
+#define clr_SSOE                 clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPIEN                clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_LSBFE                clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_MSTR                 clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_CPOL                 clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_CPHA                 clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPR1                 clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPR0                 clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPIS1                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPIS0                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPIS1                set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPIS0                set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPIF                 SPSR|=0x80
+#define set_WCOL                 SPSR|=0x40
+#define set_SPIOVF               SPSR|=0x20
+#define set_MODF                 SPSR|=0x10
+#define set_DISMODF              SPSR|=0x08
+                                     
+#define clr_SPIF                 SPSR&=0x7F
+#define clr_WCOL                 SPSR&=0xBF
+#define clr_SPIOVF               SPSR&=0xDF
+#define clr_MODF                 SPSR&=0xEF
+#define clr_DISMODF              SPSR&=0xF7
+
+/**** SPDR    F5H ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                 
+#define clr_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_PT2H                 clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_PSPIH                clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_PFBH                 clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_PWDTH                clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_PPWMH                clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_PCAPH                clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_PPIH                 clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_PI2CH                clr_SFRS_SFRPAGE;EIPH|=0x01
+                                     
+#define clr_PT2H                 clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_PSPIH                clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_PFBH                 clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_PWDTH                clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_PPWMH                clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_PCAPH                clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_PPIH                 clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_PI2CH                clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_FE_1                 FE_1  = 1
+#define set_SM1_1                SM1_1 = 1
+#define set_SM2_1                SM2_1 = 1
+#define set_REN_1                REN_1 = 1
+#define set_TB8_1                TB8_1 = 1
+#define set_RB8_1                RB8_1 = 1
+#define set_TI_1                 TI_1  = 1
+#define set_RI_1                 RI_1  = 1
+                                 
+#define clr_FE_1                 FE_1  = 0
+#define clr_SM1_1                SM1_1 = 0
+#define clr_SM2_1                SM2_1 = 0
+#define clr_REN_1                REN_1 = 0
+#define clr_TB8_1                TB8_1 = 0
+#define clr_RB8_1                RB8_1 = 0
+#define clr_TI_1                 TI_1  = 0
+#define clr_RI_1                 RI_1  = 0
+
+/**** PDTEN    F9H ****TA Protect ***/
+#define set_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN5                PMEN|=0x20
+#define set_PMEN4                PMEN|=0x10
+#define set_PMEN3                PMEN|=0x08
+#define set_PMEN2                PMEN|=0x04
+#define set_PMEN1                PMEN|=0x02
+#define set_PMEN0                PMEN|=0x01
+                                     
+#define clr_PMEN5                PMEN&=0xDF
+#define clr_PMEN4                PMEN&=0xEF
+#define clr_PMEN3                PMEN&=0xF7
+#define clr_PMEN2                PMEN&=0xFB
+#define clr_PMEN1                PMEN&=0xFD
+#define clr_PMEN0                PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD7                 PMD|=0x80
+#define set_PMD6                 PMD|=0x40
+#define set_PMD5                 PMD|=0x20
+#define set_PMD4                 PMD|=0x10
+#define set_PMD3                 PMD|=0x08
+#define set_PMD2                 PMD|=0x04
+#define set_PMD1                 PMD|=0x02
+#define set_PMD0                 PMD|=0x01
+                                    
+#define clr_PMD7                 PMD&=0x7F
+#define clr_PMD6                 PMD&=0xBF
+#define clr_PMD5                 PMD&=0xDF
+#define clr_PMD4                 PMD&=0xEF
+#define clr_PMD3                 PMD&=0xF7
+#define clr_PMD2                 PMD&=0xFB
+#define clr_PMD1                 PMD&=0xFD
+#define clr_PMD0                 PMD&=0xFE
+
+/****  PORDIS   FDH PAGE0 ****/
+/****  EIP1     FEH PAGE0 ****/                     
+#define set_PWKT                 clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_PT3                  clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_PS_1                 clr_SFRS_SFRPAGE;EIP1|=0x01
+                                     
+#define clr_PWKT                 clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_PT3                  clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_PS_1                 clr_SFRS_SFRPAGE;EIP1&=0xFE
+                                 
+/**** EIPH1    FFH PAGE0 ****/                
+#define set_PWKTH                clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_PT3H                 clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_PSH_1                clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                      
+#define clr_PWKTH                clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_PT3H                 clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_PSH_1                clr_SFRS_SFRPAGE;EIPH1&=0xFE

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/function_define_ms51_32k.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/function_define_ms51_32k.h
@@ -1,0 +1,4081 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------
+ms51_32k Function_define.h
+
+All function define inital setting file for Nuvoton MS51 32K series
+--------------------------------------------------------------------------*/
+#ifdef __CDT_PARSER__         /* For __SDCC__ */
+  #define __data
+  #define __near
+  #define __idata
+  #define __xdata
+  #define __far
+  #define __pdata
+  #define __code
+  #define __bit
+  #define __sfr
+  #define __sbit
+  #define __critical
+  #define __at(x)             /* use "__at (0xab)" instead of "__at 0xab" */
+  #define __using(x)
+  #define __interrupt(x)
+  #define __naked
+#endif
+
+typedef unsigned char         UINT8;
+typedef unsigned int          UINT16;
+typedef unsigned long         UINT32;
+typedef signed char           INT8;
+typedef signed int            INT16;
+typedef signed long           INT32;
+
+#if defined __C51__
+typedef bit                   BIT;
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+
+#elif defined __ICC8051__
+#define BIT __no_init bool __bit
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+
+#elif defined __SDCC__
+typedef __bit                 BIT;
+
+#endif
+
+
+#define Disable  0
+#define Enable   1
+
+#define DISABLE  0
+#define ENABLE   1 
+
+#define TRUE     1  
+#define FALSE    0  
+                    
+#define FAIL     1  
+#define PASS     0  
+                  
+//16 --> 8 x 2
+#define HIBYTE(v1)              ((UINT8)((v1)>>8))                      //v1 is UINT16
+#define LOBYTE(v1)              ((UINT8)((v1)&0xFF))
+//8 x 2 --> 16
+#define MAKEWORD(v1,v2)         ((((UINT16)(v1))<<8)+(UINT16)(v2))      //v1,v2 is UINT8
+//8 x 4 --> 32
+#define MAKELONG(v1,v2,v3,v4)   (UINT32)((v1<<32)+(v2<<16)+(v3<<8)+v4)  //v1,v2,v3,v4 is UINT8
+//32 --> 16 x 2
+#define YBYTE1(v1)              ((UINT16)((v1)>>16))                    //v1 is UINT32
+#define YBYTE0(v1)              ((UINT16)((v1)&0xFFFF))
+//32 --> 8 x 4
+#define TBYTE3(v1)              ((UINT8)((v1)>>24))                     //v1 is UINT32
+#define TBYTE2(v1)              ((UINT8)((v1)>>16))
+#define TBYTE1(v1)              ((UINT8)((v1)>>8)) 
+#define TBYTE0(v1)              ((UINT8)((v1)&0xFF))
+
+#define SET_BIT0        0x01
+#define SET_BIT1        0x02
+#define SET_BIT2        0x04
+#define SET_BIT3        0x08
+#define SET_BIT4        0x10
+#define SET_BIT5        0x20
+#define SET_BIT6        0x40
+#define SET_BIT7        0x80
+
+#define CLR_BIT0        0xFE
+#define CLR_BIT1        0xFD
+#define CLR_BIT2        0xFB
+#define CLR_BIT3        0xF7
+#define CLR_BIT4        0xEF
+#define CLR_BIT5        0xDF
+#define CLR_BIT6        0xBF
+#define CLR_BIT7        0x7F
+
+/*****************************************************************************/
+/*   Stack and NOP                                                           */
+/*****************************************************************************/
+#if defined __C51__
+#define   nop                                  _nop_()
+#define   CALL_NOP                             _nop_()
+#define   PUSH_SFRS                            _push_(SFRS)
+#define   POP_SFRS                             _pop_(SFRS)
+
+#elif defined __ICC8051__
+
+#define _nop_()                                asm("nop")
+#define nop                                    asm("nop")
+#define CALL_NOP                               asm("nop")
+#define PUSH_SFRS                              asm(" PUSH 0x91")
+#define POP_SFRS                               asm(" POP 0x91")
+#define _push_(SFRS)                           asm(" PUSH 0x91")
+#define _pop_(SFRS)                            asm(" POP 0x91")
+
+#elif defined __SDCC__
+#define _nop_()                                __asm__("nop;")
+#define nop                                    __asm__("nop;")
+#define CALL_NOP                               __asm__("nop;")
+#define PUSH_SFRS                              __asm__(" PUSH 0x91;")
+#define POP_SFRS                               __asm__(" POP 0x91;")
+#define _push_(SFRS)                           __asm__(" PUSH 0x91;")
+#define _pop_(SFRS)                            __asm__(" POP 0x91;")
+#endif
+
+/*****************************************************************************/
+/*    IAP function process                                                   */
+/*****************************************************************************/
+#define    PAGE_SIZE               128
+
+#define    READ_CID                0x0B
+#define    READ_DID                0x0C
+#define    READ_UID                0x04
+
+#define    PAGE_ERASE_APROM        0x22
+#define    BYTE_READ_APROM         0x00
+#define    BYTE_PROGRAM_APROM      0x21
+
+#define    PAGE_ERASE_LDROM        0x62
+#define    BYTE_READ_LDROM         0x40
+#define    BYTE_PROGRAM_LDROM      0x61
+
+#define    ENABLE_SPROM            set_IAPUEN_SPMEN
+#define    PAGE_ERASE_SPROM        0xA2
+#define    BYTE_READ_SPROM         0x80
+#define    BYTE_PROGRAM_SPROM      0xA1
+
+#define    PAGE_ERASE_CONFIG       0xE2
+#define    BYTE_READ_CONFIG        0xC0
+#define    BYTE_PROGRAM_CONFIG     0xE1
+
+#define    CID_READ                0x0B
+#define    DID_READ                0x0C
+
+/*****************************************************************************/
+/*   Software reset                                                          */
+/*****************************************************************************/
+#define    ENABLE_SOFTWARE_RESET_TO_APROM      clr_CHPCON_BS;set_CHPCON_SWRST
+#define    ENABLE_SOFTWARE_RESET_TO_LDROM      set_CHPCON_BS;set_CHPCON_SWRST
+
+/*****************************************************************************/
+/*   Power down / idle mode define                                           */
+/*****************************************************************************/
+#define    ENABLE_POWERDOWN_MODE               set_PCON_PD
+#define    ENABLE_IDLE_MODE                    set_PCON_IDLE
+
+/*****************************************************************************/
+/*   BOD Define                                                              */
+/*****************************************************************************/
+#define    BOD_ENABLE               BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    BOD_RESET_ENABLE         BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    BOD_DISABLE              BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+ 
+/****/
+#define    ENABLE_BOD               BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    ENABLE_BOD_RESET         BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    DISABLE_BOD              BIT_TMP=EA;EA=0;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+
+
+ /*****************************************************************************************/
+/* Interrupt function process */
+/*****************************************************************************************/
+#define    ENABLE_GLOBAL_INTERRUPT       EA=1            //Check
+#define    DISABLE_GLOBAL_INTERRUPT      EA=0
+/*ENABLE INTERRUPT*/
+#define    ENABLE_ADC_INTERRUPT          set_IE_EADC
+#define    ENABLE_BOD_INTERRUPT          set_IE_EBOD
+#define    ENABLE_UART0_INTERRUPT        set_IE_ES
+#define    ENABLE_TIMER1_INTERRUPT       set_IE_ET1
+#define    ENABLE_INT1_INTERRUPT         set_IE_EX1
+#define    ENABLE_TIMER0_INTERRUPT       set_IE_ET0
+#define    ENABLE_INT0_INTERRUPT         set_IE_EX0
+                                         
+#define    ENABLE_TIMER2_INTERRUPT       set_EIE_ET2
+#define    ENABLE_SPI0_INTERRUPT         set_EIE_ESPI
+#define    ENABLE_PWM0_FB_INTERRUPT      set_EIE_EFB
+#define    ENABLE_WDT_INTERRUPT          set_EIE_EWDT
+#define    ENABLE_PWM0_INTERRUPT         set_EIE_EPWM0
+#define    ENABLE_CAPTURE_INTERRUPT      set_EIE_ECAP
+#define    ENABLE_PIN_INTERRUPT          set_EIE_EPI
+#define    ENABLE_I2C_INTERRUPT          set_EIE_EI2C
+                                         
+#define    ENABLE_PWM3_INTERRUPT         set_EIE1_EPWM3
+#define    ENABLE_PWM2_INTERRUPT         set_EIE1_EPWM2
+#define    ENABLE_PWM1_INTERRUPT         set_EIE1_EPWM1
+#define    ENABLE_WKT_INTERRUPT          set_EIE1_EWKT
+#define    ENABLE_TIMER3_INTERRUPT       set_EIE1_ET3
+#define    ENABLE_UART1_INTERRUPT        set_EIE1_ES_1 
+
+#define    ENABLE_SC0_AUTO_CONVENTION_ERROR_INTERRUPT    set_SC0IE_ACERRIEN
+#define    ENABLE_SC0_BLOCK_GUARD_TIMER_INTERRUPT        set_SC0IE_BGTIEN
+#define    ENABLE_SC0_TRANSFER_ERROR_INTERRUPT           set_SC0IE_TERRIEN
+#define    ENABLE_SC0_TRASMIT_BUFFER_EMPTY_INTERRUPT     set_SC0IE_TBEIEN
+#define    ENABLE_SC0_RECEIVE_DATA_REACH_INTERRUPT       set_SC0IE_RDAIEN
+
+#define    ENABLE_SC1_AUTO_CONVENTION_ERROR_INTERRUPT    set_SC1IE_ACERRIEN
+#define    ENABLE_SC1_BLOCK_GUARD_TIMER_INTERRUPT        set_SC1IE_BGTIEN
+#define    ENABLE_SC1_TRANSFER_ERROR_INTERRUPT           set_SC1IE_TERRIEN
+#define    ENABLE_SC1_TRASMIT_BUFFER_EMPTY_INTERRUPT     set_SC1IE_TBEIEN
+#define    ENABLE_SC1_RECEIVE_DATA_REACH_INTERRUPT       set_SC1IE_RDAIEN
+
+#define    ENABLE_SC2_AUTO_CONVENTION_ERROR_INTERRUPT    set_SC2IE_ACERRIEN
+#define    ENABLE_SC2_BLOCK_GUARD_TIMER_INTERRUPT        set_SC2IE_BGTIEN
+#define    ENABLE_SC2_TRANSFER_ERROR_INTERRUPT           set_SC2IE_TERRIEN
+#define    ENABLE_SC2_TRASMIT_BUFFER_EMPTY_INTERRUPT     set_SC2IE_TBEIEN
+#define    ENABLE_SC2_RECEIVE_DATA_REACH_INTERRUPT       set_SC2IE_RDAIEN
+
+/*Disable Interrupt*/ 
+#define    DISABLE_ADC_INTERRUPT         clr_IE_EADC
+#define    DISABLE_BOD_INTERRUPT         clr_IE_EBOD
+#define    DISABLE_UART0_INTERRUPT       clr_IE_ES
+#define    DISABLE_TIMER1_INTERRUPT      clr_IE_ET1 
+#define    DISABLE_INT1_INTERRUPT        clr_IE_EX1 
+#define    DISABLE_TIMER0_INTERRUPT      clr_IE_ET0 
+#define    DISABLE_INT0_INTERRUPT        clr_IE_EX0
+
+#define    DISABLE_TIMER2_INTERRUPT      clr_EIE_ET2
+#define    DISABLE_SPI0_INTERRUPT        clr_EIE_ESPI
+#define    DISABLE_PWM0_FB_INTERRUPT     clr_EIE_EFB
+#define    DISABLE_WDT_INTERRUPT         clr_EIE_EWDT
+#define    DISABLE_PWM0_INTERRUPT        clr_EIE_EPWM0
+#define    DISABLE_CAPTURE_INTERRUPT     clr_EIE_ECAP
+#define    DISABLE_PIN_INTERRUPT         clr_EIE_EPI
+#define    DISABLE_I2C_INTERRUPT         clr_EIE_EI2C
+          
+#define    DISABLE_PWM3_INTERRUPT        clr_EIE1_EPWM3
+#define    DISABLE_PWM2_INTERRUPT        clr_EIE1_EPWM2
+#define    DISABLE_PWM1_INTERRUPT        clr_EIE1_EPWM1
+#define    DISABLE_WKT_INTERRUPT         clr_EIE1_EWKT 
+#define    DISABLE_TIMER3_INTERRUPT      clr_EIE1_ET3
+#define    DISABLE_UART1_INTERRUPT       clr_EIE1_ES_1 
+
+#define    DISABLE_SC0_AUTO_CONVENTION_ERROR_INTERRUPT    clr_SC0IE_ACERRIEN
+#define    DISABLE_SC0_BLOCK_GUARD_TIMER_INTERRUPT        clr_SC0IE_BGTIEN
+#define    DISABLE_SC0_TRANSFER_ERROR_INTERRUPT           clr_SC0IE_TERRIEN
+#define    DISABLE_SC0_TRASMIT_BUFFER_EMPTY_INTERRUPT     clr_SC0IE_TBEIEN
+#define    DISABLE_SC0_RECEIVE_DATA_REACH_INTERRUPT       clr_SC0IE_RDAIEN
+
+#define    DISABLE_SC1_AUTO_CONVENTION_ERROR_INTERRUPT    clr_SC1IE_ACERRIEN
+#define    DISABLE_SC1_BLOCK_GUARD_TIMER_INTERRUPT        clr_SC1IE_BGTIEN
+#define    DISABLE_SC1_TRANSFER_ERROR_INTERRUPT           clr_SC1IE_TERRIEN
+#define    DISABLE_SC1_TRASMIT_BUFFER_EMPTY_INTERRUPT     clr_SC1IE_TBEIEN
+#define    DISABLE_SC1_RECEIVE_DATA_REACH_INTERRUPT       clr_SC1IE_RDAIEN
+
+#define    DISABLE_SC2_AUTO_CONVENTION_ERROR_INTERRUPT    clr_SC2IE_ACERRIEN
+#define    DISABLE_SC2_BLOCK_GUARD_TIMER_INTERRUPT        clr_SC2IE_BGTIEN
+#define    DISABLE_SC2_TRANSFER_ERROR_INTERRUPT           clr_SC2IE_TERRIEN
+#define    DISABLE_SC2_TRASMIT_BUFFER_EMPTY_INTERRUPT     clr_SC2IE_TBEIEN
+#define    DISABLE_SC2_RECEIVE_DATA_REACH_INTERRUPT       clr_SC2IE_RDAIEN
+
+/* Setting Interrupt Priority */
+#define   SET_INT_INT0_LEVEL0          clr_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL1          clr_IP_PX0; set_IPH_PX0H
+#define   SET_INT_INT0_LEVEL2          set_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL3          set_IP_PX0; set_IPH_PX0H
+
+#define   SET_INT_BOD_LEVEL0           clr_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL1           clr_IP_PBOD; set_IPH_PBODH
+#define   SET_INT_BOD_LEVEL2           set_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL3           set_IP_PBOD; set_IPH_PBODH
+
+#define   SET_INT_WDT_LEVEL0           clr_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL1           clr_EIP_PWDT; set_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL2           set_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL3           set_EIP_PWDT; set_EIPH_PWDTH
+
+#define   SET_INT_TIMER0_LEVEL0        clr_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL1        clr_IP_PT0; set_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL2        set_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL3        set_IP_PT0; set_IPH_PT0H
+
+#define   SET_INT_I2C0_LEVEL0          clr_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL1          clr_EIP_PI2C; set_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL2          set_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL3          set_EIP_PI2C; set_EIPH_PI2CH
+
+#define   SET_INT_ADC_LEVEL0           clr_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL1           clr_IP_PADC; set_IPH_PADCH
+#define   SET_INT_ADC_LEVEL2           set_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL3           set_IP_PADC; set_IPH_PADCH
+
+#define   SET_INT_INT1_LEVEL0          clr_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL1          clr_IP_PX1; set_IPH_PX1H
+#define   SET_INT_INT1_LEVEL2          set_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL3          set_IP_PX1; set_IPH_PX1H
+
+#define   SET_INT_PIT_LEVEL0           clr_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL1           clr_EIP_PPI; set_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL2           set_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL3           set_EIP_PPI; set_EIPH_PPIH
+
+#define   SET_INT_Timer1_LEVEL0        clr_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL1        clr_IP_PT1; set_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL2        set_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL3        set_IP_PT1; set_IPH_PT1H
+
+#define   SET_INT_UART0_LEVEL0         clr_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL1         clr_IP_PS; set_IPH_PSH
+#define   SET_INT_UART0_LEVEL2         set_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL3         set_IP_PS; set_IPH_PSH
+
+#define   SET_INT_PWM0_BRAKE_LEVEL0    clr_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL1    clr_EIP_PFB; set_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL2    set_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL3    set_EIP_PFB; set_EIPH_PFBH
+
+#define   SET_INT_SPI_LEVEL0           clr_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL1           clr_EIP_PSPI; set_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL2           set_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL3           set_EIP_PSPI; set_EIPH_PSPIH
+
+#define   SET_INT_Timer2_LEVEL0        clr_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL1        clr_EIP_PT2; set_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL2        set_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL3        set_EIP_PT2; set_EIPH_PT2H
+
+#define   SET_INT_CAPTURE_LEVEL0       clr_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL1       clr_EIP_PCAP; set_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL2       set_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL3       set_EIP_PCAP; set_EIPH_PCAPH
+
+#define   SET_INT_PWM_LEVEL0           clr_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL1           clr_EIP_PPWM; set_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL2           set_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL3           set_EIP_PPWM; set_EIPH_PPWMH
+
+#define   SET_INT_UART1_LEVEL0         clr_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL1         clr_EIP1_PS_1; set_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL2         set_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL3         set_EIP1_PS_1; set_EIPH1_PSH_1
+
+#define   SET_INT_Timer3_LEVEL0        clr_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL1        clr_EIP1_PT3; set_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL2        set_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL3        set_EIP1_PT3; set_EIPH1_PT3H
+
+#define   SET_INT_WKT_LEVEL0           clr_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL1           clr_EIP1_PWKT; set_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL2           set_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL3           set_EIP1_PWKT; set_EIPH1_PWKTH
+
+#define   SET_INT_PWM1_LEVEL0          clr_EIP1_PPWM1; clr_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL1          clr_EIP1_PPWM1; set_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL2          set_EIP1_PPWM1; clr_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL3          set_EIP1_PPWM1; set_EIPH1_PPWM1H
+
+#define   SET_INT_PWM2_LEVEL0          clr_EIP1_PPWM2; clr_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL1          clr_EIP1_PPWM2; set_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL2          set_EIP1_PPWM2; clr_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL3          set_EIP1_PPWM2; set_EIPH1_PPWM2H
+
+#define   SET_INT_PWM3_LEVEL0          clr_EIP1_PPWM3; clr_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL1          clr_EIP1_PPWM3; set_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL2          set_EIP1_PPWM3; clr_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL3          set_EIP1_PPWM3; set_EIPH1_PPWM3H
+
+#define   SET_INT_SMC0_LEVEL0          clr_EIP2_PSC0; clr_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL1          clr_EIP2_PSC0; set_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL2          set_EIP2_PSC0; clr_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL3          set_EIP2_PSC0; set_EIPH2_PSC0H
+ 
+#define   SET_INT_SMC1_LEVEL0          clr_EIP2_PSC1; clr_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL1          clr_EIP2_PSC1; set_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL2          set_EIP2_PSC1; clr_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL3          set_EIP2_PSC1; set_EIPH2_PSC1H
+
+#define   SET_INT_SMC2_LEVEL0          clr_EIP2_PSC2; clr_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL1          clr_EIP2_PSC2; set_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL2          set_EIP2_PSC2; clr_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL3          set_EIP2_PSC2; set_EIPH2_PSC2H
+
+#define   SET_INT_PWM1_LEVEL0          clr_EIP1_PPWM1; clr_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL1          clr_EIP1_PPWM1; set_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL2          set_EIP1_PPWM1; clr_EIPH1_PPWM1H
+#define   SET_INT_PWM1_LEVEL3          set_EIP1_PPWM1; set_EIPH1_PPWM1H
+
+#define   SET_INT_PWM2_LEVEL0          clr_EIP1_PPWM2; clr_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL1          clr_EIP1_PPWM2; set_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL2          set_EIP1_PPWM2; clr_EIPH1_PPWM2H
+#define   SET_INT_PWM2_LEVEL3          set_EIP1_PPWM2; set_EIPH1_PPWM2H
+
+#define   SET_INT_PWM3_LEVEL0          clr_EIP1_PPWM3; clr_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL1          clr_EIP1_PPWM3; set_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL2          set_EIP1_PPWM3; clr_EIPH1_PPWM3H
+#define   SET_INT_PWM3_LEVEL3          set_EIP1_PPWM3; set_EIPH1_PPWM3H
+
+#define   SET_INT_SMC0_LEVEL0          clr_EIP2_PSC0; clr_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL1          clr_EIP2_PSC0; set_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL2          set_EIP2_PSC0; clr_EIPH2_PSC0H
+#define   SET_INT_SMC0_LEVEL3          set_EIP2_PSC0; set_EIPH2_PSC0H
+ 
+#define   SET_INT_SMC1_LEVEL0          clr_EIP2_PSC1; clr_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL1          clr_EIP2_PSC1; set_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL2          set_EIP2_PSC1; clr_EIPH2_PSC1H
+#define   SET_INT_SMC1_LEVEL3          set_EIP2_PSC1; set_EIPH2_PSC1H
+
+#define   SET_INT_SMC2_LEVEL0          clr_EIP2_PSC2; clr_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL1          clr_EIP2_PSC2; set_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL2          set_EIP2_PSC2; clr_EIPH2_PSC2H
+#define   SET_INT_SMC2_LEVEL3          set_EIP2_PSC2; set_EIPH2_PSC2H
+
+/* Clear Interrupt Flag */
+#define    CLEAR_ADC_INTERRUPT_FLAG          clr_ADCCON0_ADCF
+#define    CLEAR_BOD_INTERRUPT_FLAG          clr_BODCON0_BOF
+#define    CLEAR_BOD_RESET_FLAG              clr_BODCON0_BORF
+#define    CLEAR_UART0_INTERRUPT_TX_FLAG     clr_SCON_TI
+#define    CLEAR_UART0_INTERRUPT_RX_FLAG     clr_SCON_RI
+#define    CLEAR_TIMER1_INTERRUPT_FLAG       clr_TCON_TF1
+#define    CLEAR_INT1_INTERRUPT_FLAG         clr_TCON_IE1
+#define    CLEAR_TIMER0_INTERRUPT_FLAG       clr_TCON_TF0
+#define    CLEAR_INT0_INTERRUPT_FLAG         clr_TCON_IE0
+#define    CLEAR_TIMER2_INTERRUPT_FLAG       clr_T2CON_TF2
+#define    CLEAR_SPI0_INTERRUPT_FLAG         clr_SPSR_SPIF
+#define    CLEAR_PWM0_FB_INTERRUPT_FLAG      clr_PWM0FBD_FBF
+#define    CLEAR_WDT_INTERRUPT_FLAG          clr_WDCON_WDTF
+#define    CLEAR_PWM0_INTERRUPT_FLAG         clr_PWM1CON0_PWMF
+#define    CLEAR_CAPTURE_INTERRUPT_IC0_FLAG  clr_CAPCON0_CAPF0
+#define    CLEAR_CAPTURE_INTERRUPT_IC1_FLAG  clr_CAPCON0_CAPF1
+#define    CLEAR_CAPTURE_INTERRUPT_IC2_FLAG  clr_CAPCON0_CAPF2
+#define    CLEAR_PIN_INTERRUPT_PIT0_FLAG     clr_PIF_PIF0
+#define    CLEAR_PIN_INTERRUPT_PIT1_FLAG     clr_PIF_PIF1
+#define    CLEAR_PIN_INTERRUPT_PIT2_FLAG     clr_PIF_PIF2
+#define    CLEAR_PIN_INTERRUPT_PIT3_FLAG     clr_PIF_PIF3
+#define    CLEAR_PIN_INTERRUPT_PIT4_FLAG     clr_PIF_PIF4
+#define    CLEAR_PIN_INTERRUPT_PIT5_FLAG     clr_PIF_PIF5
+#define    CLEAR_PIN_INTERRUPT_PIT6_FLAG     clr_PIF_PIF6
+#define    CLEAR_PIN_INTERRUPT_PIT7_FLAG     clr_PIF_PIF7
+#define    CLEAR_I2C_TIMEOUT_INTERRUPT_FLAG  clr_I2TOC_I2TOF
+#define    CLEAR_PWM3_INTERRUPT_FLAG         clr_PWM3CON0_PWMF
+#define    CLEAR_PWM2_INTERRUPT_FLAG         clr_PWM2CON0_PWMF
+#define    CLEAR_PWM1_INTERRUPT_FLAG         clr_PWM1CON0_PWMF
+#define    CLEAR_WKT_INTERRUPT_FLAG          clr_WKCON_WKTF
+#define    CLEAR_TIMER3_INTERRUPT_FLAG       clr_T3CON_TF3
+#define    CLEAR_UART1_INTERRUPT_FLAG        clr_EIE1_ES_1 
+
+/* ------------------------ TIMER Value define  ------------------------- */
+/* setting is base on " option -> C51 -> Preprocesser Symbols -> Define "  */
+
+/* define timer base value Fsys = 8MHz  */
+/* @note    Since 8M instruction and calculate speed limitaion. the timer counter value should be less than actullay. */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_7372800      65536-614        /* 614*12    /7372800= 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_7372800     65536-6144       /* 6144*12   /7372800= 10 mS   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_50ms_FOSC_7372800     65536-30720      /* 30720*12  /7372800= 40 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_7372800     65536-368        /* 368*4     /7372800= 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_7372800     65536-922        /* 922*4     /7372800= 500 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_7372800       65536-1843       /* 1843*4    /7372800= 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_10ms_FOSC_7372800      65536-18432      /* 18432*4   /7372800= 10 mS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV16_VALUE_10ms_FOSC_7372800     65536-4608       /* 4608*16   /7372800= 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_7372800     65536-3456       /* 3456*64   /7372800= 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_1ms_FOSC_7372800     65536-57         /* 57*128    /7372800= 1 ms    (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_10ms_FOSC_7372800    65536-576        /* 576*128   /7372800= 10 ms   (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_7372800   65536-5760       /* 5760*128  /7372800= 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_7372800   65536-11520      /* 11520*128 /7372800= 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_7372800   65536-14400      /* 14400*256 /7372800= 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_100ms_FOSC_7372800   65536-1440       /* 1440*512  /7372800= 100ms.  (Timer Divider = 512 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_7372800      65536-14400      /* 14400*512 /7372800= 1 s.    (Timer Divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 8MHz  */
+/* @note    Since 8M instruction and calculate speed limitaion. the timer counter value should be less than actullay. */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_8000000      65536-667        /* 667*12    /8000000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_8000000     65536-6667       /* 6667*12   /8000000 = 10 mS   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_50ms_FOSC_8000000     65536-33335      /* 33335*12  /8000000 = 40 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_8000000     65536-400        /* 400*4     /8000000 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_8000000     65536-1000       /* 1000*4    /8000000 = 500 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_8000000       65536-2000       /* 2000*4    /8000000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_10ms_FOSC_8000000      65536-20000      /* 20000*4   /8000000 = 10 mS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV16_VALUE_10ms_FOSC_8000000     65536-5000       /* 5000*16   /8000000 = 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_8000000     65536-3750       /* 3750*64   /8000000 = 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_1ms_FOSC_8000000     65536-60         /* 62*128    /8000000 = 1 ms    (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_10ms_FOSC_8000000    65536-625        /* 625*128   /8000000 = 10 ms   (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_8000000   65536-6250       /* 6250*128  /8000000 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_8000000   65536-12500      /* 12500*128 /8000000 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_8000000   65536-15625      /* 15625*256 /8000000 = 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_100ms_FOSC_8000000   65536-1562       /* 1562*512  /8000000 = 100ms.  (Timer Divider = 512 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_8000000      65536-15625      /* 15625*512 /8000000 = 1 s.    (Timer Divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 11.0592MHz  */
+#define    TIMER_DIV12_VALUE_10us_FOSC_11059200    65536-9          /* 9*12      /11059200 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_11059200     65536-923        /* 923*12    /11059200 = 1 mS    (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_11059200    65536-9216       /* 18432*12  /11059200 = 10 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_11059200     65536-28         /* 28*4      /11059200 = 10 uS   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_11059200      65536-2765       /* 2765*4    /11059200 = 1 mS    (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_100us_FOSC_11059200    65536-277        /* 553*4     /11059200 = 100 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_11059200    65536-553        /* 1106*4    /11059200 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_11059200    65536-1383       /* 2765*4    /11059200 = 500 us  (Timer divider = 4   for TM2/TM3) */  
+#define    TIMER_DIV16_VALUE_10ms_FOSC_11059200    65536-6912       /* 1500*16   /11059200 = 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_11059200    65536-5184       /* 10368*64  /11059200 = 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_11059200  65536-8640       /* 17280*128 /11059200 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_11059200  65536-17280      /* 34560*128 /11059200 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_11059200  65536-21600      /* 43200*256 /11059200 = 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_11059200     65536-21600      /* 43200*512 /11059200 = 1 s     (Timer divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 16MHz */
+#define    TIMER_DIV12_VALUE_10us_FOSC_16000000    65536-8          /* 13*12     /16000000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_100us_FOSC_16000000   65536-130        /* 130*12    /16000000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_16000000     65536-1334       /* 1334*12   /16000000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_16000000    65536-13334      /* 13334*12  /16000000 = 10 mS   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_40ms_FOSC_16000000    65536-53336      /* 53336*12  /16000000 = 40 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_16000000     65536-30         /* 40*4      /16000000 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_100us_FOSC_16000000    65536-400        /* 400*4     /16000000 = 100 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_16000000    65536-800        /* 800*4     /16000000 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_16000000    65536-2000       /* 2000*4    /16000000 = 500 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_16000000      65536-4000       /* 4000*4    /16000000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_10ms_FOSC_16000000     65536-40000      /* 40000*4   /16000000 = 10 mS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV16_VALUE_10ms_FOSC_16000000    65536-10000      /* 10000*16  /16000000 = 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_16000000    65536-7500       /* 7500*64   /16000000 = 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_1ms_FOSC_16000000    65536-125        /* 125*128   /16000000 = 1 ms    (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_10ms_FOSC_16000000   65536-1250       /* 1250*128  /16000000 = 10 ms   (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_16000000  65536-12500      /* 12500*128 /16000000 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_16000000  65536-25000      /* 25000*128 /16000000 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_16000000  65536-31250      /* 31250*256 /16000000 = 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_100ms_FOSC_16000000  65536-3125       /* 3125*512  /16000000 = 100ms.  (Timer divider = 512 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_16000000     65536-31250      /* 31250*512 /16000000 = 1 s.    (Timer divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 16.6MHz */
+#define    TIMER_DIV12_VALUE_10us_FOSC_16600000      65536-14       /* 14*12     /16600000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_100us_FOSC_16600000     65536-138      /* 138*12    /16600000 = 100 uS, (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_16600000       65536-1384     /* 1384*12   /16600000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_16600000      65536-13834    /* 13834*12  /16600000 = 10 mS   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_40ms_FOSC_16600000      65536-55333    /* 55333*12  /16600000 = 40 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_16600000       65536-41       /* 41*4      /16600000 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_100us_FOSC_16600000      65536-415      /* 415*4     /16600000 = 100 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_16600000      65536-830      /* 830*4     /16600000 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_16600000      65536-2075     /* 2075*4    /16600000 = 500 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_16600000        65536-4150     /* 4150*4    /16600000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV16_VALUE_10ms_FOSC_16600000      65536-10375    /* 10375*16  /16600000 = 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_16600000      65536-7781     /* 7781*64   /16600000 = 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_16600000    65536-12969    /* 12969*128 /16600000 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_16600000    65536-25937    /* 25937*128 /16600000 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_16600000    65536-32422    /* 32422*256 /16600000 = 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_16600000       65536-32421    /* 32421*512 /16600000 = 1 s.    (Timer divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 18.432MHz */
+#define    TIMER_DIV12_VALUE_10us_FOSC_18432000      65536-15       /* 15*12      /18432000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_18432000       65536-1536     /* 1536*12    /18432000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_18432000       65536-46       /* 46*4       /18432000 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_18432000        65536-4608     /* 4608*4     /18432000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+/* define timer base value Fsys = 20 MHz*/
+#define    TIMER_DIV12_VALUE_10us_FOSC_20000000      65536-17       /* 17*12      /20000000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_20000000       65536-1667     /* 1667*12    /20000000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_20000000       65536-50       /* 50*4       /20000000 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_20000000        65536-5000     /* 5000*4     /20000000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+/* define timer base value Fsys = 22.1184 MHz  */
+#define    TIMER_DIV12_VALUE_10us_FOSC_22118400      65536-18       /* 18*12      /22118400 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_100us_FOSC_22118400     65536-184      /* 184*12     /22118400 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_22118400       65536-1843     /* 1843*12    /22118400 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_22118400      65536-18432    /* 18432*12   /22118400 = 10 ms   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_22118400       65536-56       /* 9*4        /22118400 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_22118400        65536-5530     /* 923*4      /22118400 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_100us_FOSC_22118400      65536-553      /* 553*4      /22118400 = 100 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_22118400      65536-1106     /* 1106*4     /22118400 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_22118400      65536-2765     /* 2765*4     /22118400 = 500 us  (Timer divider = 4   for TM2/TM3) */    
+#define    TIMER_DIV16_VALUE_10ms_FOSC_22118400      65536-13824    /* 1500*16    /22118400 = 10 ms   (Timer divider = 16  for TM2/TM3) */
+#define    TIMER_DIV64_VALUE_30ms_FOSC_22118400      65536-10368    /* 10368*64   /22118400 = 30 ms   (Timer divider = 64  for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_22118400    65536-17280    /* 17280*128  /22118400 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_22118400    65536-34560    /* 34560*128  /22118400 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_22118400    65536-43200    /* 43200*256  /22118400 = 500 ms  (Timer divider = 256 for TM2/TM3) */
+#define    TIMER_DIV512_VALUE_1s_FOSC_22118400       65536-43200    /* 43200*512  /22118400 = 1 s     (Timer divider = 512 for TM2/TM3) */
+/* define timer base value Fsys = 24 MHz*/
+#define    TIMER_DIV12_VALUE_10us_FOSC_24000000      65536-20       /* 20*12      /24000000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_100us_FOSC_24000000     65536-200      /* 130*12     /16000000 = 10 uS,  (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_1ms_FOSC_24000000       65536-2000     /* 2000*12    /24000000 = 1 mS,   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV12_VALUE_10ms_FOSC_24000000      65536-20000    /* 2000*12    /24000000 = 10 mS   (Timer divider = 12  for TM0/TM1) */
+#define    TIMER_DIV4_VALUE_10us_FOSC_24000000       65536-60       /* 60*4       /24000000 = 10 uS,  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_100us_FOSC_24000000      65536-600      /* 600*4      /24000000 = 100 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_200us_FOSC_24000000      65536-1200     /* 1200*4     /24000000 = 200 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_500us_FOSC_24000000      65536-3000     /* 3000*4     /24000000 = 500 us  (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_1ms_FOSC_24000000        65536-6000     /* 6000*4     /24000000 = 1 mS,   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV4_VALUE_10ms_FOSC_24000000       65536-60000    /* 60000*4    /24000000 = 10 ms   (Timer divider = 4   for TM2/TM3) */
+#define    TIMER_DIV16_VALUE_10ms_FOSC_24000000      65536-15000    /* 15000*16   /24000000 = 10 ms   (Timer divider = 16  for TM2/TM3) */ 
+#define    TIMER_DIV64_VALUE_30ms_FOSC_24000000      65536-11250    /* 11250*64   /24000000 = 30 ms   (Timer divider = 64  for TM2/TM3) */ 
+#define    TIMER_DIV128_VALUE_1ms_FOSC_24000000      65536-187      /* 187*128    /24000000 = 1 ms    (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_10ms_FOSC_24000000     65536-1875     /* 1875*128   /24000000 = 10 ms   (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_100ms_FOSC_24000000    65536-18750    /* 18750*128  /24000000 = 100 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV128_VALUE_200ms_FOSC_24000000    65536-37500    /* 37500*128  /24000000 = 200 ms  (Timer divider = 128 for TM2/TM3) */
+#define    TIMER_DIV256_VALUE_500ms_FOSC_24000000    65536-46875    /* 46875*256  /24000000 = 500 ms  (Timer divider = 256 for TM2/TM3) */ 
+#define    TIMER_DIV512_VALUE_10ms_FOSC_24000000     65536-468      /* 468*512    /24000000 = 100 ms  (Timer divider = 512 for TM2/TM3) */ 
+#define    TIMER_DIV512_VALUE_100ms_FOSC_24000000    65536-4687     /* 4687*512   /24000000 = 100 ms  (Timer divider = 512 for TM2/TM3) */ 
+#define    TIMER_DIV512_VALUE_500ms_FOSC_24000000    65536-23437    /* 4687*512   /24000000 = 500 ms  (Timer divider = 512 for TM2/TM3) */ 
+#define    TIMER_DIV512_VALUE_1s_FOSC_24000000       65536-46875    /* 46875*512  /24000000 = 1 s.    (Timer divider = 512 for TM2/TM3) */ 
+
+/*******************************************************************************
+*   TIMER Function Define
+********************************************************************************/
+#define    ENABLE_CLOCK_OUT                     set_CKCON_CLOEN;
+/*    Timer3 basic define  */
+#define    ENABLE_TIMER0_MODE0                  SFRS=0;TMOD&=0xF0
+#define    ENABLE_TIMER0_MODE1                  SFRS=0;TMOD&=0xF0;TMOD|=0x01
+#define    ENABLE_TIMER0_MODE2                  SFRS=0;TMOD&=0xF0;TMOD|=0x02
+#define    ENABLE_TIMER0_MODE3                  SFRS=0;TMOD&=0xF0;TMOD|=0x03
+#define    TIMER0_FSYS                          set_CKCON_T0M
+#define    TIMER0_FSYS_DIV12                    clr_CKCON_T0M
+/*    Timer1 basic define  */
+#define    ENABLE_TIMER1_MODE0                  SFRS=0;TMOD&=0x0F
+#define    ENABLE_TIMER1_MODE1                  SFRS=0;TMOD&=0x0F;TMOD|=0x10  
+#define    ENABLE_TIMER1_MODE2                  SFRS=0;TMOD&=0x0F;TMOD|=0x20  
+#define    ENABLE_TIMER1_MODE3                  SFRS=0;TMOD&=0x0F;TMOD|=0x30  
+#define    TIMER1_FSYS                          set_CKCON_T1M
+#define    TIMER1_FSYS_DIV12                    clr_CKCON_T1M
+/*    Timer3 basic define  */
+#define    TIMER3_DIV_2                  T3CON&=0xF1;T3CON|=0x01
+#define    TIMER3_DIV_4                  T3CON&=0xF1;T3CON|=0x02
+#define    TIMER3_DIV_8                  T3CON&=0xF1;T3CON|=0x03
+#define    TIMER3_DIV_16                 T3CON&=0xF1;T3CON|=0x04
+#define    TIMER3_DIV_32                 T3CON&=0xF1;T3CON|=0x05
+#define    TIMER3_DIV_64                 T3CON&=0xF1;T3CON|=0x06
+#define    TIMER3_DIV_128                T3CON&=0xF1;T3CON|=0x07
+/*    Timer2 basic define  */
+#define    TIMER2_DIV_4                  T2MOD&=0x8F;T2MOD|=0x10
+#define    TIMER2_DIV_16                 T2MOD&=0x8F;T2MOD|=0x20
+#define    TIMER2_DIV_32                 T2MOD&=0x8F;T2MOD|=0x30
+#define    TIMER2_DIV_64                 T2MOD&=0x8F;T2MOD|=0x40
+#define    TIMER2_DIV_128                T2MOD&=0x8F;T2MOD|=0x50
+#define    TIMER2_DIV_256                T2MOD&=0x8F;T2MOD|=0x60
+#define    TIMER2_DIV_512                T2MOD&=0x8F;T2MOD|=0x70
+#define    TIMER2_AUTO_RELOAD_DELAY_MODE T2CON&=0xFE;T2MOD|=0x80;T2MOD|=0x08
+#define    TIMER2_COMPARE_CAPTURE_MODE   T2CON|=0x01;T2MOD&=0x7F;T2MOD|=0x04
+#define    TIMER2_CAP0_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x89
+#define    TIMER2_CAP1_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8A
+#define    TIMER2_CAP2_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8B
+#define    DISABLE_TIMER2_CAP0           CAPCON0&=0xBF
+#define    DISABLE_TIMER2_CAP1           CAPCON0&=0xDF
+#define    DISABLE_TIMER2_CAP2           CAPCON0&=0xEF
+
+/*-------------------- Timer2 Capture define --------------------*/
+/*--- Falling Edge -----*/
+#define  IC0_P12_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x00;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC1_P11_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC2_P10_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P00_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P04_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC4_P01_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC5_P03_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC6_P05_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC7_P15_CAP0_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+                                                
+#define  IC0_P12_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x00;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC1_P11_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON0|=0x20
+#define  IC2_P10_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P00_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P04_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC4_P01_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC5_P03_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC6_P05_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC7_P15_CAP1_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+                                                
+#define  IC0_P12_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON3|=0x00;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC1_P11_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x10;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC2_P10_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x20;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P00_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x30;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P04_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x40;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC4_P01_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x50;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC5_P03_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x60;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC6_P05_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x70;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC7_P15_CAP2_FALLINGEDGE_CAPTURE       SFRS=0;CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x80;CAPCON0|=0x40;CAPCON2|=0x40
+                                                
+//----- Rising edge ----//CAPTURE               
+#define  IC0_P12_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3|=0x00;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC1_P11_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC2_P10_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P00_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P04_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC4_P01_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC5_P03_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC6_P05_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC7_P15_CAP0_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+                                                
+#define  IC0_P12_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x00;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC1_P11_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC2_P10_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P00_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P04_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC4_P01_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC5_P03_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC6_P05_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC7_P15_CAP1_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+                                                
+#define  IC0_P12_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x00;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC1_P11_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC2_P10_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P00_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P04_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC4_P01_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC5_P03_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC6_P05_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC7_P15_CAP2_RISINGEDGE_CAPTURE        SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+                                                
+//-----BOTH  edge ----                          
+#define  IC0_P12_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x00;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC1_P11_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC2_P10_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P00_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC3_P04_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC4_P01_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC5_P03_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC6_P05_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define  IC7_P15_CAP0_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+                                                
+#define  IC0_P12_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x00;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC1_P11_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC2_P10_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P00_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC3_P04_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC4_P01_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC5_P03_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC6_P05_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define  IC7_P15_CAP1_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+                                                
+#define  IC0_P12_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x00;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC1_P11_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC2_P10_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P00_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC3_P04_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC4_P01_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC5_P03_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC6_P05_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define  IC7_P15_CAP2_BOTHEDGE_CAPTURE          SFRS=0;CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+                                                
+#define  TIMER2_CAP2_DISABLE                    SFRS=0;CAPCON0&=0xBF
+#define  TIMER2_CAP1_DISABLE                    SFRS=0;CAPCON0&=0xDF
+#define  TIMER2_CAP0_DISABLE                    SFRS=0;CAPCON0&=0xEF 
+     
+/*****************************************************************************************/
+/* For PWM setting                                                                       */
+/*****************************************************************************************/
+/*--------- PMW clock source select define ---------------------*/                
+#define    ALL_PWM_CLOCK_FSYS                   SFRS=0;CKCON&=0xBF
+#define    ALL_PWM_CLOCK_TIMER1                 SFRS=0;CKCON|=0x40
+/*--------- PMW0 Setting ---------------------*/ 
+/*--------- PWM type define ------------------------------------*/ 
+#define    PWM0_EDGE_TYPE                       SFRS=0;PWM0CON1&=0xEF
+#define    PWM0_CENTER_TYPE                     SFRS=0;PWM0CON1|=0x10      
+/*--------- PWM mode define ------------------------------------*/ 
+#define    PWM0_IMDEPENDENT_MODE                SFRS=0;PWM0CON1&=0x3F                
+#define    PWM0_COMPLEMENTARY_MODE              SFRS=0;PWM0CON1&=0x3F;PWM0CON1|=0x40 
+#define    PWM0_SYNCHRONIZED_MODE               SFRS=0;PWM0CON1&=0x3F;PWM0CON1|=0x80 
+#define    PWM0_GP_MODE_ENABLE                  SFRS=0;PWM0CON1|=0x20                
+#define    PWM0_GP_MODE_DISABLE                 SFRS=0;PWM0CON1&=0xDF                              
+/*--------- PWM clock devide define ----------------------------*/
+#define    PWM0_CLOCK_DIV_1                     SFRS=0;PWM0CON1&=0xF8               
+#define    PWM0_CLOCK_DIV_2                     SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x01
+#define    PWM0_CLOCK_DIV_4                     SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x02
+#define    PWM0_CLOCK_DIV_8                     SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x03
+#define    PWM0_CLOCK_DIV_16                    SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x04
+#define    PWM0_CLOCK_DIV_32                    SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x05
+#define    PWM0_CLOCK_DIV_64                    SFRS=0;PWM0CON1&=0xF8;PWM0CON1|=0x06
+#define    PWM0_CLOCK_DIV_128                   SFRS=0;PWM0CON1|=0x07
+/*--------- PWM ouput GPIO select define ------------------------------*/
+#define    ENABLE_PWM0_CH0_P12_OUTPUT           set_PIOCON0_PIO12;
+#define    ENABLE_PWM0_CH0_P33_OUTPUT           set_PIOCON2_PIO33
+#define    ENABLE_PWM0_CH1_P14_OUTPUT           set_PIOCON1_PIO14;
+#define    ENABLE_PWM0_CH1_P11_OUTPUT           set_PIOCON0_PIO11;
+#define    ENABLE_PWM0_CH2_P05_OUTPUT           set_PIOCON1_PIO05;
+#define    ENABLE_PWM0_CH2_P10_OUTPUT           set_PIOCON0_PIO10
+#define    ENABLE_PWM0_CH3_P04_OUTPUT           set_PIOCON1_PIO04;
+#define    ENABLE_PWM0_CH3_P00_OUTPUT           set_PIOCON0_PIO00;
+#define    ENABLE_PWM0_CH4_P01_OUTPUT           set_PIOCON0_PIO01;
+#define    ENABLE_PWM0_CH5_P15_OUTPUT           set_PIOCON1_PIO15;
+#define    ENABLE_PWM0_CH5_P03_OUTPUT           set_PIOCON0_PIO03;
+#define    ENABLE_ALL_PWM0_OUTPUT               SFRS=0;PIOCON0=0xFF;SFRS=1;PIOCON1=0xFF
+
+#define    DISABLE_PWM0_CH0_P12_OUTPUT          clr_PIOCON0_PIO12
+#define    DISABLE_PWM0_CH1_P14_OUTPUT          clr_PIOCON1_PIO14
+#define    DISABLE_PWM0_CH1_P11_OUTPUT          clr_PIOCON0_PIO11
+#define    DISABLE_PWM0_CH2_P05_OUTPUT          clr_PIOCON1_PIO05
+#define    DISABLE_PWM0_CH2_P10_OUTPUT          clr_PIOCON0_PIO10
+#define    DISABLE_PWM0_CH3_P04_OUTPUT          clr_PIOCON1_PIO04
+#define    DISABLE_PWM0_CH3_P00_OUTPUT          clr_PIOCON0_PIO00
+#define    DISABLE_PWM0_CH4_P01_OUTPUT          clr_PIOCON0_PIO01
+#define    DISABLE_PWM0_CH5_P15_OUTPUT          clr_PIOCON1_PIO15
+#define    DISABLE_PWM0_CH5_P03_OUTPUT          clr_PIOCON0_PIO03
+#define    DISABLE_ALL_PWM0_OUTPUT              SFRS=0;PIOCON0=0x00;SFRS=1;PIOCON1=0x00
+
+/*--------- PWM0 I/O Polarity Control ---------------------------*/ 
+#define    PWM0_CH5_OUTPUT_INVERSE              SFRS=0;PNP|=0x20
+#define    PWM0_CH4_OUTPUT_INVERSE              SFRS=0;PNP|=0x10
+#define    PWM0_CH3_OUTPUT_INVERSE              SFRS=0;PNP|=0x08
+#define    PWM0_CH2_OUTPUT_INVERSE              SFRS=0;PNP|=0x04
+#define    PWM0_CH1_OUTPUT_INVERSE              SFRS=0;PNP|=0x02
+#define    PWM0_CH0_OUTPUT_INVERSE              SFRS=0;PNP|=0x01
+#define    PWM0_ALL_OUTPUT_INVERSE              SFRS=0;PNP=0xFF 
+#define    PWM0_CH5_OUTPUT_NORMAL               SFRS=0;PNP&=0xDF
+#define    PWM0_CH4_OUTPUT_NORMAL               SFRS=0;PNP&=0xEF
+#define    PWM0_CH3_OUTPUT_NORMAL               SFRS=0;PNP&=0xF7
+#define    PWM0_CH2_OUTPUT_NORMAL               SFRS=0;PNP&=0xFB
+#define    PWM0_CH1_OUTPUT_NORMAL               SFRS=0;PNP&=0xFD
+#define    PWM0_CH0_OUTPUT_NORMAL               SFRS=0;PNP&=0xFE
+#define    PWM0_ALL_OUTPUT_NORMAL               SFRS=0;PNP=0x00 
+/*--------- PMM0 Mask Output ENABLE -----------------------*/       
+#define    ENABLE_PWM0_CH0_MASK                 SFRS=0;PWM0MEN|=0x01
+#define    ENABLE_PWM0_CH1_MASK                 SFRS=0;PWM0MEN|=0x02
+#define    ENABLE_PWM0_CH2_MASK                 SFRS=0;PWM0MEN|=0x04
+#define    ENABLE_PWM0_CH3_MASK                 SFRS=0;PWM0MEN|=0x08
+#define    ENABLE_PWM0_CH4_MASK                 SFRS=0;PWM0MEN|=0x10
+#define    ENABLE_PWM0_CH5_MASK                 SFRS=0;PWM0MEN|=0x20
+
+#define    DISABLE_PWM0_CH0_MASK                SFRS=0;PWM0MEN&=0xFE
+#define    DISABLE_PWM0_CH1_MASK                SFRS=0;PWM0MEN&=0xFD
+#define    DISABLE_PWM0_CH2_MASK                SFRS=0;PWM0MEN&=0xFB
+#define    DISABLE_PWM0_CH3_MASK                SFRS=0;PWM0MEN&=0xF7
+#define    DISABLE_PWM0_CH4_MASK                SFRS=0;PWM0MEN&=0xEF
+#define    DISABLE_PWM0_CH5_MASK                SFRS=0;PWM0MEN&=0xDF
+/*--------- PMM0 Mask Output Value -----------------------*/ 
+#define    PWM0_CH0_MASK_0                      SFRS=0;PWM0MD&=0xFE 
+#define    PWM0_CH1_MASK_0                      SFRS=0;PWM0MD&=0xFD 
+#define    PWM0_CH2_MASK_0                      SFRS=0;PWM0MD&=0xFB 
+#define    PWM0_CH3_MASK_0                      SFRS=0;PWM0MD&=0xF7 
+#define    PWM0_CH4_MASK_0                      SFRS=0;PWM0MD&=0xEF 
+#define    PWM0_CH5_MASK_0                      SFRS=0;PWM0MD&=0xDF 
+                                                
+#define    PWM0_CH0_MASK_1                      SFRS=0;PWM0MD|=0x01 
+#define    PWM0_CH1_MASK_1                      SFRS=0;PWM0MD|=0x02 
+#define    PWM0_CH2_MASK_1                      SFRS=0;PWM0MD|=0x04 
+#define    PWM0_CH3_MASK_1                      SFRS=0;PWM0MD|=0x08  
+#define    PWM0_CH4_MASK_1                      SFRS=0;PWM0MD|=0x10  
+#define    PWM0_CH5_MASK_1                      SFRS=0;PWM0MD|=0x20  
+/*--------- PMW0 interrupt setting ------------------------------*/ 
+#define    PWM0_FALLING_INT                     SFRS=1;PWM0INTC&=0xCF               
+#define    PWM0_RISING_INT                      SFRS=1;PWM0INTC&=0xCF;PWM0INTC|=0x10
+#define    PWM0_CENTRAL_POINT_INT               SFRS=1;PWM0INTC&=0xCF;PWM0INTC|=0x20
+#define    PWM0_PERIOD_END_INT                  SFRS=1;PWM0INTC|=0x30               
+/*--------- PWM0 interrupt pin select ---------------------------*/ 
+#define    PWM0_CH0_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8               
+#define    PWM0_CH1_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8;PWM0INTC|=0x01
+#define    PWM0_CH2_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8;PWM0INTC|=0x02
+#define    PWM0_CH3_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8;PWM0INTC|=0x03
+#define    PWM0_CH4_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8;PWM0INTC|=0x04
+#define    PWM0_CH5_INTERRUPT_SELECT            SFRS=1;PWM0INTC&=0xF8;PWM0INTC|=0x05
+/*--------- PWM0 Dead time setting ------------------------------*/ 
+#define    ENABLE_PWM0_CH45_DEADTIME            SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x04;EA=BIT_TMP
+#define    ENABLE_PWM0_CH34_DEADTIME            SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x02;EA=BIT_TMP
+#define    ENABLE_PWM0_CH01_DEADTIME            SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x01;EA=BIT_TMP
+
+/*--------- PMW1 Setting ---------------------*/ 
+/*--------- PWM type define ------------------------------------*/ 
+#define    PWM1_EDGE_TYPE                     SFRS=2;PWM1CON1&=0xEF;SFRS=0
+#define    PWM1_CENTER_TYPE                   SFRS=2;PWM1CON1|=0x10;SFRS=0
+/*--------- PWM1 mode define ------------------------------------*/ 
+#define    PWM1_IMDEPENDENT_MODE              SFRS=2;PWM1CON1&=0x3F               
+#define    PWM1_COMPLEMENTARY_MODE            SFRS=2;PWM1CON1&=0x3F;PWM1CON1|=0x40
+#define    PWM1_SYNCHRONIZED_MODE             SFRS=2;PWM1CON1&=0x3F;PWM1CON1|=0x80
+//--------- PWM1 clock devide define ----------------------------
+#define    PWM1_CLOCK_DIV_1                   SFRS=2;PWM1CON1&=0xF8;              
+#define    PWM1_CLOCK_DIV_2                   SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x01
+#define    PWM1_CLOCK_DIV_4                   SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x02
+#define    PWM1_CLOCK_DIV_8                   SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x03
+#define    PWM1_CLOCK_DIV_16                  SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x04
+#define    PWM1_CLOCK_DIV_32                  SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x05
+#define    PWM1_CLOCK_DIV_64                  SFRS=2;PWM1CON1&=0xF8;PWM1CON1|=0x06
+#define    PWM1_CLOCK_DIV_128                 SFRS=2;PWM1CON1|=0x07               
+/*--------- PWM1 ouput GPIO select define ------------------------------*/  
+#define    ENABLE_PWM1_CH0_P23_OUTPUT         SFRS=2;AUXR4&=0xFC;AUXR4|=0x01;set_PIOCON2_PIO23
+#define    ENABLE_PWM1_CH0_P12_OUTPUT         SFRS=2;AUXR4&=0xFC;AUXR4|=0x02;set_PIOCON0_PIO12
+#define    ENABLE_PWM1_CH1_P22_OUTPUT         SFRS=2;AUXR4&=0xF3;AUXR4|=0x04;set_PIOCON2_PIO22
+#define    ENABLE_PWM1_CH1_P14_OUTPUT         SFRS=2;AUXR4&=0xF3;AUXR4|=0x08;set_PIOCON1_PIO14
+#define    ENABLE_PWM1_CH1_P11_OUTPUT         SFRS=2;AUXR4&=0xF3;AUXR4|=0x0C;set_PIOCON0_PIO11
+
+#define    DISABLE_PWM1_CH0_P23_OUTPUT        SFRS=2;AUXR4&=0xFC;clr_PIOCON2_PIO23;SFRS=0
+#define    DISABLE_PWM1_CH0_P12_OUTPUT        SFRS=2;AUXR4&=0xFC;clr_PIOCON0_PIO12;SFRS=0
+#define    DISABLE_PWM1_CH1_P22_OUTPUT        SFRS=2;AUXR4&=0xF3;clr_PIOCON2_PIO22;SFRS=0
+#define    DISABLE_PWM1_CH1_P14_OUTPUT        SFRS=2;AUXR4&=0xF3;clr_PIOCON1_PIO14;SFRS=0
+#define    DISABLE_PWM1_CH1_P11_OUTPUT        SFRS=2;AUXR4&=0xF3;clr_PIOCON0_PIO11;SFRS=0
+/*--------- PMM1 Mask Output ENABLE -----------------------*/       
+#define    ENABLE_PWM1_CH0_MASK               SFRS=2;PWM1MEN|=0x01;SFRS=0
+#define    ENABLE_PWM1_CH1_MASK               SFRS=2;PWM1MEN|=0x02;SFRS=0
+
+#define    DISABLE_PWM1_CH0_MASK              SFRS=2;PWM1MEN&=0xFE;SFRS=0
+#define    DISABLE_PWM1_CH1_MASK              SFRS=2;PWM1MEN&=0xFD;SFRS=0
+/*--------- PMM1 Mask Output Value -----------------------*/ 
+#define    PWM1_CH0_MASK_0                    SFRS=2;PWM1MD&=0xFE 
+#define    PWM1_CH1_MASK_0                    SFRS=2;PWM1MD&=0xFD 
+
+#define    PWM1_CH0_MASK_1                    SFRS=2;PWM1MD|=0x01 
+#define    PWM1_CH1_MASK_1                    SFRS=2;PWM1MD|=0x02 
+/*--------- PMW1 interrupt setting ------------------------------*/ 
+#define    PWM1_FALLING_INT                   SFRS=2;PWM1INTC&=0xCF
+#define    PWM1_RISING_INT                    SFRS=2;PWM1INTC&=0xCF;PWM1INTC|=0x10
+#define    PWM1_CENTRAL_POINT_INT             SFRS=2;PWM1INTC&=0xCF;PWM1INTC|=0x20
+#define    PWM1_PERIOD_END_INT                SFRS=2;PWM1INTC|=0x30
+/*--------- PWM1 interrupt pin select ---------------------------*/ 
+#define    PWM1_CH0_INTERRUPT_SELECT          SFRS=2;PWM1INTC&=0xF8               
+#define    PWM1_CH1_INTERRUPT_SELECT          SFRS=2;PWM1INTC&=0xF8;PWM1INTC|=0x01
+
+/*--------- PMW2 Setting ---------------------*/ 
+/*--------- PWM2 type define ------------------------------------*/ 
+#define    PWM2_EDGE_TYPE                     SFRS=2;PWM2CON1&=0xEF               
+#define    PWM2_CENTER_TYPE                   SFRS=2;PWM2CON1|=0x10               
+/*--------- PWM2 mode define ------------------------------------*/              
+#define    PWM2_IMDEPENDENT_MODE              SFRS=2;PWM2CON1&=0x3F               
+#define    PWM2_COMPLEMENTARY_MODE            SFRS=2;PWM2CON1&=0x3F;PWM2CON1|=0x40
+#define    PWM2_SYNCHRONIZED_MODE             SFRS=2;PWM2CON1&=0x3F;PWM2CON1|=0x80
+/*--------- PWM2 clock devide define ---------------------------- */
+#define    PWM2_CLOCK_DIV_1                   SFRS=2;PWM2CON1&=0xF8;              
+#define    PWM2_CLOCK_DIV_2                   SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x01
+#define    PWM2_CLOCK_DIV_4                   SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x02
+#define    PWM2_CLOCK_DIV_8                   SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x03
+#define    PWM2_CLOCK_DIV_16                  SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x04
+#define    PWM2_CLOCK_DIV_32                  SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x05
+#define    PWM2_CLOCK_DIV_64                  SFRS=2;PWM2CON1&=0xF8;PWM2CON1|=0x06
+#define    PWM2_CLOCK_DIV_128                 SFRS=2;PWM2CON1|=0x07               
+/*--------- PWM2 ouput GPIO select define ------------------------------*/ 
+#define    ENABLE_PWM2_CH0_P21_OUTPUT         SFRS=2;AUXR4&=0xCF;AUXR4|=0x10;set_PIOCON2_PIO21
+#define    ENABLE_PWM2_CH0_P10_OUTPUT         SFRS=2;AUXR4&=0xCF;AUXR4|=0x20;set_PIOCON0_PIO10
+#define    ENABLE_PWM2_CH0_P05_OUTPUT         SFRS=2;AUXR4&=0xCF;AUXR4|=0x30;set_PIOCON1_PIO05
+#define    ENABLE_PWM2_CH1_P30_OUTPUT         SFRS=2;AUXR4&=0x3F;AUXR4|=0x00;set_PIOCON2_PIO30
+#define    ENABLE_PWM2_CH1_P31_OUTPUT         SFRS=2;AUXR4&=0x3F;AUXR4|=0x40;set_PIOCON2_PIO31
+#define    ENABLE_PWM2_CH1_P00_OUTPUT         SFRS=2;AUXR4&=0x3F;AUXR4|=0x80;set_PIOCON0_PIO00
+#define    ENABLE_PWM2_CH1_P04_OUTPUT         SFRS=2;AUXR4&=0x3F;AUXR4|=0xC0;set_PIOCON1_PIO04
+
+#define    DISABLE_PWM2_CH0_P21_OUTPUT        SFRS=2;AUXR4&=0xCF;clr_PIOCON2_PIO21
+#define    DISABLE_PWM2_CH0_P10_OUTPUT        SFRS=2;AUXR4&=0xCF;clr_PIOCON0_PIO10
+#define    DISABLE_PWM2_CH0_P05_OUTPUT        SFRS=2;AUXR4&=0xCF;clr_PIOCON1_PIO05
+#define    DISABLE_PWM2_CH1_P30_OUTPUT        SFRS=2;AUXR4&=0x3F;clr_PIOCON2_PIO30
+#define    DISABLE_PWM2_CH1_P31_OUTPUT        SFRS=2;AUXR4&=0x3F;clr_PIOCON2_PIO31
+#define    DISABLE_PWM2_CH1_P00_OUTPUT        SFRS=2;AUXR4&=0x3F;clr_PIOCON0_PIO00
+#define    DISABLE_PWM2_CH1_P04_OUTPUT        SFRS=2;AUXR4&=0x3F;clr_PIOCON1_PIO04
+/*--------- PMM2 Mask Output ENABLE -----------------------*/       
+#define    ENABLE_PWM2_CH0_MASK               SFRS=2;PWM2MEN|=0x01
+#define    ENABLE_PWM2_CH1_MASK               SFRS=2;PWM2MEN|=0x02
+                                                                  
+#define    DISABLE_PWM2_CH0_MASK              SFRS=2;PWM2MEN&=0xFE
+#define    DISABLE_PWM2_CH1_MASK              SFRS=2;PWM2MEN&=0xFD
+/*--------- PMM2 Mask Output Value -----------------------*/ 
+#define    PWM2_CH0_MASK_0                    SFRS=2;PWM2MD&=0xFE
+#define    PWM2_CH1_MASK_0                    SFRS=2;PWM2MD&=0xFD
+                                                                 
+#define    PWM2_CH0_MASK_1                    SFRS=2;PWM2MD|=0x01
+#define    PWM2_CH1_MASK_1                    SFRS=2;PWM2MD|=0x02
+/*--------- PMW2 interrupt setting ------------------------------*/   
+#define    PWM2_FALLING_INT                   SFRS=2;PWM2INTC&=0xCF               
+#define    PWM2_RISING_INT                    SFRS=2;PWM2INTC&=0xCF;PWM2INTC|=0x10
+#define    PWM2_CENTRAL_POINT_INT             SFRS=2;PWM2INTC&=0xCF;PWM2INTC|=0x20
+#define    PWM2_PERIOD_END_INT                SFRS=2;PWM2INTC|=0x30               
+/*--------- PWM2 interrupt pin select ---------------------------*/
+#define    PWM2_CH0_INTERRUPT_SELECT          SFRS=2;PWM2INTC&=0xF8               
+#define    PWM2_CH1_INTERRUPT_SELECT          SFRS=2;PWM2INTC&=0xF8;PWM2INTC|=0x01
+
+/*--------- PMW3 Setting ---------------------*/ 
+/*--------- PWM3 type define ------------------------------------*/ 
+#define    PWM3_EDGE_TYPE                     SFRS=2;PWM3CON1&=0xEF;SFRS=0
+#define    PWM3_CENTER_TYPE                   SFRS=2;PWM3CON1|=0x10;SFRS=0
+/*--------- PWM3 mode define ------------------------------------*/ 
+#define    PWM3_IMDEPENDENT_MODE              SFRS=2;PWM3CON1&=0x3F               
+#define    PWM3_COMPLEMENTARY_MODE            SFRS=2;PWM3CON1&=0x3F;PWM3CON1|=0x40
+#define    PWM3_SYNCHRONIZED_MODE             SFRS=2;PWM3CON1&=0x3F;PWM3CON1|=0x80
+/*--------- PWM3 clock devide define ---------------------------- */
+#define    PWM3_CLOCK_DIV_1                   SFRS=2;PWM3CON1&=0xF8;              
+#define    PWM3_CLOCK_DIV_2                   SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x01
+#define    PWM3_CLOCK_DIV_4                   SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x02
+#define    PWM3_CLOCK_DIV_8                   SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x03
+#define    PWM3_CLOCK_DIV_16                  SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x04
+#define    PWM3_CLOCK_DIV_32                  SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x05
+#define    PWM3_CLOCK_DIV_64                  SFRS=2;PWM3CON1&=0xF8;PWM3CON1|=0x06
+#define    PWM3_CLOCK_DIV_128                 SFRS=2;PWM3CON1|=0x07               
+/*--------- PWM3 ouput GPIO select define ------------------------------*/ 
+#define    ENABLE_PWM3_CH0_P32_OUTPUT         SFRS=2;AUXR5&=0xFC;AUXR5|=0x01;set_PIOCON2_PIO32
+#define    ENABLE_PWM3_CH0_P01_OUTPUT         SFRS=2;AUXR5&=0xFC;AUXR5|=0x02;set_PIOCON0_PIO01
+#define    ENABLE_PWM3_CH0_P17_OUTPUT         set_PIOCON1_PIO17
+#define    ENABLE_PWM3_CH1_P34_OUTPUT         SFRS=2;AUXR5&=0xF3;AUXR5|=0x04;set_PIOCON2_PIO34
+#define    ENABLE_PWM3_CH1_P15_OUTPUT         SFRS=2;AUXR5&=0xF3;AUXR5|=0x08;set_PIOCON1_PIO15 
+#define    ENABLE_PWM3_CH1_P03_OUTPUT         SFRS=2;AUXR5&=0xF3;AUXR5|=0x0C;set_PIOCON0_PIO03
+                                              
+#define    DISABLE_PWM3_CH0_P32_OUTPUT        SFRS=2;AUXR5&=0xFC;clr_PIOCON2_PIO32
+#define    DISABLE_PWM3_CH0_P01_OUTPUT        SFRS=2;AUXR5&=0xFC;clr_PIOCON0_PIO01
+#define    DISABLE_PWM3_CH1_P34_OUTPUT        SFRS=2;AUXR5&=0xF3;clr_PIOCON2_PIO34
+#define    DISABLE_PWM3_CH1_P15_OUTPUT        SFRS=2;AUXR5&=0xF3;clr_PIOCON1_PIO15
+#define    DISABLE_PWM3_CH1_P03_OUTPUT        SFRS=2;AUXR5&=0xF3;clr_PIOCON0_PIO03
+/*--------- PMM3 Mask Output ENABLE -----------------------*/                     
+#define    ENABLE_PWM3_CH0_MASK               SFRS=2;PWM3MEN|=0x01                
+#define    ENABLE_PWM3_CH1_MASK               SFRS=2;PWM3MEN|=0x02                
+                                                                        
+#define    DISABLE_PWM3_CH0_MASK              SFRS=2;PWM3MEN&=0xFE                
+#define    DISABLE_PWM3_CH1_MASK              SFRS=2;PWM3MEN&=0xFD                
+/*--------- PMM3 Mask Output Value -----------------------*/               
+#define    PWM3_CH0_MASK_0                    SFRS=2;PWM3MD&=0xFE                
+#define    PWM3_CH1_MASK_0                    SFRS=2;PWM3MD&=0xFD                
+                
+#define    PWM3_CH0_MASK_1                    SFRS=2;PWM3MD|=0x01                
+#define    PWM3_CH1_MASK_1                    SFRS=2;PWM3MD|=0x02                
+/*--------- PMW3 interrupt setting ------------------------------*/               
+#define    PWM3_FALLING_INT                   SFRS=2;PWM3INTC&=0xCF               
+#define    PWM3_RISING_INT                    SFRS=2;PWM3INTC&=0xCF;PWM3INTC|=0x10
+#define    PWM3_CENTRAL_POINT_INT             SFRS=2;PWM3INTC&=0xCF;PWM3INTC|=0x20
+#define    PWM3_PERIOD_END_INT                SFRS=2;PWM3INTC|=0x30               
+/*--------- PWM3 interrupt pin select ---------------------------*/               
+#define    PWM3_CH0_INTERRUPT_SELECT          SFRS=2;PWM3INTC&=0xF8               
+#define    PWM3_CH1_INTERRUPT_SELECT          SFRS=2;PWM3INTC&=0xF8;PWM3INTC|=0x01
+
+/*****************************************************************************************
+* For ADC INIT setting 
+*****************************************************************************************/
+#define    ENABLE_ADC_BANDGAP                 SFRS=0;ADCCON0&=0x30;ADCCON0|=0x08;ADCCON1|=0x01   
+
+#define    ENABLE_ADC_CH0                     P17_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x00;AINDIDS0=0;AINDIDS0|=0x01;ADCCON1|=0x01
+#define    ENABLE_ADC_CH1                     P30_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x01;AINDIDS0=0;AINDIDS0|=0x02;ADCCON1|=0x01
+#define    ENABLE_ADC_CH2                     P07_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x02;AINDIDS0=0;AINDIDS0|=0x04;ADCCON1|=0x01
+#define    ENABLE_ADC_CH3                     P06_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x03;AINDIDS0=0;AINDIDS0|=0x08;ADCCON1|=0x01
+#define    ENABLE_ADC_CH4                     P05_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x04;AINDIDS0=0;AINDIDS0|=0x10;ADCCON1|=0x01
+#define    ENABLE_ADC_CH5                     P04_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x05;AINDIDS0=0;AINDIDS0|=0x20;ADCCON1|=0x01
+#define    ENABLE_ADC_CH6                     P03_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x06;AINDIDS0=0;AINDIDS0|=0x40;ADCCON1|=0x01
+#define    ENABLE_ADC_CH7                     P11_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x07;AINDIDS0=0;AINDIDS0|=0x80;ADCCON1|=0x01
+#define    ENABLE_ADC_CH9                     P21_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x09;SFRS=2;AINDIDS1=0;AINDIDS1|=0x02;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH10                    P22_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0A;SFRS=2;AINDIDS1=0;AINDIDS1|=0x04;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH11                    P23_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0B;SFRS=2;AINDIDS1=0;AINDIDS1|=0x08;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH12                    P24_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0C;SFRS=2;AINDIDS1=0;AINDIDS1|=0x10;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH13                    P13_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0D;SFRS=2;AINDIDS1=0;AINDIDS1|=0x20;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH14                    P14_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0E;SFRS=2;AINDIDS1=0;AINDIDS1|=0x40;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_CH15                    P25_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0F;SFRS=2;AINDIDS1=0;AINDIDS1|=0x80;SFRS=0;ADCCON1|=0x01
+
+#define    ENABLE_ADC_AIN0                     P17_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x00;AINDIDS0=0;AINDIDS0|=0x01;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN1                     P30_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x01;AINDIDS0=0;AINDIDS0|=0x02;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN2                     P07_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x02;AINDIDS0=0;AINDIDS0|=0x04;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN3                     P06_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x03;AINDIDS0=0;AINDIDS0|=0x08;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN4                     P05_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x04;AINDIDS0=0;AINDIDS0|=0x10;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN5                     P04_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x05;AINDIDS0=0;AINDIDS0|=0x20;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN6                     P03_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x06;AINDIDS0=0;AINDIDS0|=0x40;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN7                     P11_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x07;AINDIDS0=0;AINDIDS0|=0x80;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN9                     P21_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x09;SFRS=2;AINDIDS1=0;AINDIDS1|=0x02;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN10                    P22_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0A;SFRS=2;AINDIDS1=0;AINDIDS1|=0x04;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN11                    P23_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0B;SFRS=2;AINDIDS1=0;AINDIDS1|=0x08;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN12                    P24_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0C;SFRS=2;AINDIDS1=0;AINDIDS1|=0x10;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN13                    P13_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0D;SFRS=2;AINDIDS1=0;AINDIDS1|=0x20;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN14                    P14_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0E;SFRS=2;AINDIDS1=0;AINDIDS1|=0x40;SFRS=0;ADCCON1|=0x01
+#define    ENABLE_ADC_AIN15                    P25_INPUT_MODE;SFRS=0;ADCCON0&=0x30;ADCCON0|=0x0F;SFRS=2;AINDIDS1=0;AINDIDS1|=0x80;SFRS=0;ADCCON1|=0x01
+
+/*------ ADC mode ------*/
+#define    ENABLE_ADC_CONTINUES_MODE          SFRS=2;ADCCON3|=SET_BIT4
+#define    ENABLE_ADC_CONTINUES_HALFDONE_INT  SFRS=2;ADCCON3|=SET_BIT5
+#define    ENABLE_ADC_CONTINUES_FULLDONE_INT  SFRS=2;ADCCON3&=CLR_BIT5
+
+#define    DISABLE_ADC                        SFRS=0;ADCCON1&=0xFE;AINDIDS0=0;SFRS=2;AINDIDS1=0
+
+/* PWM0 trig ADC start define */
+#define    PWM0_CH0_FALLINGEDGE_TRIG_ADC      SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH2_FALLINGEDGE_TRIG_ADC      SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH4_FALLINGEDGE_TRIG_ADC      SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH0_RISINGEDGE_TRIG_ADC       SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH2_RISINGEDGE_TRIG_ADC       SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH4_RISINGEDGE_TRIG_ADC       SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH0_CENTRAL_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH2_CENTRAL_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH4_CENTRAL_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH0_END_TRIG_ADC              SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH2_END_TRIG_ADC              SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH4_END_TRIG_ADC              SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+/*      PWM trig ADC start define (old format) */ 
+#define    PWM0_FALLINGEDGE_TRIG_ADC         SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM2_FALLINGEDGE_TRIG_ADC         SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM4_FALLINGEDGE_TRIG_ADC         SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_RISINGEDGE_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM2_RISINGEDGE_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM4_RISINGEDGE_TRIG_ADC          SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CENTRAL_TRIG_ADC             SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM2_CENTRAL_TRIG_ADC             SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM4_CENTRAL_TRIG_ADC             SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_END_TRIG_ADC                 SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM2_END_TRIG_ADC                 SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM4_END_TRIG_ADC                 SFRS=0;ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+/* GPIO trig ADC start define*/
+#define    P04_FALLINGEDGE_TRIG_ADC           SFRS=0;ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P13_FALLINGEDGE_TRIG_ADC           SFRS=0;ADCCON0|=0x30;ADCCON1|=0x40;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P04_RISINGEDGE_TRIG_ADC            SFRS=0;ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    P13_RISINGEDGE_TRIG_ADC            SFRS=0;ADCCON0|=0x30;ADCCON1&=0xF7;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02               
+
+
+
+/*****************************************************************************************
+* For SPI INIT setting 
+*****************************************************************************************/
+#define    SPICLK_FSYS_DIV2                   SFRS=0;SPCR&=0xFC;SPCR|=0x00           
+#define    SPICLK_FSYS_DIV4                   SFRS=0;SPCR&=0xFC;SPCR|=0x01           
+#define    SPICLK_FSYS_DIV8                   SFRS=0;SPCR&=0xFC;SPCR|=0x02           
+#define    SPICLK_FSYS_DIV16                  SFRS=0;SPCR&=0xFC;SPCR|=0x03           
+
+#define    ENABLE_SPI0_SS_P15                 clr_AUXR7_SPI0NSSP1;clr_AUXR7_SPI0NSSP0
+#define    ENABLE_SPI0_SS_P35                 set_AUXR7_SPI0NSSP1;clr_AUXR7_SPI0NSSP0
+#define    ENABLE_SPI0_MOSI_P00               clr_AUXR7_SPI0MOSIP                    
+#define    ENABLE_SPI0_MOSI_P30               set_AUXR7_SPI0MOSIP                    
+#define    ENABLE_SPI0_MISO_P01               clr_AUXR7_SPI0MISOP                    
+#define    ENABLE_SPI0_MISO_P25               set_AUXR7_SPI0MISOP                    
+#define    ENABLE_SPI0_CLK_P10                clr_AUXR7_SPI0CKP                      
+#define    ENABLE_SPI0_CLK_P17                set_AUXR7_SPI0CKP                      
+
+/*****************************************************************************************
+* For UART0 and UART1 and printf funcion 
+*****************************************************************************************/
+#define    ENABLE_UART0_PRINTF                set_SCON_TI;PRINTFG=1            //For printf function must setting TI = 1
+#define    DISABLE_UART0_PRINTF               clr_SCON_TI;PRINTFG=0
+#define    ENABLE_UART1_PRINTF                set_SCON_1_TI_1;PRINTFG=1
+#define    DISABLE_UART1_PRINTF               clr_SCON_1_TI_1;PRINTFG=0
+
+/*****************************************************************************************/
+/* For UART2 ~ UART4 output setting                                                      */
+/*****************************************************************************************/
+#define    ENABLE_UART2_TXD_P03               clr_AUXR2_UART2TXP1;set_AUXR2_UART2TXP0
+#define    ENABLE_UART2_TXD_P30               set_AUXR2_UART2TXP1;clr_AUXR2_UART2TXP0
+#define    ENABLE_UART2_RXD_P04               clr_AUXR2_UART2RXP1;set_AUXR2_UART2RXP0
+#define    ENABLE_UART2_RXD_P17               set_AUXR2_UART2RXP1;clr_AUXR2_UART2RXP0
+                                                                                    
+#define    ENABLE_UART1_TXD_P16               clr_AUXR2_UART1TXP1;set_AUXR2_UART1TXP0
+#define    ENABLE_UART1_TXD_P36               set_AUXR2_UART1TXP1;clr_AUXR2_UART1TXP0
+#define    ENABLE_UART1_TXD_P10               set_AUXR2_UART1TXP1;set_AUXR2_UART1TXP0
+#define    ENABLE_UART1_RXD_P02               clr_AUXR2_UART1RXP1;set_AUXR2_UART1RXP0
+#define    ENABLE_UART1_RXD_P37               set_AUXR2_UART1RXP1;clr_AUXR2_UART1RXP0
+#define    ENABLE_UART1_RXD_P00               set_AUXR2_UART1RXP1;set_AUXR2_UART1RXP0
+                                                                                     
+#define    ENABLE_UART4_TXD_P23               clr_AUXR3_UART4TXP1;set_AUXR3_UART4TXP0
+#define    ENABLE_UART4_RXD_P22               clr_AUXR3_UART4RXP1;set_AUXR3_UART4RXP0
+                                                                                    
+#define    ENABLE_UART3_TXD_P12               clr_AUXR3_UART3TXP1;set_AUXR3_UART3TXP0
+#define    ENABLE_UART3_TXD_P15               set_AUXR3_UART3TXP1;clr_AUXR3_UART3TXP0
+#define    ENABLE_UART3_TXD_P05               set_AUXR3_UART3TXP1;set_AUXR3_UART3TXP0
+#define    ENABLE_UART3_RXD_P11               clr_AUXR3_UART3RXP1;set_AUXR3_UART3RXP0
+#define    ENABLE_UART3_RXD_P25               set_AUXR3_UART3RXP1;clr_AUXR3_UART3RXP0
+#define    ENABLE_UART3_RXD_P34               set_AUXR3_UART3RXP1;set_AUXR3_UART3RXP0
+                                              
+#define    ENABLE_UART4_RXD_DEGLITCH          set_AUXR6_UART4DG
+#define    ENABLE_UART3_RXD_DEGLITCH          set_AUXR6_UART3DG
+#define    ENABLE_UART2_RXD_DEGLITCH          set_AUXR6_UART2DG
+#define    ENABLE_UART1_RXD_DEGLITCH          set_AUXR6_UART1DG
+#define    ENABLE_UART0_RXD_DEGLITCH          set_AUXR6_UART0DG
+                                                               
+#define    DISABLE_UART4_RXD_DEGLITCH         clr_AUXR6_UART4DG
+#define    DISABLE_UART3_RXD_DEGLITCH         clr_AUXR6_UART3DG
+#define    DISABLE_UART2_RXD_DEGLITCH         clr_AUXR6_UART2DG
+#define    DISABLE_UART1_RXD_DEGLITCH         clr_AUXR6_UART1DG
+#define    DISABLE_UART0_RXD_DEGLITCH         clr_AUXR6_UART0DG
+
+/****************************************************************************************/
+/* INT0 setting                                                                         */
+/****************************************************************************************/
+#define    INT0_FALLING_EDGE_TRIG             set_TCON_IT0  //TBD
+#define    INT0_LOW_LEVEL_TRIG                clr_TCON_IT0  //TBD
+
+/****************************************************************************************/
+/* INT1 setting                                                                         */
+/****************************************************************************************/
+#define    INT1_FALLING_EDGE_TRIG             set_TCON_IT1  //Check
+#define    INT1_LOW_LEVEL_TRIG                clr_TCON_IT1  //Check
+
+/*****************************************************************************************
+* WDT setting
+*****************************************************************************************/
+#define    WDT_TIMEOUT_6MS                    TA=0xAA;TA=0x55;WDCON&=0xF8
+#define    WDT_TIMEOUT_25MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x01
+#define    WDT_TIMEOUT_50MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x02
+#define    WDT_TIMEOUT_100MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x03
+#define    WDT_TIMEOUT_200MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x04
+#define    WDT_TIMEOUT_400MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x05
+#define    WDT_TIMEOUT_800MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x06
+#define    WDT_TIMEOUT_1_6S                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x07
+
+#define    WDT_RUN_IN_POWERDOWN_ENABLE        set_WDCON_WIDPD
+#define    WDT_RUN_IN_POWERDOWN_DISABLE       clr_WDCON_WIDPD
+#define    WDT_COUNTER_CLEAR                  set_WDCON_WDCLR
+#define    WDT_COUNTER_RUN                    set_WDCON_WDTR
+
+/*************************************************************************/
+/*   PIN interrupt define                                                */
+/*************************************************************************/
+//---------------- Pin interrupt channel 0 PIT0 ------------------------
+#define    ENABLE_PIT0_P00_LOWLEVEL          SFRS=2;PIPS0=0x00;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P01_LOWLEVEL          SFRS=2;PIPS0=0x01;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P02_LOWLEVEL          SFRS=2;PIPS0=0x02;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P03_LOWLEVEL          SFRS=2;PIPS0=0x03;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P04_LOWLEVEL          SFRS=2;PIPS0=0x04;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P05_LOWLEVEL          SFRS=2;PIPS0=0x05;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P06_LOWLEVEL          SFRS=2;PIPS0=0x06;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P07_LOWLEVEL          SFRS=2;PIPS0=0x07;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P10_LOWLEVEL          SFRS=2;PIPS0=0x10;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P11_LOWLEVEL          SFRS=2;PIPS0=0x11;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P12_LOWLEVEL          SFRS=2;PIPS0=0x12;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P13_LOWLEVEL          SFRS=2;PIPS0=0x13;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P14_LOWLEVEL          SFRS=2;PIPS0=0x14;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P15_LOWLEVEL          SFRS=2;PIPS0=0x15;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P16_LOWLEVEL          SFRS=2;PIPS0=0x16;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P17_LOWLEVEL          SFRS=2;PIPS0=0x17;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P20_LOWLEVEL          SFRS=2;PIPS0=0x20;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P21_LOWLEVEL          SFRS=2;PIPS0=0x21;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P22_LOWLEVEL          SFRS=2;PIPS0=0x22;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P23_LOWLEVEL          SFRS=2;PIPS0=0x23;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P24_LOWLEVEL          SFRS=2;PIPS0=0x24;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P25_LOWLEVEL          SFRS=2;PIPS0=0x25;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P30_LOWLEVEL          SFRS=2;PIPS0=0x30;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P31_LOWLEVEL          SFRS=2;PIPS0=0x31;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P32_LOWLEVEL          SFRS=2;PIPS0=0x32;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P33_LOWLEVEL          SFRS=2;PIPS0=0x33;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P34_LOWLEVEL          SFRS=2;PIPS0=0x34;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P35_LOWLEVEL          SFRS=2;PIPS0=0x35;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P36_LOWLEVEL          SFRS=2;PIPS0=0x36;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P37_LOWLEVEL          SFRS=2;PIPS0=0x37;SFRS=0;PICON&=CLR_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+
+#define    ENABLE_PIT0_P00_HIGHLEVEL         SFRS=2;PIPS0=0x00;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P01_HIGHLEVEL         SFRS=2;PIPS0=0x01;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P02_HIGHLEVEL         SFRS=2;PIPS0=0x02;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P03_HIGHLEVEL         SFRS=2;PIPS0=0x03;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P04_HIGHLEVEL         SFRS=2;PIPS0=0x04;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P05_HIGHLEVEL         SFRS=2;PIPS0=0x05;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P06_HIGHLEVEL         SFRS=2;PIPS0=0x06;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P07_HIGHLEVEL         SFRS=2;PIPS0=0x07;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P10_HIGHLEVEL         SFRS=2;PIPS0=0x10;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P11_HIGHLEVEL         SFRS=2;PIPS0=0x11;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P12_HIGHLEVEL         SFRS=2;PIPS0=0x12;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P13_HIGHLEVEL         SFRS=2;PIPS0=0x13;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P14_HIGHLEVEL         SFRS=2;PIPS0=0x14;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P15_HIGHLEVEL         SFRS=2;PIPS0=0x15;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P16_HIGHLEVEL         SFRS=2;PIPS0=0x16;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P17_HIGHLEVEL         SFRS=2;PIPS0=0x17;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P20_HIGHLEVEL         SFRS=2;PIPS0=0x20;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P21_HIGHLEVEL         SFRS=2;PIPS0=0x21;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P22_HIGHLEVEL         SFRS=2;PIPS0=0x22;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P23_HIGHLEVEL         SFRS=2;PIPS0=0x23;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P24_HIGHLEVEL         SFRS=2;PIPS0=0x24;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P25_HIGHLEVEL         SFRS=2;PIPS0=0x25;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P30_HIGHLEVEL         SFRS=2;PIPS0=0x30;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P31_HIGHLEVEL         SFRS=2;PIPS0=0x31;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P32_HIGHLEVEL         SFRS=2;PIPS0=0x32;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P33_HIGHLEVEL         SFRS=2;PIPS0=0x33;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P34_HIGHLEVEL         SFRS=2;PIPS0=0x34;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P35_HIGHLEVEL         SFRS=2;PIPS0=0x35;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P36_HIGHLEVEL         SFRS=2;PIPS0=0x36;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P37_HIGHLEVEL         SFRS=2;PIPS0=0x37;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+
+#define    ENABLE_PIT0_P00_FALLINGEDGE       SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P01_FALLINGEDGE       SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P02_FALLINGEDGE       SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P03_FALLINGEDGE       SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P04_FALLINGEDGE       SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P05_FALLINGEDGE       SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P06_FALLINGEDGE       SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P07_FALLINGEDGE       SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P10_FALLINGEDGE       SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P11_FALLINGEDGE       SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P12_FALLINGEDGE       SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P13_FALLINGEDGE       SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P14_FALLINGEDGE       SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P15_FALLINGEDGE       SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P16_FALLINGEDGE       SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P17_FALLINGEDGE       SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P20_FALLINGEDGE       SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P21_FALLINGEDGE       SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P22_FALLINGEDGE       SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P23_FALLINGEDGE       SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P24_FALLINGEDGE       SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P25_FALLINGEDGE       SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P30_FALLINGEDGE       SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P31_FALLINGEDGE       SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P32_FALLINGEDGE       SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P33_FALLINGEDGE       SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P34_FALLINGEDGE       SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P35_FALLINGEDGE       SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P36_FALLINGEDGE       SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+#define    ENABLE_PIT0_P37_FALLINGEDGE       SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN&=CLR_BIT0
+
+#define    ENABLE_PIT0_P00_RISINGEDGE        SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P01_RISINGEDGE        SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P02_RISINGEDGE        SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P03_RISINGEDGE        SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P04_RISINGEDGE        SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P05_RISINGEDGE        SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P06_RISINGEDGE        SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P07_RISINGEDGE        SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P10_RISINGEDGE        SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P11_RISINGEDGE        SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P12_RISINGEDGE        SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P13_RISINGEDGE        SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P14_RISINGEDGE        SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P15_RISINGEDGE        SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P16_RISINGEDGE        SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P17_RISINGEDGE        SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P20_RISINGEDGE        SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P21_RISINGEDGE        SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P22_RISINGEDGE        SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P23_RISINGEDGE        SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P24_RISINGEDGE        SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P25_RISINGEDGE        SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P30_RISINGEDGE        SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P31_RISINGEDGE        SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P32_RISINGEDGE        SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P33_RISINGEDGE        SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P34_RISINGEDGE        SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P35_RISINGEDGE        SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P36_RISINGEDGE        SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P37_RISINGEDGE        SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN|=SET_BIT0
+
+#define    ENABLE_PIT0_P00_BOTHEDGE          SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P01_BOTHEDGE          SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P02_BOTHEDGE          SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P03_BOTHEDGE          SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P04_BOTHEDGE          SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P05_BOTHEDGE          SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P06_BOTHEDGE          SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P07_BOTHEDGE          SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P10_BOTHEDGE          SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P11_BOTHEDGE          SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P12_BOTHEDGE          SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P13_BOTHEDGE          SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P14_BOTHEDGE          SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P15_BOTHEDGE          SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P16_BOTHEDGE          SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P17_BOTHEDGE          SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P20_BOTHEDGE          SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P21_BOTHEDGE          SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P22_BOTHEDGE          SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P23_BOTHEDGE          SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P24_BOTHEDGE          SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P25_BOTHEDGE          SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P30_BOTHEDGE          SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P31_BOTHEDGE          SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P32_BOTHEDGE          SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P33_BOTHEDGE          SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P34_BOTHEDGE          SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P35_BOTHEDGE          SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P36_BOTHEDGE          SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+#define    ENABLE_PIT0_P37_BOTHEDGE          SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN|=SET_BIT0;PIPEN|=SET_BIT0
+
+//---------------- Pin interrupt channel 0 PIT0 Disable ------------------------
+#define    DISABLE_PIT0_P00_LOWLEVEL         SFRS=2;PIPS0=0x00;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P01_LOWLEVEL         SFRS=2;PIPS0=0x01;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P02_LOWLEVEL         SFRS=2;PIPS0=0x02;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P03_LOWLEVEL         SFRS=2;PIPS0=0x03;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P04_LOWLEVEL         SFRS=2;PIPS0=0x04;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P05_LOWLEVEL         SFRS=2;PIPS0=0x05;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P06_LOWLEVEL         SFRS=2;PIPS0=0x06;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P07_LOWLEVEL         SFRS=2;PIPS0=0x07;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P10_LOWLEVEL         SFRS=2;PIPS0=0x10;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P11_LOWLEVEL         SFRS=2;PIPS0=0x11;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P12_LOWLEVEL         SFRS=2;PIPS0=0x12;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P13_LOWLEVEL         SFRS=2;PIPS0=0x13;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P14_LOWLEVEL         SFRS=2;PIPS0=0x14;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P15_LOWLEVEL         SFRS=2;PIPS0=0x15;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P16_LOWLEVEL         SFRS=2;PIPS0=0x16;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P17_LOWLEVEL         SFRS=2;PIPS0=0x17;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P20_LOWLEVEL         SFRS=2;PIPS0=0x20;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P21_LOWLEVEL         SFRS=2;PIPS0=0x21;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P22_LOWLEVEL         SFRS=2;PIPS0=0x22;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P23_LOWLEVEL         SFRS=2;PIPS0=0x23;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P24_LOWLEVEL         SFRS=2;PIPS0=0x24;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P25_LOWLEVEL         SFRS=2;PIPS0=0x25;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P30_LOWLEVEL         SFRS=2;PIPS0=0x30;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P31_LOWLEVEL         SFRS=2;PIPS0=0x31;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P32_LOWLEVEL         SFRS=2;PIPS0=0x32;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P33_LOWLEVEL         SFRS=2;PIPS0=0x33;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P34_LOWLEVEL         SFRS=2;PIPS0=0x34;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P35_LOWLEVEL         SFRS=2;PIPS0=0x35;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P36_LOWLEVEL         SFRS=2;PIPS0=0x36;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P37_LOWLEVEL         SFRS=2;PIPS0=0x37;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+
+#define    DISABLE_PIT0_P00_HIGHLEVEL        SFRS=2;PIPS0=0x00;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P01_HIGHLEVEL        SFRS=2;PIPS0=0x01;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P02_HIGHLEVEL        SFRS=2;PIPS0=0x02;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P03_HIGHLEVEL        SFRS=2;PIPS0=0x03;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P04_HIGHLEVEL        SFRS=2;PIPS0=0x04;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P05_HIGHLEVEL        SFRS=2;PIPS0=0x05;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P06_HIGHLEVEL        SFRS=2;PIPS0=0x06;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P07_HIGHLEVEL        SFRS=2;PIPS0=0x07;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P10_HIGHLEVEL        SFRS=2;PIPS0=0x10;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P11_HIGHLEVEL        SFRS=2;PIPS0=0x11;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P12_HIGHLEVEL        SFRS=2;PIPS0=0x12;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P13_HIGHLEVEL        SFRS=2;PIPS0=0x13;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P14_HIGHLEVEL        SFRS=2;PIPS0=0x14;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P15_HIGHLEVEL        SFRS=2;PIPS0=0x15;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P16_HIGHLEVEL        SFRS=2;PIPS0=0x16;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P17_HIGHLEVEL        SFRS=2;PIPS0=0x17;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P20_HIGHLEVEL        SFRS=2;PIPS0=0x20;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P21_HIGHLEVEL        SFRS=2;PIPS0=0x21;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P22_HIGHLEVEL        SFRS=2;PIPS0=0x22;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P23_HIGHLEVEL        SFRS=2;PIPS0=0x23;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P24_HIGHLEVEL        SFRS=2;PIPS0=0x24;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P25_HIGHLEVEL        SFRS=2;PIPS0=0x25;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P30_HIGHLEVEL        SFRS=2;PIPS0=0x30;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P31_HIGHLEVEL        SFRS=2;PIPS0=0x31;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P32_HIGHLEVEL        SFRS=2;PIPS0=0x32;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P33_HIGHLEVEL        SFRS=2;PIPS0=0x33;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P34_HIGHLEVEL        SFRS=2;PIPS0=0x34;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P35_HIGHLEVEL        SFRS=2;PIPS0=0x35;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P36_HIGHLEVEL        SFRS=2;PIPS0=0x36;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P37_HIGHLEVEL        SFRS=2;PIPS0=0x37;SFRS=0;PICON&=CLR_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+
+#define    DISABLE_PIT0_P00_FALLINGEDGE      SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P01_FALLINGEDGE      SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P02_FALLINGEDGE      SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P03_FALLINGEDGE      SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P04_FALLINGEDGE      SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P05_FALLINGEDGE      SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P06_FALLINGEDGE      SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P07_FALLINGEDGE      SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P10_FALLINGEDGE      SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P11_FALLINGEDGE      SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P12_FALLINGEDGE      SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P13_FALLINGEDGE      SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P14_FALLINGEDGE      SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P15_FALLINGEDGE      SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P16_FALLINGEDGE      SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P17_FALLINGEDGE      SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P20_FALLINGEDGE      SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P21_FALLINGEDGE      SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P22_FALLINGEDGE      SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P23_FALLINGEDGE      SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P24_FALLINGEDGE      SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P25_FALLINGEDGE      SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P30_FALLINGEDGE      SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P31_FALLINGEDGE      SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P32_FALLINGEDGE      SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P33_FALLINGEDGE      SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P34_FALLINGEDGE      SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P35_FALLINGEDGE      SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P36_FALLINGEDGE      SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P37_FALLINGEDGE      SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+
+#define    DISABLE_PIT0_P00_RISINGEDGE       SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P01_RISINGEDGE       SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P02_RISINGEDGE       SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P03_RISINGEDGE       SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P04_RISINGEDGE       SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P05_RISINGEDGE       SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P06_RISINGEDGE       SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P07_RISINGEDGE       SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P10_RISINGEDGE       SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P11_RISINGEDGE       SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P12_RISINGEDGE       SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P13_RISINGEDGE       SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P14_RISINGEDGE       SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P15_RISINGEDGE       SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P16_RISINGEDGE       SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P17_RISINGEDGE       SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P20_RISINGEDGE       SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P21_RISINGEDGE       SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P22_RISINGEDGE       SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P23_RISINGEDGE       SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P24_RISINGEDGE       SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P25_RISINGEDGE       SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P30_RISINGEDGE       SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P31_RISINGEDGE       SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P32_RISINGEDGE       SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P33_RISINGEDGE       SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P34_RISINGEDGE       SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P35_RISINGEDGE       SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P36_RISINGEDGE       SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P37_RISINGEDGE       SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+
+#define    DISABLE_PIT0_P00_BOTHEDGE         SFRS=2;PIPS0=0x00;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P01_BOTHEDGE         SFRS=2;PIPS0=0x01;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P02_BOTHEDGE         SFRS=2;PIPS0=0x02;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P03_BOTHEDGE         SFRS=2;PIPS0=0x03;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P04_BOTHEDGE         SFRS=2;PIPS0=0x04;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P05_BOTHEDGE         SFRS=2;PIPS0=0x05;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P06_BOTHEDGE         SFRS=2;PIPS0=0x06;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P07_BOTHEDGE         SFRS=2;PIPS0=0x07;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P10_BOTHEDGE         SFRS=2;PIPS0=0x10;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P11_BOTHEDGE         SFRS=2;PIPS0=0x11;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P12_BOTHEDGE         SFRS=2;PIPS0=0x12;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P13_BOTHEDGE         SFRS=2;PIPS0=0x13;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P14_BOTHEDGE         SFRS=2;PIPS0=0x14;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P15_BOTHEDGE         SFRS=2;PIPS0=0x15;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P16_BOTHEDGE         SFRS=2;PIPS0=0x16;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P17_BOTHEDGE         SFRS=2;PIPS0=0x17;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P20_BOTHEDGE         SFRS=2;PIPS0=0x20;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P21_BOTHEDGE         SFRS=2;PIPS0=0x21;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P22_BOTHEDGE         SFRS=2;PIPS0=0x22;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P23_BOTHEDGE         SFRS=2;PIPS0=0x23;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P24_BOTHEDGE         SFRS=2;PIPS0=0x24;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P25_BOTHEDGE         SFRS=2;PIPS0=0x25;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P30_BOTHEDGE         SFRS=2;PIPS0=0x30;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P31_BOTHEDGE         SFRS=2;PIPS0=0x31;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P32_BOTHEDGE         SFRS=2;PIPS0=0x32;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P33_BOTHEDGE         SFRS=2;PIPS0=0x33;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P34_BOTHEDGE         SFRS=2;PIPS0=0x34;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P35_BOTHEDGE         SFRS=2;PIPS0=0x35;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P36_BOTHEDGE         SFRS=2;PIPS0=0x36;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+#define    DISABLE_PIT0_P37_BOTHEDGE         SFRS=2;PIPS0=0x37;SFRS=0;PICON|=SET_BIT0;PINEN&=CLR_BIT0;PIPEN&=CLR_BIT0
+
+  /*------- -------- Pin interrupt channel 1 PIT1 ------------------------ */
+#define    ENABLE_PIT1_P00_LOWLEVEL          SFRS=2;PIPS1=0x00;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P01_LOWLEVEL          SFRS=2;PIPS1=0x01;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P02_LOWLEVEL          SFRS=2;PIPS1=0x02;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P03_LOWLEVEL          SFRS=2;PIPS1=0x03;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P04_LOWLEVEL          SFRS=2;PIPS1=0x04;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P05_LOWLEVEL          SFRS=2;PIPS1=0x05;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P06_LOWLEVEL          SFRS=2;PIPS1=0x06;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P07_LOWLEVEL          SFRS=2;PIPS1=0x07;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P10_LOWLEVEL          SFRS=2;PIPS1=0x10;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P11_LOWLEVEL          SFRS=2;PIPS1=0x11;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P12_LOWLEVEL          SFRS=2;PIPS1=0x12;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P13_LOWLEVEL          SFRS=2;PIPS1=0x13;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P14_LOWLEVEL          SFRS=2;PIPS1=0x14;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P15_LOWLEVEL          SFRS=2;PIPS1=0x15;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P16_LOWLEVEL          SFRS=2;PIPS1=0x16;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P17_LOWLEVEL          SFRS=2;PIPS1=0x17;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P20_LOWLEVEL          SFRS=2;PIPS1=0x20;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P21_LOWLEVEL          SFRS=2;PIPS1=0x21;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P22_LOWLEVEL          SFRS=2;PIPS1=0x22;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P23_LOWLEVEL          SFRS=2;PIPS1=0x23;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P24_LOWLEVEL          SFRS=2;PIPS1=0x24;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P25_LOWLEVEL          SFRS=2;PIPS1=0x25;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P30_LOWLEVEL          SFRS=2;PIPS1=0x30;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P31_LOWLEVEL          SFRS=2;PIPS1=0x31;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P32_LOWLEVEL          SFRS=2;PIPS1=0x32;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P33_LOWLEVEL          SFRS=2;PIPS1=0x33;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P34_LOWLEVEL          SFRS=2;PIPS1=0x34;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P35_LOWLEVEL          SFRS=2;PIPS1=0x35;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P36_LOWLEVEL          SFRS=2;PIPS1=0x36;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P37_LOWLEVEL          SFRS=2;PIPS1=0x37;SFRS=0;PICON&=CLR_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+
+#define    ENABLE_PIT1_P00_HIGHLEVEL         SFRS=2;PIPS1=0x00;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P01_HIGHLEVEL         SFRS=2;PIPS1=0x01;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P02_HIGHLEVEL         SFRS=2;PIPS1=0x02;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P03_HIGHLEVEL         SFRS=2;PIPS1=0x03;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P04_HIGHLEVEL         SFRS=2;PIPS1=0x04;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P05_HIGHLEVEL         SFRS=2;PIPS1=0x05;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P06_HIGHLEVEL         SFRS=2;PIPS1=0x06;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P07_HIGHLEVEL         SFRS=2;PIPS1=0x07;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P10_HIGHLEVEL         SFRS=2;PIPS1=0x10;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P11_HIGHLEVEL         SFRS=2;PIPS1=0x11;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P12_HIGHLEVEL         SFRS=2;PIPS1=0x12;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P13_HIGHLEVEL         SFRS=2;PIPS1=0x13;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P14_HIGHLEVEL         SFRS=2;PIPS1=0x14;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P15_HIGHLEVEL         SFRS=2;PIPS1=0x15;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P16_HIGHLEVEL         SFRS=2;PIPS1=0x16;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P17_HIGHLEVEL         SFRS=2;PIPS1=0x17;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P20_HIGHLEVEL         SFRS=2;PIPS1=0x20;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P21_HIGHLEVEL         SFRS=2;PIPS1=0x21;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P22_HIGHLEVEL         SFRS=2;PIPS1=0x22;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P23_HIGHLEVEL         SFRS=2;PIPS1=0x23;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P24_HIGHLEVEL         SFRS=2;PIPS1=0x24;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P25_HIGHLEVEL         SFRS=2;PIPS1=0x25;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P30_HIGHLEVEL         SFRS=2;PIPS1=0x30;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P31_HIGHLEVEL         SFRS=2;PIPS1=0x31;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P32_HIGHLEVEL         SFRS=2;PIPS1=0x32;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P33_HIGHLEVEL         SFRS=2;PIPS1=0x33;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P34_HIGHLEVEL         SFRS=2;PIPS1=0x34;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P35_HIGHLEVEL         SFRS=2;PIPS1=0x35;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P36_HIGHLEVEL         SFRS=2;PIPS1=0x36;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P37_HIGHLEVEL         SFRS=2;PIPS1=0x37;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+
+#define    ENABLE_PIT1_P00_FALLINGEDGE       SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P01_FALLINGEDGE       SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P02_FALLINGEDGE       SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P03_FALLINGEDGE       SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P04_FALLINGEDGE       SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P05_FALLINGEDGE       SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P06_FALLINGEDGE       SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P07_FALLINGEDGE       SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P10_FALLINGEDGE       SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P11_FALLINGEDGE       SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P12_FALLINGEDGE       SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P13_FALLINGEDGE       SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P14_FALLINGEDGE       SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P15_FALLINGEDGE       SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P16_FALLINGEDGE       SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P17_FALLINGEDGE       SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P20_FALLINGEDGE       SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P21_FALLINGEDGE       SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P22_FALLINGEDGE       SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P23_FALLINGEDGE       SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P24_FALLINGEDGE       SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P25_FALLINGEDGE       SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P30_FALLINGEDGE       SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P31_FALLINGEDGE       SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P32_FALLINGEDGE       SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P33_FALLINGEDGE       SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P34_FALLINGEDGE       SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P35_FALLINGEDGE       SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P36_FALLINGEDGE       SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+#define    ENABLE_PIT1_P37_FALLINGEDGE       SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN&=CLR_BIT1
+
+#define    ENABLE_PIT1_P00_RISINGEDGE        SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P01_RISINGEDGE        SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P02_RISINGEDGE        SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P03_RISINGEDGE        SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P04_RISINGEDGE        SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P05_RISINGEDGE        SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P06_RISINGEDGE        SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P07_RISINGEDGE        SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P10_RISINGEDGE        SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P11_RISINGEDGE        SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P12_RISINGEDGE        SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P13_RISINGEDGE        SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P14_RISINGEDGE        SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P15_RISINGEDGE        SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P16_RISINGEDGE        SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P17_RISINGEDGE        SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P20_RISINGEDGE        SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P21_RISINGEDGE        SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P22_RISINGEDGE        SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P23_RISINGEDGE        SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P24_RISINGEDGE        SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P25_RISINGEDGE        SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P30_RISINGEDGE        SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P31_RISINGEDGE        SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P32_RISINGEDGE        SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P33_RISINGEDGE        SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P34_RISINGEDGE        SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P35_RISINGEDGE        SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P36_RISINGEDGE        SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P37_RISINGEDGE        SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN|=SET_BIT1
+
+#define    ENABLE_PIT1_P00_BOTHEDGE          SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P01_BOTHEDGE          SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P02_BOTHEDGE          SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P03_BOTHEDGE          SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P04_BOTHEDGE          SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P05_BOTHEDGE          SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P06_BOTHEDGE          SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P07_BOTHEDGE          SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P10_BOTHEDGE          SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P11_BOTHEDGE          SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P12_BOTHEDGE          SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P13_BOTHEDGE          SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P14_BOTHEDGE          SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P15_BOTHEDGE          SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P16_BOTHEDGE          SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P17_BOTHEDGE          SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P20_BOTHEDGE          SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P21_BOTHEDGE          SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P22_BOTHEDGE          SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P23_BOTHEDGE          SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P24_BOTHEDGE          SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P25_BOTHEDGE          SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P30_BOTHEDGE          SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P31_BOTHEDGE          SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P32_BOTHEDGE          SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P33_BOTHEDGE          SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P34_BOTHEDGE          SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P35_BOTHEDGE          SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P36_BOTHEDGE          SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+#define    ENABLE_PIT1_P37_BOTHEDGE          SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN|=SET_BIT1;PIPEN|=SET_BIT1
+
+  /*------- -------- Pin interrupt channel 1 PIT1 Disable ------------------------ */
+#define    DISABLE_PIT1_P00_LOWLEVEL         SFRS=2;PIPS1=0x00;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P01_LOWLEVEL         SFRS=2;PIPS1=0x01;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P02_LOWLEVEL         SFRS=2;PIPS1=0x02;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P03_LOWLEVEL         SFRS=2;PIPS1=0x03;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P04_LOWLEVEL         SFRS=2;PIPS1=0x04;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P05_LOWLEVEL         SFRS=2;PIPS1=0x05;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P06_LOWLEVEL         SFRS=2;PIPS1=0x06;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P07_LOWLEVEL         SFRS=2;PIPS1=0x07;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P10_LOWLEVEL         SFRS=2;PIPS1=0x10;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P11_LOWLEVEL         SFRS=2;PIPS1=0x11;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P12_LOWLEVEL         SFRS=2;PIPS1=0x12;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P13_LOWLEVEL         SFRS=2;PIPS1=0x13;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P14_LOWLEVEL         SFRS=2;PIPS1=0x14;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P15_LOWLEVEL         SFRS=2;PIPS1=0x15;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P16_LOWLEVEL         SFRS=2;PIPS1=0x16;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P17_LOWLEVEL         SFRS=2;PIPS1=0x17;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P20_LOWLEVEL         SFRS=2;PIPS1=0x20;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P21_LOWLEVEL         SFRS=2;PIPS1=0x21;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P22_LOWLEVEL         SFRS=2;PIPS1=0x22;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P23_LOWLEVEL         SFRS=2;PIPS1=0x23;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P24_LOWLEVEL         SFRS=2;PIPS1=0x24;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P25_LOWLEVEL         SFRS=2;PIPS1=0x25;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P30_LOWLEVEL         SFRS=2;PIPS1=0x30;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P31_LOWLEVEL         SFRS=2;PIPS1=0x31;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P32_LOWLEVEL         SFRS=2;PIPS1=0x32;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P33_LOWLEVEL         SFRS=2;PIPS1=0x33;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P34_LOWLEVEL         SFRS=2;PIPS1=0x34;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P35_LOWLEVEL         SFRS=2;PIPS1=0x35;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P36_LOWLEVEL         SFRS=2;PIPS1=0x36;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P37_LOWLEVEL         SFRS=2;PIPS1=0x37;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+
+#define    DISABLE_PIT1_P00_HIGHLEVEL        SFRS=2;PIPS1=0x00;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P01_HIGHLEVEL        SFRS=2;PIPS1=0x01;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P02_HIGHLEVEL        SFRS=2;PIPS1=0x02;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P03_HIGHLEVEL        SFRS=2;PIPS1=0x03;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P04_HIGHLEVEL        SFRS=2;PIPS1=0x04;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P05_HIGHLEVEL        SFRS=2;PIPS1=0x05;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P06_HIGHLEVEL        SFRS=2;PIPS1=0x06;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P07_HIGHLEVEL        SFRS=2;PIPS1=0x07;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P10_HIGHLEVEL        SFRS=2;PIPS1=0x10;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P11_HIGHLEVEL        SFRS=2;PIPS1=0x11;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P12_HIGHLEVEL        SFRS=2;PIPS1=0x12;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P13_HIGHLEVEL        SFRS=2;PIPS1=0x13;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P14_HIGHLEVEL        SFRS=2;PIPS1=0x14;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P15_HIGHLEVEL        SFRS=2;PIPS1=0x15;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P16_HIGHLEVEL        SFRS=2;PIPS1=0x16;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P17_HIGHLEVEL        SFRS=2;PIPS1=0x17;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P20_HIGHLEVEL        SFRS=2;PIPS1=0x20;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P21_HIGHLEVEL        SFRS=2;PIPS1=0x21;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P22_HIGHLEVEL        SFRS=2;PIPS1=0x22;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P23_HIGHLEVEL        SFRS=2;PIPS1=0x23;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P24_HIGHLEVEL        SFRS=2;PIPS1=0x24;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P25_HIGHLEVEL        SFRS=2;PIPS1=0x25;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P30_HIGHLEVEL        SFRS=2;PIPS1=0x30;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P31_HIGHLEVEL        SFRS=2;PIPS1=0x31;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P32_HIGHLEVEL        SFRS=2;PIPS1=0x32;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P33_HIGHLEVEL        SFRS=2;PIPS1=0x33;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P34_HIGHLEVEL        SFRS=2;PIPS1=0x34;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P35_HIGHLEVEL        SFRS=2;PIPS1=0x35;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P36_HIGHLEVEL        SFRS=2;PIPS1=0x36;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P37_HIGHLEVEL        SFRS=2;PIPS1=0x37;SFRS=0;PICON&=CLR_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+
+#define    DISABLE_PIT1_P00_FALLINGEDGE      SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P01_FALLINGEDGE      SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P02_FALLINGEDGE      SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P03_FALLINGEDGE      SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P04_FALLINGEDGE      SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P05_FALLINGEDGE      SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P06_FALLINGEDGE      SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P07_FALLINGEDGE      SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P10_FALLINGEDGE      SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P11_FALLINGEDGE      SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P12_FALLINGEDGE      SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P13_FALLINGEDGE      SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P14_FALLINGEDGE      SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P15_FALLINGEDGE      SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P16_FALLINGEDGE      SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P17_FALLINGEDGE      SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P20_FALLINGEDGE      SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P21_FALLINGEDGE      SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P22_FALLINGEDGE      SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P23_FALLINGEDGE      SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P24_FALLINGEDGE      SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P25_FALLINGEDGE      SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P30_FALLINGEDGE      SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P31_FALLINGEDGE      SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P32_FALLINGEDGE      SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P33_FALLINGEDGE      SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P34_FALLINGEDGE      SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P35_FALLINGEDGE      SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P36_FALLINGEDGE      SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P37_FALLINGEDGE      SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+
+#define    DISABLE_PIT1_P00_RISINGEDGE       SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P01_RISINGEDGE       SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P02_RISINGEDGE       SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P03_RISINGEDGE       SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P04_RISINGEDGE       SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P05_RISINGEDGE       SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P06_RISINGEDGE       SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P07_RISINGEDGE       SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P10_RISINGEDGE       SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P11_RISINGEDGE       SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P12_RISINGEDGE       SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P13_RISINGEDGE       SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P14_RISINGEDGE       SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P15_RISINGEDGE       SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P16_RISINGEDGE       SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P17_RISINGEDGE       SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P20_RISINGEDGE       SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P21_RISINGEDGE       SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P22_RISINGEDGE       SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P23_RISINGEDGE       SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P24_RISINGEDGE       SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P25_RISINGEDGE       SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P30_RISINGEDGE       SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P31_RISINGEDGE       SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P32_RISINGEDGE       SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P33_RISINGEDGE       SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P34_RISINGEDGE       SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P35_RISINGEDGE       SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P36_RISINGEDGE       SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P37_RISINGEDGE       SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+
+#define    DISABLE_PIT1_P00_BOTHEDGE         SFRS=2;PIPS1=0x00;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P01_BOTHEDGE         SFRS=2;PIPS1=0x01;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P02_BOTHEDGE         SFRS=2;PIPS1=0x02;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P03_BOTHEDGE         SFRS=2;PIPS1=0x03;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P04_BOTHEDGE         SFRS=2;PIPS1=0x04;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P05_BOTHEDGE         SFRS=2;PIPS1=0x05;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P06_BOTHEDGE         SFRS=2;PIPS1=0x06;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P07_BOTHEDGE         SFRS=2;PIPS1=0x07;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P10_BOTHEDGE         SFRS=2;PIPS1=0x10;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P11_BOTHEDGE         SFRS=2;PIPS1=0x11;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P12_BOTHEDGE         SFRS=2;PIPS1=0x12;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P13_BOTHEDGE         SFRS=2;PIPS1=0x13;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P14_BOTHEDGE         SFRS=2;PIPS1=0x14;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P15_BOTHEDGE         SFRS=2;PIPS1=0x15;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P16_BOTHEDGE         SFRS=2;PIPS1=0x16;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P17_BOTHEDGE         SFRS=2;PIPS1=0x17;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P20_BOTHEDGE         SFRS=2;PIPS1=0x20;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P21_BOTHEDGE         SFRS=2;PIPS1=0x21;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P22_BOTHEDGE         SFRS=2;PIPS1=0x22;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P23_BOTHEDGE         SFRS=2;PIPS1=0x23;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P24_BOTHEDGE         SFRS=2;PIPS1=0x24;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P25_BOTHEDGE         SFRS=2;PIPS1=0x25;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P30_BOTHEDGE         SFRS=2;PIPS1=0x30;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P31_BOTHEDGE         SFRS=2;PIPS1=0x31;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P32_BOTHEDGE         SFRS=2;PIPS1=0x32;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P33_BOTHEDGE         SFRS=2;PIPS1=0x33;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P34_BOTHEDGE         SFRS=2;PIPS1=0x34;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P35_BOTHEDGE         SFRS=2;PIPS1=0x35;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P36_BOTHEDGE         SFRS=2;PIPS1=0x36;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+#define    DISABLE_PIT1_P37_BOTHEDGE         SFRS=2;PIPS1=0x37;SFRS=0;PICON|=SET_BIT1;PINEN&=CLR_BIT1;PIPEN&=CLR_BIT1
+
+
+  /*------- -------- Pin interrupt channel 2 PIT2 Enable ------------------------ */
+#define    ENABLE_PIT2_P00_LOWLEVEL          SFRS=2;PIPS2=0x00;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P01_LOWLEVEL          SFRS=2;PIPS2=0x01;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P02_LOWLEVEL          SFRS=2;PIPS2=0x02;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P03_LOWLEVEL          SFRS=2;PIPS2=0x03;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P04_LOWLEVEL          SFRS=2;PIPS2=0x04;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P05_LOWLEVEL          SFRS=2;PIPS2=0x05;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P06_LOWLEVEL          SFRS=2;PIPS2=0x06;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P07_LOWLEVEL          SFRS=2;PIPS2=0x07;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P10_LOWLEVEL          SFRS=2;PIPS2=0x10;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P11_LOWLEVEL          SFRS=2;PIPS2=0x11;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P12_LOWLEVEL          SFRS=2;PIPS2=0x12;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P13_LOWLEVEL          SFRS=2;PIPS2=0x13;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P14_LOWLEVEL          SFRS=2;PIPS2=0x14;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P15_LOWLEVEL          SFRS=2;PIPS2=0x15;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P16_LOWLEVEL          SFRS=2;PIPS2=0x16;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P17_LOWLEVEL          SFRS=2;PIPS2=0x17;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P20_LOWLEVEL          SFRS=2;PIPS2=0x20;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P21_LOWLEVEL          SFRS=2;PIPS2=0x21;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P22_LOWLEVEL          SFRS=2;PIPS2=0x22;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P23_LOWLEVEL          SFRS=2;PIPS2=0x23;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P24_LOWLEVEL          SFRS=2;PIPS2=0x24;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P25_LOWLEVEL          SFRS=2;PIPS2=0x25;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P30_LOWLEVEL          SFRS=2;PIPS2=0x30;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P31_LOWLEVEL          SFRS=2;PIPS2=0x31;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P32_LOWLEVEL          SFRS=2;PIPS2=0x32;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P33_LOWLEVEL          SFRS=2;PIPS2=0x33;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P34_LOWLEVEL          SFRS=2;PIPS2=0x34;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P35_LOWLEVEL          SFRS=2;PIPS2=0x35;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P36_LOWLEVEL          SFRS=2;PIPS2=0x36;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P37_LOWLEVEL          SFRS=2;PIPS2=0x37;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+           
+#define    ENABLE_PIT2_P00_HIGHLEVEL         SFRS=2;PIPS2=0x00;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P01_HIGHLEVEL         SFRS=2;PIPS2=0x01;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P02_HIGHLEVEL         SFRS=2;PIPS2=0x02;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P03_HIGHLEVEL         SFRS=2;PIPS2=0x03;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P04_HIGHLEVEL         SFRS=2;PIPS2=0x04;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P05_HIGHLEVEL         SFRS=2;PIPS2=0x05;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P06_HIGHLEVEL         SFRS=2;PIPS2=0x06;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P07_HIGHLEVEL         SFRS=2;PIPS2=0x07;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P10_HIGHLEVEL         SFRS=2;PIPS2=0x10;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P11_HIGHLEVEL         SFRS=2;PIPS2=0x11;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P12_HIGHLEVEL         SFRS=2;PIPS2=0x12;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P13_HIGHLEVEL         SFRS=2;PIPS2=0x13;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P14_HIGHLEVEL         SFRS=2;PIPS2=0x14;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P15_HIGHLEVEL         SFRS=2;PIPS2=0x15;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P16_HIGHLEVEL         SFRS=2;PIPS2=0x16;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P17_HIGHLEVEL         SFRS=2;PIPS2=0x17;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P20_HIGHLEVEL         SFRS=2;PIPS2=0x20;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P21_HIGHLEVEL         SFRS=2;PIPS2=0x21;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P22_HIGHLEVEL         SFRS=2;PIPS2=0x22;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P23_HIGHLEVEL         SFRS=2;PIPS2=0x23;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P24_HIGHLEVEL         SFRS=2;PIPS2=0x24;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P25_HIGHLEVEL         SFRS=2;PIPS2=0x25;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P30_HIGHLEVEL         SFRS=2;PIPS2=0x30;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P31_HIGHLEVEL         SFRS=2;PIPS2=0x31;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P32_HIGHLEVEL         SFRS=2;PIPS2=0x32;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P33_HIGHLEVEL         SFRS=2;PIPS2=0x33;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P34_HIGHLEVEL         SFRS=2;PIPS2=0x34;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P35_HIGHLEVEL         SFRS=2;PIPS2=0x35;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P36_HIGHLEVEL         SFRS=2;PIPS2=0x36;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P37_HIGHLEVEL         SFRS=2;PIPS2=0x37;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+           
+#define    ENABLE_PIT2_P00_FALLINGEDGE       SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P01_FALLINGEDGE       SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P02_FALLINGEDGE       SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P03_FALLINGEDGE       SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P04_FALLINGEDGE       SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P05_FALLINGEDGE       SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P06_FALLINGEDGE       SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P07_FALLINGEDGE       SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P10_FALLINGEDGE       SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P11_FALLINGEDGE       SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P12_FALLINGEDGE       SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P13_FALLINGEDGE       SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P14_FALLINGEDGE       SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P15_FALLINGEDGE       SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P16_FALLINGEDGE       SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P17_FALLINGEDGE       SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P20_FALLINGEDGE       SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P21_FALLINGEDGE       SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P22_FALLINGEDGE       SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P23_FALLINGEDGE       SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P24_FALLINGEDGE       SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P25_FALLINGEDGE       SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P30_FALLINGEDGE       SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P31_FALLINGEDGE       SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P32_FALLINGEDGE       SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P33_FALLINGEDGE       SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P34_FALLINGEDGE       SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P35_FALLINGEDGE       SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P36_FALLINGEDGE       SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    ENABLE_PIT2_P37_FALLINGEDGE       SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+
+#define    ENABLE_PIT2_P00_RISINGEDGE        SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P01_RISINGEDGE        SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P02_RISINGEDGE        SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P03_RISINGEDGE        SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P04_RISINGEDGE        SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P05_RISINGEDGE        SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P06_RISINGEDGE        SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P07_RISINGEDGE        SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P10_RISINGEDGE        SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P11_RISINGEDGE        SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P12_RISINGEDGE        SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P13_RISINGEDGE        SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P14_RISINGEDGE        SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P15_RISINGEDGE        SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P16_RISINGEDGE        SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P17_RISINGEDGE        SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P20_RISINGEDGE        SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P21_RISINGEDGE        SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P22_RISINGEDGE        SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P23_RISINGEDGE        SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P24_RISINGEDGE        SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P25_RISINGEDGE        SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P30_RISINGEDGE        SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P31_RISINGEDGE        SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P32_RISINGEDGE        SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P33_RISINGEDGE        SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P34_RISINGEDGE        SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P35_RISINGEDGE        SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P36_RISINGEDGE        SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P37_RISINGEDGE        SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+
+#define    ENABLE_PIT2_P00_BOTHEDGE          SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P01_BOTHEDGE          SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P02_BOTHEDGE          SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P03_BOTHEDGE          SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P04_BOTHEDGE          SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P05_BOTHEDGE          SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P06_BOTHEDGE          SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P07_BOTHEDGE          SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P10_BOTHEDGE          SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P11_BOTHEDGE          SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P12_BOTHEDGE          SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P13_BOTHEDGE          SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P14_BOTHEDGE          SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P15_BOTHEDGE          SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P16_BOTHEDGE          SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P17_BOTHEDGE          SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P20_BOTHEDGE          SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P21_BOTHEDGE          SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P22_BOTHEDGE          SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P23_BOTHEDGE          SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P24_BOTHEDGE          SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P25_BOTHEDGE          SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P30_BOTHEDGE          SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P31_BOTHEDGE          SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P32_BOTHEDGE          SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P33_BOTHEDGE          SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P34_BOTHEDGE          SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P35_BOTHEDGE          SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P36_BOTHEDGE          SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+#define    ENABLE_PIT2_P37_BOTHEDGE          SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN|=SET_BIT2
+
+  /*------- -------- Pin interrupt channel 2 PIT2 Disable ------------------------ */
+#define    DISABLE_PIT2_P00_LOWLEVEL         SFRS=2;PIPS2=0x00;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P01_LOWLEVEL         SFRS=2;PIPS2=0x01;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P02_LOWLEVEL         SFRS=2;PIPS2=0x02;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P03_LOWLEVEL         SFRS=2;PIPS2=0x03;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P04_LOWLEVEL         SFRS=2;PIPS2=0x04;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P05_LOWLEVEL         SFRS=2;PIPS2=0x05;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P06_LOWLEVEL         SFRS=2;PIPS2=0x06;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P07_LOWLEVEL         SFRS=2;PIPS2=0x07;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P10_LOWLEVEL         SFRS=2;PIPS2=0x10;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P11_LOWLEVEL         SFRS=2;PIPS2=0x11;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P12_LOWLEVEL         SFRS=2;PIPS2=0x12;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P13_LOWLEVEL         SFRS=2;PIPS2=0x13;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P14_LOWLEVEL         SFRS=2;PIPS2=0x14;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P15_LOWLEVEL         SFRS=2;PIPS2=0x15;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P16_LOWLEVEL         SFRS=2;PIPS2=0x16;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P17_LOWLEVEL         SFRS=2;PIPS2=0x17;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P20_LOWLEVEL         SFRS=2;PIPS2=0x20;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P21_LOWLEVEL         SFRS=2;PIPS2=0x21;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P22_LOWLEVEL         SFRS=2;PIPS2=0x22;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P23_LOWLEVEL         SFRS=2;PIPS2=0x23;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P24_LOWLEVEL         SFRS=2;PIPS2=0x24;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P25_LOWLEVEL         SFRS=2;PIPS2=0x25;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P30_LOWLEVEL         SFRS=2;PIPS2=0x30;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P31_LOWLEVEL         SFRS=2;PIPS2=0x31;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P32_LOWLEVEL         SFRS=2;PIPS2=0x32;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P33_LOWLEVEL         SFRS=2;PIPS2=0x33;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P34_LOWLEVEL         SFRS=2;PIPS2=0x34;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P35_LOWLEVEL         SFRS=2;PIPS2=0x35;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P36_LOWLEVEL         SFRS=2;PIPS2=0x36;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P37_LOWLEVEL         SFRS=2;PIPS2=0x37;SFRS=0;PICON&=CLR_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+
+#define    DISABLE_PIT2_P00_HIGHLEVEL        SFRS=2;PIPS2=0x00;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P01_HIGHLEVEL        SFRS=2;PIPS2=0x01;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P02_HIGHLEVEL        SFRS=2;PIPS2=0x02;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P03_HIGHLEVEL        SFRS=2;PIPS2=0x03;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P04_HIGHLEVEL        SFRS=2;PIPS2=0x04;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P05_HIGHLEVEL        SFRS=2;PIPS2=0x05;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P06_HIGHLEVEL        SFRS=2;PIPS2=0x06;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P07_HIGHLEVEL        SFRS=2;PIPS2=0x07;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P10_HIGHLEVEL        SFRS=2;PIPS2=0x10;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P11_HIGHLEVEL        SFRS=2;PIPS2=0x11;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P12_HIGHLEVEL        SFRS=2;PIPS2=0x12;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P13_HIGHLEVEL        SFRS=2;PIPS2=0x13;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P14_HIGHLEVEL        SFRS=2;PIPS2=0x14;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P15_HIGHLEVEL        SFRS=2;PIPS2=0x15;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P16_HIGHLEVEL        SFRS=2;PIPS2=0x16;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P17_HIGHLEVEL        SFRS=2;PIPS2=0x17;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P20_HIGHLEVEL        SFRS=2;PIPS2=0x20;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P21_HIGHLEVEL        SFRS=2;PIPS2=0x21;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P22_HIGHLEVEL        SFRS=2;PIPS2=0x22;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P23_HIGHLEVEL        SFRS=2;PIPS2=0x23;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P24_HIGHLEVEL        SFRS=2;PIPS2=0x24;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P25_HIGHLEVEL        SFRS=2;PIPS2=0x25;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P30_HIGHLEVEL        SFRS=2;PIPS2=0x30;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P31_HIGHLEVEL        SFRS=2;PIPS2=0x31;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P32_HIGHLEVEL        SFRS=2;PIPS2=0x32;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P33_HIGHLEVEL        SFRS=2;PIPS2=0x33;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P34_HIGHLEVEL        SFRS=2;PIPS2=0x34;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P35_HIGHLEVEL        SFRS=2;PIPS2=0x35;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P36_HIGHLEVEL        SFRS=2;PIPS2=0x36;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+#define    DISABLE_PIT2_P37_HIGHLEVEL        SFRS=2;PIPS2=0x37;SFRS=0;PICON&=CLR_BIT2;PINEN&=CLR_BIT2;PIPEN|=SET_BIT2
+
+#define    DISABLE_PIT2_P00_FALLINGEDGE      SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P01_FALLINGEDGE      SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P02_FALLINGEDGE      SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P03_FALLINGEDGE      SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P04_FALLINGEDGE      SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P05_FALLINGEDGE      SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P06_FALLINGEDGE      SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P07_FALLINGEDGE      SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P10_FALLINGEDGE      SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P11_FALLINGEDGE      SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P12_FALLINGEDGE      SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P13_FALLINGEDGE      SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P14_FALLINGEDGE      SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P15_FALLINGEDGE      SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P16_FALLINGEDGE      SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P17_FALLINGEDGE      SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P20_FALLINGEDGE      SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P21_FALLINGEDGE      SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P22_FALLINGEDGE      SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P23_FALLINGEDGE      SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P24_FALLINGEDGE      SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P25_FALLINGEDGE      SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P30_FALLINGEDGE      SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P31_FALLINGEDGE      SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P32_FALLINGEDGE      SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P33_FALLINGEDGE      SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P34_FALLINGEDGE      SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P35_FALLINGEDGE      SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P36_FALLINGEDGE      SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P37_FALLINGEDGE      SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN|=SET_BIT2;PIPEN&=CLR_BIT2
+
+#define    DISABLE_PIT2_P00_RISINGEDGE       SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P01_RISINGEDGE       SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P02_RISINGEDGE       SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P03_RISINGEDGE       SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P04_RISINGEDGE       SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P05_RISINGEDGE       SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P06_RISINGEDGE       SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P07_RISINGEDGE       SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P10_RISINGEDGE       SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P11_RISINGEDGE       SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P12_RISINGEDGE       SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P13_RISINGEDGE       SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P14_RISINGEDGE       SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P15_RISINGEDGE       SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P16_RISINGEDGE       SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P17_RISINGEDGE       SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P20_RISINGEDGE       SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P21_RISINGEDGE       SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P22_RISINGEDGE       SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P23_RISINGEDGE       SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P24_RISINGEDGE       SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P25_RISINGEDGE       SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P30_RISINGEDGE       SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P31_RISINGEDGE       SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P32_RISINGEDGE       SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P33_RISINGEDGE       SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P34_RISINGEDGE       SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P35_RISINGEDGE       SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P36_RISINGEDGE       SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P37_RISINGEDGE       SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+
+#define    DISABLE_PIT2_P00_BOTHEDGE         SFRS=2;PIPS2=0x00;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P01_BOTHEDGE         SFRS=2;PIPS2=0x01;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P02_BOTHEDGE         SFRS=2;PIPS2=0x02;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P03_BOTHEDGE         SFRS=2;PIPS2=0x03;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P04_BOTHEDGE         SFRS=2;PIPS2=0x04;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P05_BOTHEDGE         SFRS=2;PIPS2=0x05;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P06_BOTHEDGE         SFRS=2;PIPS2=0x06;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P07_BOTHEDGE         SFRS=2;PIPS2=0x07;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P10_BOTHEDGE         SFRS=2;PIPS2=0x10;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P11_BOTHEDGE         SFRS=2;PIPS2=0x11;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P12_BOTHEDGE         SFRS=2;PIPS2=0x12;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P13_BOTHEDGE         SFRS=2;PIPS2=0x13;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P14_BOTHEDGE         SFRS=2;PIPS2=0x14;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P15_BOTHEDGE         SFRS=2;PIPS2=0x15;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P16_BOTHEDGE         SFRS=2;PIPS2=0x16;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P17_BOTHEDGE         SFRS=2;PIPS2=0x17;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P20_BOTHEDGE         SFRS=2;PIPS2=0x20;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P21_BOTHEDGE         SFRS=2;PIPS2=0x21;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P22_BOTHEDGE         SFRS=2;PIPS2=0x22;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P23_BOTHEDGE         SFRS=2;PIPS2=0x23;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P24_BOTHEDGE         SFRS=2;PIPS2=0x24;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P25_BOTHEDGE         SFRS=2;PIPS2=0x25;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P30_BOTHEDGE         SFRS=2;PIPS2=0x30;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P31_BOTHEDGE         SFRS=2;PIPS2=0x31;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P32_BOTHEDGE         SFRS=2;PIPS2=0x32;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P33_BOTHEDGE         SFRS=2;PIPS2=0x33;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P34_BOTHEDGE         SFRS=2;PIPS2=0x34;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P35_BOTHEDGE         SFRS=2;PIPS2=0x35;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P36_BOTHEDGE         SFRS=2;PIPS2=0x36;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+#define    DISABLE_PIT2_P37_BOTHEDGE         SFRS=2;PIPS2=0x37;SFRS=0;PICON|=SET_BIT2;PINEN&=CLR_BIT2;PIPEN&=CLR_BIT2
+
+  /*------- -------- Pin interrupt channel 3 PIT3 Enable ------------------------ */
+#define    ENABLE_PIT3_P00_LOWLEVEL          SFRS=2;PIPS3=0x00;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P01_LOWLEVEL          SFRS=2;PIPS3=0x01;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P02_LOWLEVEL          SFRS=2;PIPS3=0x02;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P03_LOWLEVEL          SFRS=2;PIPS3=0x03;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P04_LOWLEVEL          SFRS=2;PIPS3=0x04;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P05_LOWLEVEL          SFRS=2;PIPS3=0x05;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P06_LOWLEVEL          SFRS=2;PIPS3=0x06;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P07_LOWLEVEL          SFRS=2;PIPS3=0x07;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P10_LOWLEVEL          SFRS=2;PIPS3=0x10;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P11_LOWLEVEL          SFRS=2;PIPS3=0x11;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P12_LOWLEVEL          SFRS=2;PIPS3=0x12;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P13_LOWLEVEL          SFRS=2;PIPS3=0x13;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P14_LOWLEVEL          SFRS=2;PIPS3=0x14;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P15_LOWLEVEL          SFRS=2;PIPS3=0x15;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P16_LOWLEVEL          SFRS=2;PIPS3=0x16;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P17_LOWLEVEL          SFRS=2;PIPS3=0x17;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P20_LOWLEVEL          SFRS=2;PIPS3=0x20;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P21_LOWLEVEL          SFRS=2;PIPS3=0x21;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P22_LOWLEVEL          SFRS=2;PIPS3=0x22;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P23_LOWLEVEL          SFRS=2;PIPS3=0x23;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P24_LOWLEVEL          SFRS=2;PIPS3=0x24;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P25_LOWLEVEL          SFRS=2;PIPS3=0x25;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P30_LOWLEVEL          SFRS=2;PIPS3=0x30;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P31_LOWLEVEL          SFRS=2;PIPS3=0x31;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P32_LOWLEVEL          SFRS=2;PIPS3=0x32;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P33_LOWLEVEL          SFRS=2;PIPS3=0x33;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P34_LOWLEVEL          SFRS=2;PIPS3=0x34;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P35_LOWLEVEL          SFRS=2;PIPS3=0x35;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P36_LOWLEVEL          SFRS=2;PIPS3=0x36;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P37_LOWLEVEL          SFRS=2;PIPS3=0x37;SFRS=0;PICON&=CLR_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+           
+#define    ENABLE_PIT3_P00_HIGHLEVEL         SFRS=2;PIPS3=0x00;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P01_HIGHLEVEL         SFRS=2;PIPS3=0x01;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P02_HIGHLEVEL         SFRS=2;PIPS3=0x02;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P03_HIGHLEVEL         SFRS=2;PIPS3=0x03;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P04_HIGHLEVEL         SFRS=2;PIPS3=0x04;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P05_HIGHLEVEL         SFRS=2;PIPS3=0x05;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P06_HIGHLEVEL         SFRS=2;PIPS3=0x06;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P07_HIGHLEVEL         SFRS=2;PIPS3=0x07;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P10_HIGHLEVEL         SFRS=2;PIPS3=0x10;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P11_HIGHLEVEL         SFRS=2;PIPS3=0x11;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P12_HIGHLEVEL         SFRS=2;PIPS3=0x12;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P13_HIGHLEVEL         SFRS=2;PIPS3=0x13;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P14_HIGHLEVEL         SFRS=2;PIPS3=0x14;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P15_HIGHLEVEL         SFRS=2;PIPS3=0x15;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P16_HIGHLEVEL         SFRS=2;PIPS3=0x16;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P17_HIGHLEVEL         SFRS=2;PIPS3=0x17;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P20_HIGHLEVEL         SFRS=2;PIPS3=0x20;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P21_HIGHLEVEL         SFRS=2;PIPS3=0x21;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P22_HIGHLEVEL         SFRS=2;PIPS3=0x22;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P23_HIGHLEVEL         SFRS=2;PIPS3=0x23;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P24_HIGHLEVEL         SFRS=2;PIPS3=0x24;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P25_HIGHLEVEL         SFRS=2;PIPS3=0x25;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P30_HIGHLEVEL         SFRS=2;PIPS3=0x30;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P31_HIGHLEVEL         SFRS=2;PIPS3=0x31;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P32_HIGHLEVEL         SFRS=2;PIPS3=0x32;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P33_HIGHLEVEL         SFRS=2;PIPS3=0x33;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P34_HIGHLEVEL         SFRS=2;PIPS3=0x34;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P35_HIGHLEVEL         SFRS=2;PIPS3=0x35;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P36_HIGHLEVEL         SFRS=2;PIPS3=0x36;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P37_HIGHLEVEL         SFRS=2;PIPS3=0x37;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+           
+#define    ENABLE_PIT3_P00_FALLINGEDGE       SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P01_FALLINGEDGE       SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P02_FALLINGEDGE       SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P03_FALLINGEDGE       SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P04_FALLINGEDGE       SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P05_FALLINGEDGE       SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P06_FALLINGEDGE       SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P07_FALLINGEDGE       SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P10_FALLINGEDGE       SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P11_FALLINGEDGE       SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P12_FALLINGEDGE       SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P13_FALLINGEDGE       SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P14_FALLINGEDGE       SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P15_FALLINGEDGE       SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P16_FALLINGEDGE       SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P17_FALLINGEDGE       SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P20_FALLINGEDGE       SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P21_FALLINGEDGE       SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P22_FALLINGEDGE       SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P23_FALLINGEDGE       SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P24_FALLINGEDGE       SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P25_FALLINGEDGE       SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P30_FALLINGEDGE       SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P31_FALLINGEDGE       SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P32_FALLINGEDGE       SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P33_FALLINGEDGE       SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P34_FALLINGEDGE       SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P35_FALLINGEDGE       SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P36_FALLINGEDGE       SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+#define    ENABLE_PIT3_P37_FALLINGEDGE       SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN&=CLR_BIT3
+           
+#define    ENABLE_PIT3_P00_RISINGEDGE        SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P01_RISINGEDGE        SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P02_RISINGEDGE        SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P03_RISINGEDGE        SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P04_RISINGEDGE        SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P05_RISINGEDGE        SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P06_RISINGEDGE        SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P07_RISINGEDGE        SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P10_RISINGEDGE        SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P11_RISINGEDGE        SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P12_RISINGEDGE        SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P13_RISINGEDGE        SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P14_RISINGEDGE        SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P15_RISINGEDGE        SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P16_RISINGEDGE        SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P17_RISINGEDGE        SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P20_RISINGEDGE        SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P21_RISINGEDGE        SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P22_RISINGEDGE        SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P23_RISINGEDGE        SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P24_RISINGEDGE        SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P25_RISINGEDGE        SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P30_RISINGEDGE        SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P31_RISINGEDGE        SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P32_RISINGEDGE        SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P33_RISINGEDGE        SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P34_RISINGEDGE        SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P35_RISINGEDGE        SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P36_RISINGEDGE        SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P37_RISINGEDGE        SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN|=SET_BIT3
+
+#define    ENABLE_PIT3_P00_BOTHEDGE          SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P01_BOTHEDGE          SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P02_BOTHEDGE          SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P03_BOTHEDGE          SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P04_BOTHEDGE          SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P05_BOTHEDGE          SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P06_BOTHEDGE          SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P07_BOTHEDGE          SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P10_BOTHEDGE          SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P11_BOTHEDGE          SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P12_BOTHEDGE          SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P13_BOTHEDGE          SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P14_BOTHEDGE          SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P15_BOTHEDGE          SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P16_BOTHEDGE          SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P17_BOTHEDGE          SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P20_BOTHEDGE          SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P21_BOTHEDGE          SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P22_BOTHEDGE          SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P23_BOTHEDGE          SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P24_BOTHEDGE          SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P25_BOTHEDGE          SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P30_BOTHEDGE          SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P31_BOTHEDGE          SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P32_BOTHEDGE          SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P33_BOTHEDGE          SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P34_BOTHEDGE          SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P35_BOTHEDGE          SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P36_BOTHEDGE          SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+#define    ENABLE_PIT3_P37_BOTHEDGE          SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN|=SET_BIT3;PIPEN|=SET_BIT3
+
+  /*------- -------- Pin interrupt channel 3 PIT3 Disable ------------------------ */
+#define    DISABLE_PIT3_P00_LOWLEVEL         SFRS=2;PIPS3=0x00;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P01_LOWLEVEL         SFRS=2;PIPS3=0x01;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P02_LOWLEVEL         SFRS=2;PIPS3=0x02;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P03_LOWLEVEL         SFRS=2;PIPS3=0x03;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P04_LOWLEVEL         SFRS=2;PIPS3=0x04;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P05_LOWLEVEL         SFRS=2;PIPS3=0x05;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P06_LOWLEVEL         SFRS=2;PIPS3=0x06;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P07_LOWLEVEL         SFRS=2;PIPS3=0x07;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P10_LOWLEVEL         SFRS=2;PIPS3=0x10;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P11_LOWLEVEL         SFRS=2;PIPS3=0x11;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P12_LOWLEVEL         SFRS=2;PIPS3=0x12;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P13_LOWLEVEL         SFRS=2;PIPS3=0x13;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P14_LOWLEVEL         SFRS=2;PIPS3=0x14;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P15_LOWLEVEL         SFRS=2;PIPS3=0x15;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P16_LOWLEVEL         SFRS=2;PIPS3=0x16;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P17_LOWLEVEL         SFRS=2;PIPS3=0x17;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P20_LOWLEVEL         SFRS=2;PIPS3=0x20;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P21_LOWLEVEL         SFRS=2;PIPS3=0x21;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P22_LOWLEVEL         SFRS=2;PIPS3=0x22;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P23_LOWLEVEL         SFRS=2;PIPS3=0x23;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P24_LOWLEVEL         SFRS=2;PIPS3=0x24;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P25_LOWLEVEL         SFRS=2;PIPS3=0x25;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P30_LOWLEVEL         SFRS=2;PIPS3=0x30;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P31_LOWLEVEL         SFRS=2;PIPS3=0x31;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P32_LOWLEVEL         SFRS=2;PIPS3=0x32;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P33_LOWLEVEL         SFRS=2;PIPS3=0x33;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P34_LOWLEVEL         SFRS=2;PIPS3=0x34;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P35_LOWLEVEL         SFRS=2;PIPS3=0x35;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P36_LOWLEVEL         SFRS=2;PIPS3=0x36;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P37_LOWLEVEL         SFRS=2;PIPS3=0x37;SFRS=0;PICON&=CLR_BIT3;PINEN|=CLR_BIT3;PIPEN&=CLR_BIT3
+
+#define    DISABLE_PIT3_P00_HIGHLEVEL        SFRS=2;PIPS3=0x00;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P01_HIGHLEVEL        SFRS=2;PIPS3=0x01;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P02_HIGHLEVEL        SFRS=2;PIPS3=0x02;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P03_HIGHLEVEL        SFRS=2;PIPS3=0x03;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P04_HIGHLEVEL        SFRS=2;PIPS3=0x04;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P05_HIGHLEVEL        SFRS=2;PIPS3=0x05;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P06_HIGHLEVEL        SFRS=2;PIPS3=0x06;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P07_HIGHLEVEL        SFRS=2;PIPS3=0x07;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P10_HIGHLEVEL        SFRS=2;PIPS3=0x10;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P11_HIGHLEVEL        SFRS=2;PIPS3=0x11;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P12_HIGHLEVEL        SFRS=2;PIPS3=0x12;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P13_HIGHLEVEL        SFRS=2;PIPS3=0x13;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P14_HIGHLEVEL        SFRS=2;PIPS3=0x14;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P15_HIGHLEVEL        SFRS=2;PIPS3=0x15;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P16_HIGHLEVEL        SFRS=2;PIPS3=0x16;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P17_HIGHLEVEL        SFRS=2;PIPS3=0x17;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P20_HIGHLEVEL        SFRS=2;PIPS3=0x20;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P21_HIGHLEVEL        SFRS=2;PIPS3=0x21;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P22_HIGHLEVEL        SFRS=2;PIPS3=0x22;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P23_HIGHLEVEL        SFRS=2;PIPS3=0x23;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P24_HIGHLEVEL        SFRS=2;PIPS3=0x24;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P25_HIGHLEVEL        SFRS=2;PIPS3=0x25;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P30_HIGHLEVEL        SFRS=2;PIPS3=0x30;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P31_HIGHLEVEL        SFRS=2;PIPS3=0x31;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P32_HIGHLEVEL        SFRS=2;PIPS3=0x32;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P33_HIGHLEVEL        SFRS=2;PIPS3=0x33;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P34_HIGHLEVEL        SFRS=2;PIPS3=0x34;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P35_HIGHLEVEL        SFRS=2;PIPS3=0x35;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P36_HIGHLEVEL        SFRS=2;PIPS3=0x36;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+#define    DISABLE_PIT3_P37_HIGHLEVEL        SFRS=2;PIPS3=0x37;SFRS=0;PICON&=CLR_BIT3;PINEN&=CLR_BIT3;PIPEN|=CLR_BIT3
+
+#define    DISABLE_PIT3_P00_FALLINGEDGE      SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P01_FALLINGEDGE      SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P02_FALLINGEDGE      SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P03_FALLINGEDGE      SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P04_FALLINGEDGE      SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P05_FALLINGEDGE      SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P06_FALLINGEDGE      SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P07_FALLINGEDGE      SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P10_FALLINGEDGE      SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P11_FALLINGEDGE      SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P12_FALLINGEDGE      SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P13_FALLINGEDGE      SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P14_FALLINGEDGE      SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P15_FALLINGEDGE      SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P16_FALLINGEDGE      SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P17_FALLINGEDGE      SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P20_FALLINGEDGE      SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P21_FALLINGEDGE      SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P22_FALLINGEDGE      SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P23_FALLINGEDGE      SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P24_FALLINGEDGE      SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P25_FALLINGEDGE      SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P30_FALLINGEDGE      SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P31_FALLINGEDGE      SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P32_FALLINGEDGE      SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P33_FALLINGEDGE      SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P34_FALLINGEDGE      SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P35_FALLINGEDGE      SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P36_FALLINGEDGE      SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P37_FALLINGEDGE      SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+
+#define    DISABLE_PIT3_P00_RISINGEDGE       SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P01_RISINGEDGE       SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P02_RISINGEDGE       SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P03_RISINGEDGE       SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P04_RISINGEDGE       SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P05_RISINGEDGE       SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P06_RISINGEDGE       SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P07_RISINGEDGE       SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P10_RISINGEDGE       SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P11_RISINGEDGE       SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P12_RISINGEDGE       SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P13_RISINGEDGE       SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P14_RISINGEDGE       SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P15_RISINGEDGE       SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P16_RISINGEDGE       SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P17_RISINGEDGE       SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P20_RISINGEDGE       SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P21_RISINGEDGE       SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P22_RISINGEDGE       SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P23_RISINGEDGE       SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P24_RISINGEDGE       SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P25_RISINGEDGE       SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P30_RISINGEDGE       SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P31_RISINGEDGE       SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P32_RISINGEDGE       SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P33_RISINGEDGE       SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P34_RISINGEDGE       SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P35_RISINGEDGE       SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P36_RISINGEDGE       SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P37_RISINGEDGE       SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+
+#define    DISABLE_PIT3_P00_BOTHEDGE         SFRS=2;PIPS3=0x00;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P01_BOTHEDGE         SFRS=2;PIPS3=0x01;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P02_BOTHEDGE         SFRS=2;PIPS3=0x02;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P03_BOTHEDGE         SFRS=2;PIPS3=0x03;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P04_BOTHEDGE         SFRS=2;PIPS3=0x04;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P05_BOTHEDGE         SFRS=2;PIPS3=0x05;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P06_BOTHEDGE         SFRS=2;PIPS3=0x06;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P07_BOTHEDGE         SFRS=2;PIPS3=0x07;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P10_BOTHEDGE         SFRS=2;PIPS3=0x10;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P11_BOTHEDGE         SFRS=2;PIPS3=0x11;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P12_BOTHEDGE         SFRS=2;PIPS3=0x12;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P13_BOTHEDGE         SFRS=2;PIPS3=0x13;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P14_BOTHEDGE         SFRS=2;PIPS3=0x14;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P15_BOTHEDGE         SFRS=2;PIPS3=0x15;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P16_BOTHEDGE         SFRS=2;PIPS3=0x16;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P17_BOTHEDGE         SFRS=2;PIPS3=0x17;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P20_BOTHEDGE         SFRS=2;PIPS3=0x20;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P21_BOTHEDGE         SFRS=2;PIPS3=0x21;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P22_BOTHEDGE         SFRS=2;PIPS3=0x22;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P23_BOTHEDGE         SFRS=2;PIPS3=0x23;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P24_BOTHEDGE         SFRS=2;PIPS3=0x24;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P25_BOTHEDGE         SFRS=2;PIPS3=0x25;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P30_BOTHEDGE         SFRS=2;PIPS3=0x30;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P31_BOTHEDGE         SFRS=2;PIPS3=0x31;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P32_BOTHEDGE         SFRS=2;PIPS3=0x32;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P33_BOTHEDGE         SFRS=2;PIPS3=0x33;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P34_BOTHEDGE         SFRS=2;PIPS3=0x34;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P35_BOTHEDGE         SFRS=2;PIPS3=0x35;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P36_BOTHEDGE         SFRS=2;PIPS3=0x36;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+#define    DISABLE_PIT3_P37_BOTHEDGE         SFRS=2;PIPS3=0x37;SFRS=0;PICON|=SET_BIT3;PINEN&=CLR_BIT3;PIPEN&=CLR_BIT3
+
+  /*------- -------- Pin interrupt channel 4 PIT4 Enable ------------------------ */
+#define    ENABLE_PIT4_P00_LOWLEVEL          SFRS=2;PIPS4=0x00;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P01_LOWLEVEL          SFRS=2;PIPS4=0x01;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P02_LOWLEVEL          SFRS=2;PIPS4=0x02;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P03_LOWLEVEL          SFRS=2;PIPS4=0x03;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P04_LOWLEVEL          SFRS=2;PIPS4=0x04;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P05_LOWLEVEL          SFRS=2;PIPS4=0x05;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P06_LOWLEVEL          SFRS=2;PIPS4=0x06;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P07_LOWLEVEL          SFRS=2;PIPS4=0x07;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P10_LOWLEVEL          SFRS=2;PIPS4=0x10;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P11_LOWLEVEL          SFRS=2;PIPS4=0x11;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P12_LOWLEVEL          SFRS=2;PIPS4=0x12;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P13_LOWLEVEL          SFRS=2;PIPS4=0x13;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P14_LOWLEVEL          SFRS=2;PIPS4=0x14;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P15_LOWLEVEL          SFRS=2;PIPS4=0x15;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P16_LOWLEVEL          SFRS=2;PIPS4=0x16;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P17_LOWLEVEL          SFRS=2;PIPS4=0x17;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P20_LOWLEVEL          SFRS=2;PIPS4=0x20;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P21_LOWLEVEL          SFRS=2;PIPS4=0x21;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P22_LOWLEVEL          SFRS=2;PIPS4=0x22;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P23_LOWLEVEL          SFRS=2;PIPS4=0x23;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P24_LOWLEVEL          SFRS=2;PIPS4=0x24;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P25_LOWLEVEL          SFRS=2;PIPS4=0x25;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P30_LOWLEVEL          SFRS=2;PIPS4=0x30;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P31_LOWLEVEL          SFRS=2;PIPS4=0x31;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P32_LOWLEVEL          SFRS=2;PIPS4=0x32;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P33_LOWLEVEL          SFRS=2;PIPS4=0x33;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P34_LOWLEVEL          SFRS=2;PIPS4=0x34;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P35_LOWLEVEL          SFRS=2;PIPS4=0x35;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P36_LOWLEVEL          SFRS=2;PIPS4=0x36;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P37_LOWLEVEL          SFRS=2;PIPS4=0x37;SFRS=0;PICON&=CLR_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+           
+#define    ENABLE_PIT4_P00_HIGHLEVEL         SFRS=2;PIPS4=0x00;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P01_HIGHLEVEL         SFRS=2;PIPS4=0x01;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P02_HIGHLEVEL         SFRS=2;PIPS4=0x02;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P03_HIGHLEVEL         SFRS=2;PIPS4=0x03;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P04_HIGHLEVEL         SFRS=2;PIPS4=0x04;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P05_HIGHLEVEL         SFRS=2;PIPS4=0x05;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P06_HIGHLEVEL         SFRS=2;PIPS4=0x06;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P07_HIGHLEVEL         SFRS=2;PIPS4=0x07;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P10_HIGHLEVEL         SFRS=2;PIPS4=0x10;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P11_HIGHLEVEL         SFRS=2;PIPS4=0x11;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P12_HIGHLEVEL         SFRS=2;PIPS4=0x12;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P13_HIGHLEVEL         SFRS=2;PIPS4=0x13;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P14_HIGHLEVEL         SFRS=2;PIPS4=0x14;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P15_HIGHLEVEL         SFRS=2;PIPS4=0x15;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P16_HIGHLEVEL         SFRS=2;PIPS4=0x16;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P17_HIGHLEVEL         SFRS=2;PIPS4=0x17;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P20_HIGHLEVEL         SFRS=2;PIPS4=0x20;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P21_HIGHLEVEL         SFRS=2;PIPS4=0x21;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P22_HIGHLEVEL         SFRS=2;PIPS4=0x22;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P23_HIGHLEVEL         SFRS=2;PIPS4=0x23;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P24_HIGHLEVEL         SFRS=2;PIPS4=0x24;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P25_HIGHLEVEL         SFRS=2;PIPS4=0x25;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P30_HIGHLEVEL         SFRS=2;PIPS4=0x30;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P31_HIGHLEVEL         SFRS=2;PIPS4=0x31;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P32_HIGHLEVEL         SFRS=2;PIPS4=0x32;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P33_HIGHLEVEL         SFRS=2;PIPS4=0x33;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P34_HIGHLEVEL         SFRS=2;PIPS4=0x34;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P35_HIGHLEVEL         SFRS=2;PIPS4=0x35;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P36_HIGHLEVEL         SFRS=2;PIPS4=0x36;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P37_HIGHLEVEL         SFRS=2;PIPS4=0x37;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+           
+#define    ENABLE_PIT4_P00_FALLINGEDGE       SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P01_FALLINGEDGE       SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P02_FALLINGEDGE       SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P03_FALLINGEDGE       SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P04_FALLINGEDGE       SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P05_FALLINGEDGE       SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P06_FALLINGEDGE       SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P07_FALLINGEDGE       SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P10_FALLINGEDGE       SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P11_FALLINGEDGE       SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P12_FALLINGEDGE       SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P13_FALLINGEDGE       SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P14_FALLINGEDGE       SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P15_FALLINGEDGE       SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P16_FALLINGEDGE       SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P17_FALLINGEDGE       SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P20_FALLINGEDGE       SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P21_FALLINGEDGE       SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P22_FALLINGEDGE       SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P23_FALLINGEDGE       SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P24_FALLINGEDGE       SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P25_FALLINGEDGE       SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P30_FALLINGEDGE       SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P31_FALLINGEDGE       SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P32_FALLINGEDGE       SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P33_FALLINGEDGE       SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P34_FALLINGEDGE       SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P35_FALLINGEDGE       SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P36_FALLINGEDGE       SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+#define    ENABLE_PIT4_P37_FALLINGEDGE       SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN&=CLR_BIT4
+           
+#define    ENABLE_PIT4_P00_RISINGEDGE        SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P01_RISINGEDGE        SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P02_RISINGEDGE        SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P03_RISINGEDGE        SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P04_RISINGEDGE        SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P05_RISINGEDGE        SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P06_RISINGEDGE        SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P07_RISINGEDGE        SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P10_RISINGEDGE        SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P11_RISINGEDGE        SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P12_RISINGEDGE        SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P13_RISINGEDGE        SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P14_RISINGEDGE        SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P15_RISINGEDGE        SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P16_RISINGEDGE        SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P17_RISINGEDGE        SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P20_RISINGEDGE        SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P21_RISINGEDGE        SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P22_RISINGEDGE        SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P23_RISINGEDGE        SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P24_RISINGEDGE        SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P25_RISINGEDGE        SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P30_RISINGEDGE        SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P31_RISINGEDGE        SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P32_RISINGEDGE        SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P33_RISINGEDGE        SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P34_RISINGEDGE        SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P35_RISINGEDGE        SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P36_RISINGEDGE        SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P37_RISINGEDGE        SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN|=SET_BIT4
+
+#define    ENABLE_PIT4_P00_BOTHEDGE          SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P01_BOTHEDGE          SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P02_BOTHEDGE          SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P03_BOTHEDGE          SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P04_BOTHEDGE          SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P05_BOTHEDGE          SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P06_BOTHEDGE          SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P07_BOTHEDGE          SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P10_BOTHEDGE          SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P11_BOTHEDGE          SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P12_BOTHEDGE          SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P13_BOTHEDGE          SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P14_BOTHEDGE          SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P15_BOTHEDGE          SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P16_BOTHEDGE          SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P17_BOTHEDGE          SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P20_BOTHEDGE          SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P21_BOTHEDGE          SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P22_BOTHEDGE          SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P23_BOTHEDGE          SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P24_BOTHEDGE          SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P25_BOTHEDGE          SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P30_BOTHEDGE          SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P31_BOTHEDGE          SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P32_BOTHEDGE          SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P33_BOTHEDGE          SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P34_BOTHEDGE          SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P35_BOTHEDGE          SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P36_BOTHEDGE          SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+#define    ENABLE_PIT4_P37_BOTHEDGE          SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN|=SET_BIT4;PIPEN|=SET_BIT4
+
+  /*--------------- Pin interrupt channel 4 PIT4 Disable------------------------ */
+#define    DISABLE_PIT4_P00_LOWLEVEL         SFRS=2;PIPS4=0x00;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P01_LOWLEVEL         SFRS=2;PIPS4=0x01;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P02_LOWLEVEL         SFRS=2;PIPS4=0x02;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P03_LOWLEVEL         SFRS=2;PIPS4=0x03;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P04_LOWLEVEL         SFRS=2;PIPS4=0x04;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P05_LOWLEVEL         SFRS=2;PIPS4=0x05;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P06_LOWLEVEL         SFRS=2;PIPS4=0x06;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P07_LOWLEVEL         SFRS=2;PIPS4=0x07;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P10_LOWLEVEL         SFRS=2;PIPS4=0x10;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P11_LOWLEVEL         SFRS=2;PIPS4=0x11;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P12_LOWLEVEL         SFRS=2;PIPS4=0x12;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P13_LOWLEVEL         SFRS=2;PIPS4=0x13;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P14_LOWLEVEL         SFRS=2;PIPS4=0x14;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P15_LOWLEVEL         SFRS=2;PIPS4=0x15;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P16_LOWLEVEL         SFRS=2;PIPS4=0x16;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P17_LOWLEVEL         SFRS=2;PIPS4=0x17;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P20_LOWLEVEL         SFRS=2;PIPS4=0x20;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P21_LOWLEVEL         SFRS=2;PIPS4=0x21;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P22_LOWLEVEL         SFRS=2;PIPS4=0x22;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P23_LOWLEVEL         SFRS=2;PIPS4=0x23;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P24_LOWLEVEL         SFRS=2;PIPS4=0x24;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P25_LOWLEVEL         SFRS=2;PIPS4=0x25;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P30_LOWLEVEL         SFRS=2;PIPS4=0x30;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P31_LOWLEVEL         SFRS=2;PIPS4=0x31;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P32_LOWLEVEL         SFRS=2;PIPS4=0x32;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P33_LOWLEVEL         SFRS=2;PIPS4=0x33;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P34_LOWLEVEL         SFRS=2;PIPS4=0x34;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P35_LOWLEVEL         SFRS=2;PIPS4=0x35;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P36_LOWLEVEL         SFRS=2;PIPS4=0x36;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P37_LOWLEVEL         SFRS=2;PIPS4=0x37;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+
+#define    DISABLE_PIT4_P00_HIGHLEVEL        SFRS=2;PIPS4=0x00;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P01_HIGHLEVEL        SFRS=2;PIPS4=0x01;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P02_HIGHLEVEL        SFRS=2;PIPS4=0x02;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P03_HIGHLEVEL        SFRS=2;PIPS4=0x03;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P04_HIGHLEVEL        SFRS=2;PIPS4=0x04;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P05_HIGHLEVEL        SFRS=2;PIPS4=0x05;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P06_HIGHLEVEL        SFRS=2;PIPS4=0x06;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P07_HIGHLEVEL        SFRS=2;PIPS4=0x07;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P10_HIGHLEVEL        SFRS=2;PIPS4=0x10;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P11_HIGHLEVEL        SFRS=2;PIPS4=0x11;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P12_HIGHLEVEL        SFRS=2;PIPS4=0x12;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P13_HIGHLEVEL        SFRS=2;PIPS4=0x13;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P14_HIGHLEVEL        SFRS=2;PIPS4=0x14;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P15_HIGHLEVEL        SFRS=2;PIPS4=0x15;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P16_HIGHLEVEL        SFRS=2;PIPS4=0x16;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P17_HIGHLEVEL        SFRS=2;PIPS4=0x17;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P20_HIGHLEVEL        SFRS=2;PIPS4=0x20;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P21_HIGHLEVEL        SFRS=2;PIPS4=0x21;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P22_HIGHLEVEL        SFRS=2;PIPS4=0x22;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P23_HIGHLEVEL        SFRS=2;PIPS4=0x23;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P24_HIGHLEVEL        SFRS=2;PIPS4=0x24;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P25_HIGHLEVEL        SFRS=2;PIPS4=0x25;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P30_HIGHLEVEL        SFRS=2;PIPS4=0x30;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P31_HIGHLEVEL        SFRS=2;PIPS4=0x31;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P32_HIGHLEVEL        SFRS=2;PIPS4=0x32;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P33_HIGHLEVEL        SFRS=2;PIPS4=0x33;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P34_HIGHLEVEL        SFRS=2;PIPS4=0x34;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P35_HIGHLEVEL        SFRS=2;PIPS4=0x35;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P36_HIGHLEVEL        SFRS=2;PIPS4=0x36;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P37_HIGHLEVEL        SFRS=2;PIPS4=0x37;SFRS=0;PICON&=CLR_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+
+#define    DISABLE_PIT4_P00_FALLINGEDGE      SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P01_FALLINGEDGE      SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P02_FALLINGEDGE      SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P03_FALLINGEDGE      SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P04_FALLINGEDGE      SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P05_FALLINGEDGE      SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P06_FALLINGEDGE      SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P07_FALLINGEDGE      SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P10_FALLINGEDGE      SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P11_FALLINGEDGE      SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P12_FALLINGEDGE      SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P13_FALLINGEDGE      SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P14_FALLINGEDGE      SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P15_FALLINGEDGE      SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P16_FALLINGEDGE      SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P17_FALLINGEDGE      SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P20_FALLINGEDGE      SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P21_FALLINGEDGE      SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P22_FALLINGEDGE      SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P23_FALLINGEDGE      SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P24_FALLINGEDGE      SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P25_FALLINGEDGE      SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P30_FALLINGEDGE      SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P31_FALLINGEDGE      SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P32_FALLINGEDGE      SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P33_FALLINGEDGE      SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P34_FALLINGEDGE      SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P35_FALLINGEDGE      SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P36_FALLINGEDGE      SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P37_FALLINGEDGE      SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+
+#define    DISABLE_PIT4_P00_RISINGEDGE       SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P01_RISINGEDGE       SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P02_RISINGEDGE       SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P03_RISINGEDGE       SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P04_RISINGEDGE       SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P05_RISINGEDGE       SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P06_RISINGEDGE       SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P07_RISINGEDGE       SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P10_RISINGEDGE       SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P11_RISINGEDGE       SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P12_RISINGEDGE       SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P13_RISINGEDGE       SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P14_RISINGEDGE       SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P15_RISINGEDGE       SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P16_RISINGEDGE       SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P17_RISINGEDGE       SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P20_RISINGEDGE       SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P21_RISINGEDGE       SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P22_RISINGEDGE       SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P23_RISINGEDGE       SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P24_RISINGEDGE       SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P25_RISINGEDGE       SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P30_RISINGEDGE       SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P31_RISINGEDGE       SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P32_RISINGEDGE       SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P33_RISINGEDGE       SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P34_RISINGEDGE       SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P35_RISINGEDGE       SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P36_RISINGEDGE       SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P37_RISINGEDGE       SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+
+#define    DISABLE_PIT4_P00_BOTHEDGE         SFRS=2;PIPS4=0x00;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P01_BOTHEDGE         SFRS=2;PIPS4=0x01;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P02_BOTHEDGE         SFRS=2;PIPS4=0x02;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P03_BOTHEDGE         SFRS=2;PIPS4=0x03;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P04_BOTHEDGE         SFRS=2;PIPS4=0x04;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P05_BOTHEDGE         SFRS=2;PIPS4=0x05;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P06_BOTHEDGE         SFRS=2;PIPS4=0x06;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P07_BOTHEDGE         SFRS=2;PIPS4=0x07;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P10_BOTHEDGE         SFRS=2;PIPS4=0x10;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P11_BOTHEDGE         SFRS=2;PIPS4=0x11;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P12_BOTHEDGE         SFRS=2;PIPS4=0x12;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P13_BOTHEDGE         SFRS=2;PIPS4=0x13;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P14_BOTHEDGE         SFRS=2;PIPS4=0x14;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P15_BOTHEDGE         SFRS=2;PIPS4=0x15;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P16_BOTHEDGE         SFRS=2;PIPS4=0x16;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P17_BOTHEDGE         SFRS=2;PIPS4=0x17;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P20_BOTHEDGE         SFRS=2;PIPS4=0x20;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P21_BOTHEDGE         SFRS=2;PIPS4=0x21;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P22_BOTHEDGE         SFRS=2;PIPS4=0x22;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P23_BOTHEDGE         SFRS=2;PIPS4=0x23;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P24_BOTHEDGE         SFRS=2;PIPS4=0x24;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P25_BOTHEDGE         SFRS=2;PIPS4=0x25;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P30_BOTHEDGE         SFRS=2;PIPS4=0x30;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P31_BOTHEDGE         SFRS=2;PIPS4=0x31;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P32_BOTHEDGE         SFRS=2;PIPS4=0x32;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P33_BOTHEDGE         SFRS=2;PIPS4=0x33;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P34_BOTHEDGE         SFRS=2;PIPS4=0x34;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P35_BOTHEDGE         SFRS=2;PIPS4=0x35;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P36_BOTHEDGE         SFRS=2;PIPS4=0x36;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+#define    DISABLE_PIT4_P37_BOTHEDGE         SFRS=2;PIPS4=0x37;SFRS=0;PICON|=SET_BIT4;PINEN&=CLR_BIT4;PIPEN&=CLR_BIT4
+
+  /*------- -------- Pin interrupt channel 5 PIT5 Enable------------------------ */
+#define    ENABLE_PIT5_P00_LOWLEVEL          SFRS=2;PIPS5=0x00;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P01_LOWLEVEL          SFRS=2;PIPS5=0x01;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P02_LOWLEVEL          SFRS=2;PIPS5=0x02;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P03_LOWLEVEL          SFRS=2;PIPS5=0x03;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P04_LOWLEVEL          SFRS=2;PIPS5=0x04;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P05_LOWLEVEL          SFRS=2;PIPS5=0x05;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P06_LOWLEVEL          SFRS=2;PIPS5=0x06;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P07_LOWLEVEL          SFRS=2;PIPS5=0x07;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P10_LOWLEVEL          SFRS=2;PIPS5=0x10;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P11_LOWLEVEL          SFRS=2;PIPS5=0x11;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P12_LOWLEVEL          SFRS=2;PIPS5=0x12;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P13_LOWLEVEL          SFRS=2;PIPS5=0x13;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P14_LOWLEVEL          SFRS=2;PIPS5=0x14;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P15_LOWLEVEL          SFRS=2;PIPS5=0x15;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P16_LOWLEVEL          SFRS=2;PIPS5=0x16;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P17_LOWLEVEL          SFRS=2;PIPS5=0x17;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P20_LOWLEVEL          SFRS=2;PIPS5=0x20;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P21_LOWLEVEL          SFRS=2;PIPS5=0x21;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P22_LOWLEVEL          SFRS=2;PIPS5=0x22;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P23_LOWLEVEL          SFRS=2;PIPS5=0x23;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P24_LOWLEVEL          SFRS=2;PIPS5=0x24;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P25_LOWLEVEL          SFRS=2;PIPS5=0x25;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P30_LOWLEVEL          SFRS=2;PIPS5=0x30;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P31_LOWLEVEL          SFRS=2;PIPS5=0x31;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P32_LOWLEVEL          SFRS=2;PIPS5=0x32;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P33_LOWLEVEL          SFRS=2;PIPS5=0x33;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P34_LOWLEVEL          SFRS=2;PIPS5=0x34;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P35_LOWLEVEL          SFRS=2;PIPS5=0x35;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P36_LOWLEVEL          SFRS=2;PIPS5=0x36;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P37_LOWLEVEL          SFRS=2;PIPS5=0x37;SFRS=0;PICON&=CLR_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+           
+#define    ENABLE_PIT5_P00_HIGHLEVEL         SFRS=2;PIPS5=0x00;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P01_HIGHLEVEL         SFRS=2;PIPS5=0x01;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P02_HIGHLEVEL         SFRS=2;PIPS5=0x02;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P03_HIGHLEVEL         SFRS=2;PIPS5=0x03;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P04_HIGHLEVEL         SFRS=2;PIPS5=0x04;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P05_HIGHLEVEL         SFRS=2;PIPS5=0x05;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P06_HIGHLEVEL         SFRS=2;PIPS5=0x06;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P07_HIGHLEVEL         SFRS=2;PIPS5=0x07;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P10_HIGHLEVEL         SFRS=2;PIPS5=0x10;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P11_HIGHLEVEL         SFRS=2;PIPS5=0x11;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P12_HIGHLEVEL         SFRS=2;PIPS5=0x12;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P13_HIGHLEVEL         SFRS=2;PIPS5=0x13;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P14_HIGHLEVEL         SFRS=2;PIPS5=0x14;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P15_HIGHLEVEL         SFRS=2;PIPS5=0x15;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P16_HIGHLEVEL         SFRS=2;PIPS5=0x16;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P17_HIGHLEVEL         SFRS=2;PIPS5=0x17;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P20_HIGHLEVEL         SFRS=2;PIPS5=0x20;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P21_HIGHLEVEL         SFRS=2;PIPS5=0x21;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P22_HIGHLEVEL         SFRS=2;PIPS5=0x22;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P23_HIGHLEVEL         SFRS=2;PIPS5=0x23;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P24_HIGHLEVEL         SFRS=2;PIPS5=0x24;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P25_HIGHLEVEL         SFRS=2;PIPS5=0x25;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P30_HIGHLEVEL         SFRS=2;PIPS5=0x30;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P31_HIGHLEVEL         SFRS=2;PIPS5=0x31;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P32_HIGHLEVEL         SFRS=2;PIPS5=0x32;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P33_HIGHLEVEL         SFRS=2;PIPS5=0x33;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P34_HIGHLEVEL         SFRS=2;PIPS5=0x34;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P35_HIGHLEVEL         SFRS=2;PIPS5=0x35;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P36_HIGHLEVEL         SFRS=2;PIPS5=0x36;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P37_HIGHLEVEL         SFRS=2;PIPS5=0x37;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+           
+#define    ENABLE_PIT5_P00_FALLINGEDGE       SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P01_FALLINGEDGE       SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P02_FALLINGEDGE       SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P03_FALLINGEDGE       SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P04_FALLINGEDGE       SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P05_FALLINGEDGE       SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P06_FALLINGEDGE       SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P07_FALLINGEDGE       SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P10_FALLINGEDGE       SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P11_FALLINGEDGE       SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P12_FALLINGEDGE       SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P13_FALLINGEDGE       SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P14_FALLINGEDGE       SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P15_FALLINGEDGE       SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P16_FALLINGEDGE       SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P17_FALLINGEDGE       SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P20_FALLINGEDGE       SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P21_FALLINGEDGE       SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P22_FALLINGEDGE       SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P23_FALLINGEDGE       SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P24_FALLINGEDGE       SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P25_FALLINGEDGE       SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P30_FALLINGEDGE       SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P31_FALLINGEDGE       SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P32_FALLINGEDGE       SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P33_FALLINGEDGE       SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P34_FALLINGEDGE       SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P35_FALLINGEDGE       SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P36_FALLINGEDGE       SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+#define    ENABLE_PIT5_P37_FALLINGEDGE       SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN&=CLR_BIT5
+           
+#define    ENABLE_PIT5_P00_RISINGEDGE        SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P01_RISINGEDGE        SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P02_RISINGEDGE        SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P03_RISINGEDGE        SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P04_RISINGEDGE        SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P05_RISINGEDGE        SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P06_RISINGEDGE        SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P07_RISINGEDGE        SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P10_RISINGEDGE        SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P11_RISINGEDGE        SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P12_RISINGEDGE        SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P13_RISINGEDGE        SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P14_RISINGEDGE        SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P15_RISINGEDGE        SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P16_RISINGEDGE        SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P17_RISINGEDGE        SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P20_RISINGEDGE        SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P21_RISINGEDGE        SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P22_RISINGEDGE        SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P23_RISINGEDGE        SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P24_RISINGEDGE        SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P25_RISINGEDGE        SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P30_RISINGEDGE        SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P31_RISINGEDGE        SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P32_RISINGEDGE        SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P33_RISINGEDGE        SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P34_RISINGEDGE        SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P35_RISINGEDGE        SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P36_RISINGEDGE        SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P37_RISINGEDGE        SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN|=SET_BIT5
+
+#define    ENABLE_PIT5_P00_BOTHEDGE          SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P01_BOTHEDGE          SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P02_BOTHEDGE          SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P03_BOTHEDGE          SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P04_BOTHEDGE          SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P05_BOTHEDGE          SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P06_BOTHEDGE          SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P07_BOTHEDGE          SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P10_BOTHEDGE          SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P11_BOTHEDGE          SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P12_BOTHEDGE          SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P13_BOTHEDGE          SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P14_BOTHEDGE          SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P15_BOTHEDGE          SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P16_BOTHEDGE          SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P17_BOTHEDGE          SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P20_BOTHEDGE          SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P21_BOTHEDGE          SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P22_BOTHEDGE          SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P23_BOTHEDGE          SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P24_BOTHEDGE          SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P25_BOTHEDGE          SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P30_BOTHEDGE          SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P31_BOTHEDGE          SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P32_BOTHEDGE          SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P33_BOTHEDGE          SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P34_BOTHEDGE          SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P35_BOTHEDGE          SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P36_BOTHEDGE          SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+#define    ENABLE_PIT5_P37_BOTHEDGE          SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN|=SET_BIT5;PIPEN|=SET_BIT5
+
+  /*------- -------- Pin interrupt channel 5 PIT5 Disable------------------------ */
+#define    DISABLE_PIT5_P00_LOWLEVEL         SFRS=2;PIPS5=0x00;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P01_LOWLEVEL         SFRS=2;PIPS5=0x01;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P02_LOWLEVEL         SFRS=2;PIPS5=0x02;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P03_LOWLEVEL         SFRS=2;PIPS5=0x03;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P04_LOWLEVEL         SFRS=2;PIPS5=0x04;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P05_LOWLEVEL         SFRS=2;PIPS5=0x05;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P06_LOWLEVEL         SFRS=2;PIPS5=0x06;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P07_LOWLEVEL         SFRS=2;PIPS5=0x07;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P10_LOWLEVEL         SFRS=2;PIPS5=0x10;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P11_LOWLEVEL         SFRS=2;PIPS5=0x11;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P12_LOWLEVEL         SFRS=2;PIPS5=0x12;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P13_LOWLEVEL         SFRS=2;PIPS5=0x13;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P14_LOWLEVEL         SFRS=2;PIPS5=0x14;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P15_LOWLEVEL         SFRS=2;PIPS5=0x15;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P16_LOWLEVEL         SFRS=2;PIPS5=0x16;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P17_LOWLEVEL         SFRS=2;PIPS5=0x17;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P20_LOWLEVEL         SFRS=2;PIPS5=0x20;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P21_LOWLEVEL         SFRS=2;PIPS5=0x21;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P22_LOWLEVEL         SFRS=2;PIPS5=0x22;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P23_LOWLEVEL         SFRS=2;PIPS5=0x23;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P24_LOWLEVEL         SFRS=2;PIPS5=0x24;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P25_LOWLEVEL         SFRS=2;PIPS5=0x25;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P30_LOWLEVEL         SFRS=2;PIPS5=0x30;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P31_LOWLEVEL         SFRS=2;PIPS5=0x31;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P32_LOWLEVEL         SFRS=2;PIPS5=0x32;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P33_LOWLEVEL         SFRS=2;PIPS5=0x33;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P34_LOWLEVEL         SFRS=2;PIPS5=0x34;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P35_LOWLEVEL         SFRS=2;PIPS5=0x35;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P36_LOWLEVEL         SFRS=2;PIPS5=0x36;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P37_LOWLEVEL         SFRS=2;PIPS5=0x37;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+
+#define    DISABLE_PIT5_P00_HIGHLEVEL        SFRS=2;PIPS5=0x00;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P01_HIGHLEVEL        SFRS=2;PIPS5=0x01;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P02_HIGHLEVEL        SFRS=2;PIPS5=0x02;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P03_HIGHLEVEL        SFRS=2;PIPS5=0x03;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P04_HIGHLEVEL        SFRS=2;PIPS5=0x04;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P05_HIGHLEVEL        SFRS=2;PIPS5=0x05;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P06_HIGHLEVEL        SFRS=2;PIPS5=0x06;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P07_HIGHLEVEL        SFRS=2;PIPS5=0x07;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P10_HIGHLEVEL        SFRS=2;PIPS5=0x10;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P11_HIGHLEVEL        SFRS=2;PIPS5=0x11;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P12_HIGHLEVEL        SFRS=2;PIPS5=0x12;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P13_HIGHLEVEL        SFRS=2;PIPS5=0x13;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P14_HIGHLEVEL        SFRS=2;PIPS5=0x14;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P15_HIGHLEVEL        SFRS=2;PIPS5=0x15;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P16_HIGHLEVEL        SFRS=2;PIPS5=0x16;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P17_HIGHLEVEL        SFRS=2;PIPS5=0x17;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P20_HIGHLEVEL        SFRS=2;PIPS5=0x20;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P21_HIGHLEVEL        SFRS=2;PIPS5=0x21;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P22_HIGHLEVEL        SFRS=2;PIPS5=0x22;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P23_HIGHLEVEL        SFRS=2;PIPS5=0x23;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P24_HIGHLEVEL        SFRS=2;PIPS5=0x24;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P25_HIGHLEVEL        SFRS=2;PIPS5=0x25;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P30_HIGHLEVEL        SFRS=2;PIPS5=0x30;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P31_HIGHLEVEL        SFRS=2;PIPS5=0x31;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P32_HIGHLEVEL        SFRS=2;PIPS5=0x32;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P33_HIGHLEVEL        SFRS=2;PIPS5=0x33;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P34_HIGHLEVEL        SFRS=2;PIPS5=0x34;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P35_HIGHLEVEL        SFRS=2;PIPS5=0x35;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P36_HIGHLEVEL        SFRS=2;PIPS5=0x36;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P37_HIGHLEVEL        SFRS=2;PIPS5=0x37;SFRS=0;PICON&=CLR_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+
+#define    DISABLE_PIT5_P00_FALLINGEDGE      SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P01_FALLINGEDGE      SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P02_FALLINGEDGE      SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P03_FALLINGEDGE      SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P04_FALLINGEDGE      SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P05_FALLINGEDGE      SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P06_FALLINGEDGE      SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P07_FALLINGEDGE      SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P10_FALLINGEDGE      SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P11_FALLINGEDGE      SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P12_FALLINGEDGE      SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P13_FALLINGEDGE      SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P14_FALLINGEDGE      SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P15_FALLINGEDGE      SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P16_FALLINGEDGE      SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P17_FALLINGEDGE      SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P20_FALLINGEDGE      SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P21_FALLINGEDGE      SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P22_FALLINGEDGE      SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P23_FALLINGEDGE      SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P24_FALLINGEDGE      SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P25_FALLINGEDGE      SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P30_FALLINGEDGE      SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P31_FALLINGEDGE      SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P32_FALLINGEDGE      SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P33_FALLINGEDGE      SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P34_FALLINGEDGE      SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P35_FALLINGEDGE      SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P36_FALLINGEDGE      SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P37_FALLINGEDGE      SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+
+#define    DISABLE_PIT5_P00_RISINGEDGE       SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P01_RISINGEDGE       SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P02_RISINGEDGE       SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P03_RISINGEDGE       SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P04_RISINGEDGE       SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P05_RISINGEDGE       SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P06_RISINGEDGE       SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P07_RISINGEDGE       SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P10_RISINGEDGE       SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P11_RISINGEDGE       SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P12_RISINGEDGE       SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P13_RISINGEDGE       SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P14_RISINGEDGE       SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P15_RISINGEDGE       SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P16_RISINGEDGE       SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P17_RISINGEDGE       SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P20_RISINGEDGE       SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P21_RISINGEDGE       SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P22_RISINGEDGE       SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P23_RISINGEDGE       SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P24_RISINGEDGE       SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P25_RISINGEDGE       SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P30_RISINGEDGE       SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P31_RISINGEDGE       SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P32_RISINGEDGE       SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P33_RISINGEDGE       SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P34_RISINGEDGE       SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P35_RISINGEDGE       SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P36_RISINGEDGE       SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P37_RISINGEDGE       SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+
+#define    DISABLE_PIT5_P00_BOTHEDGE         SFRS=2;PIPS5=0x00;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P01_BOTHEDGE         SFRS=2;PIPS5=0x01;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P02_BOTHEDGE         SFRS=2;PIPS5=0x02;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P03_BOTHEDGE         SFRS=2;PIPS5=0x03;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P04_BOTHEDGE         SFRS=2;PIPS5=0x04;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P05_BOTHEDGE         SFRS=2;PIPS5=0x05;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P06_BOTHEDGE         SFRS=2;PIPS5=0x06;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P07_BOTHEDGE         SFRS=2;PIPS5=0x07;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P10_BOTHEDGE         SFRS=2;PIPS5=0x10;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P11_BOTHEDGE         SFRS=2;PIPS5=0x11;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P12_BOTHEDGE         SFRS=2;PIPS5=0x12;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P13_BOTHEDGE         SFRS=2;PIPS5=0x13;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P14_BOTHEDGE         SFRS=2;PIPS5=0x14;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P15_BOTHEDGE         SFRS=2;PIPS5=0x15;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P16_BOTHEDGE         SFRS=2;PIPS5=0x16;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P17_BOTHEDGE         SFRS=2;PIPS5=0x17;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P20_BOTHEDGE         SFRS=2;PIPS5=0x20;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P21_BOTHEDGE         SFRS=2;PIPS5=0x21;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P22_BOTHEDGE         SFRS=2;PIPS5=0x22;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P23_BOTHEDGE         SFRS=2;PIPS5=0x23;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P24_BOTHEDGE         SFRS=2;PIPS5=0x24;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P25_BOTHEDGE         SFRS=2;PIPS5=0x25;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P30_BOTHEDGE         SFRS=2;PIPS5=0x30;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P31_BOTHEDGE         SFRS=2;PIPS5=0x31;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P32_BOTHEDGE         SFRS=2;PIPS5=0x32;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P33_BOTHEDGE         SFRS=2;PIPS5=0x33;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P34_BOTHEDGE         SFRS=2;PIPS5=0x34;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P35_BOTHEDGE         SFRS=2;PIPS5=0x35;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P36_BOTHEDGE         SFRS=2;PIPS5=0x36;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+#define    DISABLE_PIT5_P37_BOTHEDGE         SFRS=2;PIPS5=0x37;SFRS=0;PICON|=SET_BIT5;PINEN&=CLR_BIT5;PIPEN&=CLR_BIT5
+
+  /*------- -------- Pin interrupt channel 6 PIT6 Enable ------------------------ */
+#define    ENABLE_PIT6_P00_LOWLEVEL          SFRS=2;PIPS6=0x00;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P01_LOWLEVEL          SFRS=2;PIPS6=0x01;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P02_LOWLEVEL          SFRS=2;PIPS6=0x02;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P03_LOWLEVEL          SFRS=2;PIPS6=0x03;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P04_LOWLEVEL          SFRS=2;PIPS6=0x04;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P05_LOWLEVEL          SFRS=2;PIPS6=0x05;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P06_LOWLEVEL          SFRS=2;PIPS6=0x06;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P07_LOWLEVEL          SFRS=2;PIPS6=0x07;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P10_LOWLEVEL          SFRS=2;PIPS6=0x10;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P11_LOWLEVEL          SFRS=2;PIPS6=0x11;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P12_LOWLEVEL          SFRS=2;PIPS6=0x12;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P13_LOWLEVEL          SFRS=2;PIPS6=0x13;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P14_LOWLEVEL          SFRS=2;PIPS6=0x14;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P15_LOWLEVEL          SFRS=2;PIPS6=0x15;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P16_LOWLEVEL          SFRS=2;PIPS6=0x16;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P17_LOWLEVEL          SFRS=2;PIPS6=0x17;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P20_LOWLEVEL          SFRS=2;PIPS6=0x20;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P21_LOWLEVEL          SFRS=2;PIPS6=0x21;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P22_LOWLEVEL          SFRS=2;PIPS6=0x22;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P23_LOWLEVEL          SFRS=2;PIPS6=0x23;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P24_LOWLEVEL          SFRS=2;PIPS6=0x24;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P25_LOWLEVEL          SFRS=2;PIPS6=0x25;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P30_LOWLEVEL          SFRS=2;PIPS6=0x30;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P31_LOWLEVEL          SFRS=2;PIPS6=0x31;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P32_LOWLEVEL          SFRS=2;PIPS6=0x32;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P33_LOWLEVEL          SFRS=2;PIPS6=0x33;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P34_LOWLEVEL          SFRS=2;PIPS6=0x34;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P35_LOWLEVEL          SFRS=2;PIPS6=0x35;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P36_LOWLEVEL          SFRS=2;PIPS6=0x36;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P37_LOWLEVEL          SFRS=2;PIPS6=0x37;SFRS=0;PICON&=CLR_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+
+#define    ENABLE_PIT6_P00_HIGHLEVEL         SFRS=2;PIPS6=0x00;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P01_HIGHLEVEL         SFRS=2;PIPS6=0x01;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P02_HIGHLEVEL         SFRS=2;PIPS6=0x02;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P03_HIGHLEVEL         SFRS=2;PIPS6=0x03;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P04_HIGHLEVEL         SFRS=2;PIPS6=0x04;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P05_HIGHLEVEL         SFRS=2;PIPS6=0x05;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P06_HIGHLEVEL         SFRS=2;PIPS6=0x06;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P07_HIGHLEVEL         SFRS=2;PIPS6=0x07;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P10_HIGHLEVEL         SFRS=2;PIPS6=0x10;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P11_HIGHLEVEL         SFRS=2;PIPS6=0x11;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P12_HIGHLEVEL         SFRS=2;PIPS6=0x12;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P13_HIGHLEVEL         SFRS=2;PIPS6=0x13;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P14_HIGHLEVEL         SFRS=2;PIPS6=0x14;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P15_HIGHLEVEL         SFRS=2;PIPS6=0x15;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P16_HIGHLEVEL         SFRS=2;PIPS6=0x16;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P17_HIGHLEVEL         SFRS=2;PIPS6=0x17;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P20_HIGHLEVEL         SFRS=2;PIPS6=0x20;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P21_HIGHLEVEL         SFRS=2;PIPS6=0x21;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P22_HIGHLEVEL         SFRS=2;PIPS6=0x22;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P23_HIGHLEVEL         SFRS=2;PIPS6=0x23;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P24_HIGHLEVEL         SFRS=2;PIPS6=0x24;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P25_HIGHLEVEL         SFRS=2;PIPS6=0x25;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P30_HIGHLEVEL         SFRS=2;PIPS6=0x30;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P31_HIGHLEVEL         SFRS=2;PIPS6=0x31;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P32_HIGHLEVEL         SFRS=2;PIPS6=0x32;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P33_HIGHLEVEL         SFRS=2;PIPS6=0x33;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P34_HIGHLEVEL         SFRS=2;PIPS6=0x34;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P35_HIGHLEVEL         SFRS=2;PIPS6=0x35;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P36_HIGHLEVEL         SFRS=2;PIPS6=0x36;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P37_HIGHLEVEL         SFRS=2;PIPS6=0x37;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+
+#define    ENABLE_PIT6_P00_FALLINGEDGE       SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P01_FALLINGEDGE       SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P02_FALLINGEDGE       SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P03_FALLINGEDGE       SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P04_FALLINGEDGE       SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P05_FALLINGEDGE       SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P06_FALLINGEDGE       SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P07_FALLINGEDGE       SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P10_FALLINGEDGE       SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P11_FALLINGEDGE       SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P12_FALLINGEDGE       SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P13_FALLINGEDGE       SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P14_FALLINGEDGE       SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P15_FALLINGEDGE       SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P16_FALLINGEDGE       SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P17_FALLINGEDGE       SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P20_FALLINGEDGE       SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P21_FALLINGEDGE       SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P22_FALLINGEDGE       SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P23_FALLINGEDGE       SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P24_FALLINGEDGE       SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P25_FALLINGEDGE       SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P30_FALLINGEDGE       SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P31_FALLINGEDGE       SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P32_FALLINGEDGE       SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P33_FALLINGEDGE       SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P34_FALLINGEDGE       SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P35_FALLINGEDGE       SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P36_FALLINGEDGE       SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+#define    ENABLE_PIT6_P37_FALLINGEDGE       SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN&=CLR_BIT6
+
+#define    ENABLE_PIT6_P00_RISINGEDGE        SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P01_RISINGEDGE        SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P02_RISINGEDGE        SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P03_RISINGEDGE        SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P04_RISINGEDGE        SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P05_RISINGEDGE        SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P06_RISINGEDGE        SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P07_RISINGEDGE        SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P10_RISINGEDGE        SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P11_RISINGEDGE        SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P12_RISINGEDGE        SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P13_RISINGEDGE        SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P14_RISINGEDGE        SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P15_RISINGEDGE        SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P16_RISINGEDGE        SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P17_RISINGEDGE        SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P20_RISINGEDGE        SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P21_RISINGEDGE        SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P22_RISINGEDGE        SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P23_RISINGEDGE        SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P24_RISINGEDGE        SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P25_RISINGEDGE        SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P30_RISINGEDGE        SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P31_RISINGEDGE        SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P32_RISINGEDGE        SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P33_RISINGEDGE        SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P34_RISINGEDGE        SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P35_RISINGEDGE        SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P36_RISINGEDGE        SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P37_RISINGEDGE        SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN|=SET_BIT6
+
+#define    ENABLE_PIT6_P00_BOTHEDGE          SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P01_BOTHEDGE          SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P02_BOTHEDGE          SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P03_BOTHEDGE          SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P04_BOTHEDGE          SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P05_BOTHEDGE          SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P06_BOTHEDGE          SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P07_BOTHEDGE          SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P10_BOTHEDGE          SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P11_BOTHEDGE          SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P12_BOTHEDGE          SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P13_BOTHEDGE          SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P14_BOTHEDGE          SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P15_BOTHEDGE          SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P16_BOTHEDGE          SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P17_BOTHEDGE          SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P20_BOTHEDGE          SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P21_BOTHEDGE          SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P22_BOTHEDGE          SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P23_BOTHEDGE          SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P24_BOTHEDGE          SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P25_BOTHEDGE          SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P30_BOTHEDGE          SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P31_BOTHEDGE          SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P32_BOTHEDGE          SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P33_BOTHEDGE          SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P34_BOTHEDGE          SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P35_BOTHEDGE          SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P36_BOTHEDGE          SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+#define    ENABLE_PIT6_P37_BOTHEDGE          SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN|=SET_BIT6;PIPEN|=SET_BIT6
+
+  /*------- -------- Pin interrupt channel 6 PIT6 Disable ------------------------ */
+#define    DISABLE_PIT6_P00_LOWLEVEL         SFRS=2;PIPS6=0x00;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P01_LOWLEVEL         SFRS=2;PIPS6=0x01;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P02_LOWLEVEL         SFRS=2;PIPS6=0x02;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P03_LOWLEVEL         SFRS=2;PIPS6=0x03;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P04_LOWLEVEL         SFRS=2;PIPS6=0x04;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P05_LOWLEVEL         SFRS=2;PIPS6=0x05;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P06_LOWLEVEL         SFRS=2;PIPS6=0x06;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P07_LOWLEVEL         SFRS=2;PIPS6=0x07;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P10_LOWLEVEL         SFRS=2;PIPS6=0x10;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P11_LOWLEVEL         SFRS=2;PIPS6=0x11;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P12_LOWLEVEL         SFRS=2;PIPS6=0x12;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P13_LOWLEVEL         SFRS=2;PIPS6=0x13;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P14_LOWLEVEL         SFRS=2;PIPS6=0x14;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P15_LOWLEVEL         SFRS=2;PIPS6=0x15;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P16_LOWLEVEL         SFRS=2;PIPS6=0x16;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P17_LOWLEVEL         SFRS=2;PIPS6=0x17;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P20_LOWLEVEL         SFRS=2;PIPS6=0x20;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P21_LOWLEVEL         SFRS=2;PIPS6=0x21;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P22_LOWLEVEL         SFRS=2;PIPS6=0x22;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P23_LOWLEVEL         SFRS=2;PIPS6=0x23;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P24_LOWLEVEL         SFRS=2;PIPS6=0x24;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P25_LOWLEVEL         SFRS=2;PIPS6=0x25;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P30_LOWLEVEL         SFRS=2;PIPS6=0x30;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P31_LOWLEVEL         SFRS=2;PIPS6=0x31;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P32_LOWLEVEL         SFRS=2;PIPS6=0x32;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P33_LOWLEVEL         SFRS=2;PIPS6=0x33;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P34_LOWLEVEL         SFRS=2;PIPS6=0x34;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P35_LOWLEVEL         SFRS=2;PIPS6=0x35;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P36_LOWLEVEL         SFRS=2;PIPS6=0x36;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P37_LOWLEVEL         SFRS=2;PIPS6=0x37;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+
+#define    DISABLE_PIT6_P00_HIGHLEVEL        SFRS=2;PIPS6=0x00;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P01_HIGHLEVEL        SFRS=2;PIPS6=0x01;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P02_HIGHLEVEL        SFRS=2;PIPS6=0x02;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P03_HIGHLEVEL        SFRS=2;PIPS6=0x03;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P04_HIGHLEVEL        SFRS=2;PIPS6=0x04;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P05_HIGHLEVEL        SFRS=2;PIPS6=0x05;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P06_HIGHLEVEL        SFRS=2;PIPS6=0x06;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P07_HIGHLEVEL        SFRS=2;PIPS6=0x07;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P10_HIGHLEVEL        SFRS=2;PIPS6=0x10;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P11_HIGHLEVEL        SFRS=2;PIPS6=0x11;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P12_HIGHLEVEL        SFRS=2;PIPS6=0x12;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P13_HIGHLEVEL        SFRS=2;PIPS6=0x13;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P14_HIGHLEVEL        SFRS=2;PIPS6=0x14;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P15_HIGHLEVEL        SFRS=2;PIPS6=0x15;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P16_HIGHLEVEL        SFRS=2;PIPS6=0x16;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P17_HIGHLEVEL        SFRS=2;PIPS6=0x17;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P20_HIGHLEVEL        SFRS=2;PIPS6=0x20;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P21_HIGHLEVEL        SFRS=2;PIPS6=0x21;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P22_HIGHLEVEL        SFRS=2;PIPS6=0x22;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P23_HIGHLEVEL        SFRS=2;PIPS6=0x23;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P24_HIGHLEVEL        SFRS=2;PIPS6=0x24;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P25_HIGHLEVEL        SFRS=2;PIPS6=0x25;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P30_HIGHLEVEL        SFRS=2;PIPS6=0x30;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P31_HIGHLEVEL        SFRS=2;PIPS6=0x31;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P32_HIGHLEVEL        SFRS=2;PIPS6=0x32;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P33_HIGHLEVEL        SFRS=2;PIPS6=0x33;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P34_HIGHLEVEL        SFRS=2;PIPS6=0x34;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P35_HIGHLEVEL        SFRS=2;PIPS6=0x35;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P36_HIGHLEVEL        SFRS=2;PIPS6=0x36;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P37_HIGHLEVEL        SFRS=2;PIPS6=0x37;SFRS=0;PICON&=CLR_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+
+#define    DISABLE_PIT6_P00_FALLINGEDGE      SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P01_FALLINGEDGE      SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P02_FALLINGEDGE      SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P03_FALLINGEDGE      SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P04_FALLINGEDGE      SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P05_FALLINGEDGE      SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P06_FALLINGEDGE      SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P07_FALLINGEDGE      SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P10_FALLINGEDGE      SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P11_FALLINGEDGE      SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P12_FALLINGEDGE      SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P13_FALLINGEDGE      SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P14_FALLINGEDGE      SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P15_FALLINGEDGE      SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P16_FALLINGEDGE      SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P17_FALLINGEDGE      SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P20_FALLINGEDGE      SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P21_FALLINGEDGE      SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P22_FALLINGEDGE      SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P23_FALLINGEDGE      SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P24_FALLINGEDGE      SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P25_FALLINGEDGE      SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P30_FALLINGEDGE      SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P31_FALLINGEDGE      SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P32_FALLINGEDGE      SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P33_FALLINGEDGE      SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P34_FALLINGEDGE      SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P35_FALLINGEDGE      SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P36_FALLINGEDGE      SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P37_FALLINGEDGE      SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+
+#define    DISABLE_PIT6_P00_RISINGEDGE       SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P01_RISINGEDGE       SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P02_RISINGEDGE       SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P03_RISINGEDGE       SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P04_RISINGEDGE       SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P05_RISINGEDGE       SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P06_RISINGEDGE       SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P07_RISINGEDGE       SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P10_RISINGEDGE       SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P11_RISINGEDGE       SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P12_RISINGEDGE       SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P13_RISINGEDGE       SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P14_RISINGEDGE       SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P15_RISINGEDGE       SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P16_RISINGEDGE       SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P17_RISINGEDGE       SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P20_RISINGEDGE       SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P21_RISINGEDGE       SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P22_RISINGEDGE       SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P23_RISINGEDGE       SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P24_RISINGEDGE       SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P25_RISINGEDGE       SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P30_RISINGEDGE       SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P31_RISINGEDGE       SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P32_RISINGEDGE       SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P33_RISINGEDGE       SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P34_RISINGEDGE       SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P35_RISINGEDGE       SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P36_RISINGEDGE       SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P37_RISINGEDGE       SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+
+#define    DISABLE_PIT6_P00_BOTHEDGE         SFRS=2;PIPS6=0x00;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P01_BOTHEDGE         SFRS=2;PIPS6=0x01;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P02_BOTHEDGE         SFRS=2;PIPS6=0x02;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P03_BOTHEDGE         SFRS=2;PIPS6=0x03;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P04_BOTHEDGE         SFRS=2;PIPS6=0x04;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P05_BOTHEDGE         SFRS=2;PIPS6=0x05;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P06_BOTHEDGE         SFRS=2;PIPS6=0x06;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P07_BOTHEDGE         SFRS=2;PIPS6=0x07;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P10_BOTHEDGE         SFRS=2;PIPS6=0x10;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P11_BOTHEDGE         SFRS=2;PIPS6=0x11;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P12_BOTHEDGE         SFRS=2;PIPS6=0x12;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P13_BOTHEDGE         SFRS=2;PIPS6=0x13;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P14_BOTHEDGE         SFRS=2;PIPS6=0x14;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P15_BOTHEDGE         SFRS=2;PIPS6=0x15;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P16_BOTHEDGE         SFRS=2;PIPS6=0x16;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P17_BOTHEDGE         SFRS=2;PIPS6=0x17;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P20_BOTHEDGE         SFRS=2;PIPS6=0x20;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P21_BOTHEDGE         SFRS=2;PIPS6=0x21;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P22_BOTHEDGE         SFRS=2;PIPS6=0x22;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P23_BOTHEDGE         SFRS=2;PIPS6=0x23;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P24_BOTHEDGE         SFRS=2;PIPS6=0x24;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P25_BOTHEDGE         SFRS=2;PIPS6=0x25;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P30_BOTHEDGE         SFRS=2;PIPS6=0x30;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P31_BOTHEDGE         SFRS=2;PIPS6=0x31;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P32_BOTHEDGE         SFRS=2;PIPS6=0x32;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P33_BOTHEDGE         SFRS=2;PIPS6=0x33;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P34_BOTHEDGE         SFRS=2;PIPS6=0x34;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P35_BOTHEDGE         SFRS=2;PIPS6=0x35;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P36_BOTHEDGE         SFRS=2;PIPS6=0x36;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+#define    DISABLE_PIT6_P37_BOTHEDGE         SFRS=2;PIPS6=0x37;SFRS=0;PICON|=SET_BIT6;PINEN&=CLR_BIT6;PIPEN&=CLR_BIT6
+
+  /*------- -------- Pin interrupt channel 7 PIT7 Enable ------------------------ */
+#define    ENABLE_PIT7_P00_LOWLEVEL          SFRS=2;PIPS7=0x00;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P01_LOWLEVEL          SFRS=2;PIPS7=0x01;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P02_LOWLEVEL          SFRS=2;PIPS7=0x02;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P03_LOWLEVEL          SFRS=2;PIPS7=0x03;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P04_LOWLEVEL          SFRS=2;PIPS7=0x04;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P05_LOWLEVEL          SFRS=2;PIPS7=0x05;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P06_LOWLEVEL          SFRS=2;PIPS7=0x06;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P07_LOWLEVEL          SFRS=2;PIPS7=0x07;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P10_LOWLEVEL          SFRS=2;PIPS7=0x10;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P11_LOWLEVEL          SFRS=2;PIPS7=0x11;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P12_LOWLEVEL          SFRS=2;PIPS7=0x12;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P13_LOWLEVEL          SFRS=2;PIPS7=0x13;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P14_LOWLEVEL          SFRS=2;PIPS7=0x14;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P15_LOWLEVEL          SFRS=2;PIPS7=0x15;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P16_LOWLEVEL          SFRS=2;PIPS7=0x16;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P17_LOWLEVEL          SFRS=2;PIPS7=0x17;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P20_LOWLEVEL          SFRS=2;PIPS7=0x20;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P21_LOWLEVEL          SFRS=2;PIPS7=0x21;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P22_LOWLEVEL          SFRS=2;PIPS7=0x22;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P23_LOWLEVEL          SFRS=2;PIPS7=0x23;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P24_LOWLEVEL          SFRS=2;PIPS7=0x24;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P25_LOWLEVEL          SFRS=2;PIPS7=0x25;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P30_LOWLEVEL          SFRS=2;PIPS7=0x30;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P31_LOWLEVEL          SFRS=2;PIPS7=0x31;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P32_LOWLEVEL          SFRS=2;PIPS7=0x32;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P33_LOWLEVEL          SFRS=2;PIPS7=0x33;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P34_LOWLEVEL          SFRS=2;PIPS7=0x34;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P35_LOWLEVEL          SFRS=2;PIPS7=0x35;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P36_LOWLEVEL          SFRS=2;PIPS7=0x36;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P37_LOWLEVEL          SFRS=2;PIPS7=0x37;SFRS=0;PICON&=CLR_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+
+#define    ENABLE_PIT7_P00_HIGHLEVEL         SFRS=2;PIPS7=0x00;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P01_HIGHLEVEL         SFRS=2;PIPS7=0x01;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P02_HIGHLEVEL         SFRS=2;PIPS7=0x02;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P03_HIGHLEVEL         SFRS=2;PIPS7=0x03;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P04_HIGHLEVEL         SFRS=2;PIPS7=0x04;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P05_HIGHLEVEL         SFRS=2;PIPS7=0x05;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P06_HIGHLEVEL         SFRS=2;PIPS7=0x06;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P07_HIGHLEVEL         SFRS=2;PIPS7=0x07;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P10_HIGHLEVEL         SFRS=2;PIPS7=0x10;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P11_HIGHLEVEL         SFRS=2;PIPS7=0x11;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P12_HIGHLEVEL         SFRS=2;PIPS7=0x12;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P13_HIGHLEVEL         SFRS=2;PIPS7=0x13;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P14_HIGHLEVEL         SFRS=2;PIPS7=0x14;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P15_HIGHLEVEL         SFRS=2;PIPS7=0x15;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P16_HIGHLEVEL         SFRS=2;PIPS7=0x16;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P17_HIGHLEVEL         SFRS=2;PIPS7=0x17;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P20_HIGHLEVEL         SFRS=2;PIPS7=0x20;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P21_HIGHLEVEL         SFRS=2;PIPS7=0x21;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P22_HIGHLEVEL         SFRS=2;PIPS7=0x22;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P23_HIGHLEVEL         SFRS=2;PIPS7=0x23;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P24_HIGHLEVEL         SFRS=2;PIPS7=0x24;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P25_HIGHLEVEL         SFRS=2;PIPS7=0x25;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P30_HIGHLEVEL         SFRS=2;PIPS7=0x30;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P31_HIGHLEVEL         SFRS=2;PIPS7=0x31;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P32_HIGHLEVEL         SFRS=2;PIPS7=0x32;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P33_HIGHLEVEL         SFRS=2;PIPS7=0x33;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P34_HIGHLEVEL         SFRS=2;PIPS7=0x34;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P35_HIGHLEVEL         SFRS=2;PIPS7=0x35;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P36_HIGHLEVEL         SFRS=2;PIPS7=0x36;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P37_HIGHLEVEL         SFRS=2;PIPS7=0x37;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+
+#define    ENABLE_PIT7_P00_FALLINGEDGE       SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P01_FALLINGEDGE       SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P02_FALLINGEDGE       SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P03_FALLINGEDGE       SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P04_FALLINGEDGE       SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P05_FALLINGEDGE       SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P06_FALLINGEDGE       SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P07_FALLINGEDGE       SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P10_FALLINGEDGE       SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P11_FALLINGEDGE       SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P12_FALLINGEDGE       SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P13_FALLINGEDGE       SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P14_FALLINGEDGE       SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P15_FALLINGEDGE       SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P16_FALLINGEDGE       SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P17_FALLINGEDGE       SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P20_FALLINGEDGE       SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P21_FALLINGEDGE       SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P22_FALLINGEDGE       SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P23_FALLINGEDGE       SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P24_FALLINGEDGE       SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P25_FALLINGEDGE       SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P30_FALLINGEDGE       SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P31_FALLINGEDGE       SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P32_FALLINGEDGE       SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P33_FALLINGEDGE       SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P34_FALLINGEDGE       SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P35_FALLINGEDGE       SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P36_FALLINGEDGE       SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+#define    ENABLE_PIT7_P37_FALLINGEDGE       SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN&=CLR_BIT7
+
+#define    ENABLE_PIT7_P00_RISINGEDGE        SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P01_RISINGEDGE        SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P02_RISINGEDGE        SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P03_RISINGEDGE        SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P04_RISINGEDGE        SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P05_RISINGEDGE        SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P06_RISINGEDGE        SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P07_RISINGEDGE        SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P10_RISINGEDGE        SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P11_RISINGEDGE        SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P12_RISINGEDGE        SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P13_RISINGEDGE        SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P14_RISINGEDGE        SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P15_RISINGEDGE        SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P16_RISINGEDGE        SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P17_RISINGEDGE        SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P20_RISINGEDGE        SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P21_RISINGEDGE        SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P22_RISINGEDGE        SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P23_RISINGEDGE        SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P24_RISINGEDGE        SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P25_RISINGEDGE        SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P30_RISINGEDGE        SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P31_RISINGEDGE        SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P32_RISINGEDGE        SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P33_RISINGEDGE        SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P34_RISINGEDGE        SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P35_RISINGEDGE        SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P36_RISINGEDGE        SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P37_RISINGEDGE        SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN|=SET_BIT7
+
+#define    ENABLE_PIT7_P00_BOTHEDGE          SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P01_BOTHEDGE          SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P02_BOTHEDGE          SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P03_BOTHEDGE          SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P04_BOTHEDGE          SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P05_BOTHEDGE          SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P06_BOTHEDGE          SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P07_BOTHEDGE          SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P10_BOTHEDGE          SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P11_BOTHEDGE          SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P12_BOTHEDGE          SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P13_BOTHEDGE          SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P14_BOTHEDGE          SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P15_BOTHEDGE          SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P16_BOTHEDGE          SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P17_BOTHEDGE          SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P20_BOTHEDGE          SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P21_BOTHEDGE          SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P22_BOTHEDGE          SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P23_BOTHEDGE          SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P24_BOTHEDGE          SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P25_BOTHEDGE          SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P30_BOTHEDGE          SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P31_BOTHEDGE          SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P32_BOTHEDGE          SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P33_BOTHEDGE          SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P34_BOTHEDGE          SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P35_BOTHEDGE          SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P36_BOTHEDGE          SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+#define    ENABLE_PIT7_P37_BOTHEDGE          SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN|=SET_BIT7;PIPEN|=SET_BIT7
+
+  /*------- -------- Pin interrupt channel 7 PIT7 Disable ------------------------ */
+#define    DISABLE_PIT7_P00_LOWLEVEL         SFRS=2;PIPS7=0x00;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P01_LOWLEVEL         SFRS=2;PIPS7=0x01;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P02_LOWLEVEL         SFRS=2;PIPS7=0x02;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P03_LOWLEVEL         SFRS=2;PIPS7=0x03;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P04_LOWLEVEL         SFRS=2;PIPS7=0x04;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P05_LOWLEVEL         SFRS=2;PIPS7=0x05;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P06_LOWLEVEL         SFRS=2;PIPS7=0x06;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P07_LOWLEVEL         SFRS=2;PIPS7=0x07;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P10_LOWLEVEL         SFRS=2;PIPS7=0x10;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P11_LOWLEVEL         SFRS=2;PIPS7=0x11;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P12_LOWLEVEL         SFRS=2;PIPS7=0x12;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P13_LOWLEVEL         SFRS=2;PIPS7=0x13;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P14_LOWLEVEL         SFRS=2;PIPS7=0x14;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P15_LOWLEVEL         SFRS=2;PIPS7=0x15;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P16_LOWLEVEL         SFRS=2;PIPS7=0x16;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P17_LOWLEVEL         SFRS=2;PIPS7=0x17;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P20_LOWLEVEL         SFRS=2;PIPS7=0x20;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P21_LOWLEVEL         SFRS=2;PIPS7=0x21;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P22_LOWLEVEL         SFRS=2;PIPS7=0x22;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P23_LOWLEVEL         SFRS=2;PIPS7=0x23;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P24_LOWLEVEL         SFRS=2;PIPS7=0x24;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P25_LOWLEVEL         SFRS=2;PIPS7=0x25;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P30_LOWLEVEL         SFRS=2;PIPS7=0x30;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P31_LOWLEVEL         SFRS=2;PIPS7=0x31;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P32_LOWLEVEL         SFRS=2;PIPS7=0x32;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P33_LOWLEVEL         SFRS=2;PIPS7=0x33;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P34_LOWLEVEL         SFRS=2;PIPS7=0x34;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P35_LOWLEVEL         SFRS=2;PIPS7=0x35;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P36_LOWLEVEL         SFRS=2;PIPS7=0x36;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P37_LOWLEVEL         SFRS=2;PIPS7=0x37;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+
+#define    DISABLE_PIT7_P00_HIGHLEVEL        SFRS=2;PIPS7=0x00;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P01_HIGHLEVEL        SFRS=2;PIPS7=0x01;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P02_HIGHLEVEL        SFRS=2;PIPS7=0x02;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P03_HIGHLEVEL        SFRS=2;PIPS7=0x03;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P04_HIGHLEVEL        SFRS=2;PIPS7=0x04;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P05_HIGHLEVEL        SFRS=2;PIPS7=0x05;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P06_HIGHLEVEL        SFRS=2;PIPS7=0x06;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P07_HIGHLEVEL        SFRS=2;PIPS7=0x07;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P10_HIGHLEVEL        SFRS=2;PIPS7=0x10;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P11_HIGHLEVEL        SFRS=2;PIPS7=0x11;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P12_HIGHLEVEL        SFRS=2;PIPS7=0x12;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P13_HIGHLEVEL        SFRS=2;PIPS7=0x13;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P14_HIGHLEVEL        SFRS=2;PIPS7=0x14;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P15_HIGHLEVEL        SFRS=2;PIPS7=0x15;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P16_HIGHLEVEL        SFRS=2;PIPS7=0x16;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P17_HIGHLEVEL        SFRS=2;PIPS7=0x17;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P20_HIGHLEVEL        SFRS=2;PIPS7=0x20;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P21_HIGHLEVEL        SFRS=2;PIPS7=0x21;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P22_HIGHLEVEL        SFRS=2;PIPS7=0x22;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P23_HIGHLEVEL        SFRS=2;PIPS7=0x23;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P24_HIGHLEVEL        SFRS=2;PIPS7=0x24;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P25_HIGHLEVEL        SFRS=2;PIPS7=0x25;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P30_HIGHLEVEL        SFRS=2;PIPS7=0x30;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P31_HIGHLEVEL        SFRS=2;PIPS7=0x31;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P32_HIGHLEVEL        SFRS=2;PIPS7=0x32;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P33_HIGHLEVEL        SFRS=2;PIPS7=0x33;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P34_HIGHLEVEL        SFRS=2;PIPS7=0x34;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P35_HIGHLEVEL        SFRS=2;PIPS7=0x35;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P36_HIGHLEVEL        SFRS=2;PIPS7=0x36;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P37_HIGHLEVEL        SFRS=2;PIPS7=0x37;SFRS=0;PICON&=CLR_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+
+#define    DISABLE_PIT7_P00_FALLINGEDGE      SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P01_FALLINGEDGE      SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P02_FALLINGEDGE      SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P03_FALLINGEDGE      SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P04_FALLINGEDGE      SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P05_FALLINGEDGE      SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P06_FALLINGEDGE      SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P07_FALLINGEDGE      SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P10_FALLINGEDGE      SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P11_FALLINGEDGE      SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P12_FALLINGEDGE      SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P13_FALLINGEDGE      SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P14_FALLINGEDGE      SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P15_FALLINGEDGE      SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P16_FALLINGEDGE      SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P17_FALLINGEDGE      SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P20_FALLINGEDGE      SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P21_FALLINGEDGE      SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P22_FALLINGEDGE      SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P23_FALLINGEDGE      SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P24_FALLINGEDGE      SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P25_FALLINGEDGE      SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P30_FALLINGEDGE      SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P31_FALLINGEDGE      SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P32_FALLINGEDGE      SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P33_FALLINGEDGE      SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P34_FALLINGEDGE      SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P35_FALLINGEDGE      SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P36_FALLINGEDGE      SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P37_FALLINGEDGE      SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+
+#define    DISABLE_PIT7_P00_RISINGEDGE       SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P01_RISINGEDGE       SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P02_RISINGEDGE       SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P03_RISINGEDGE       SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P04_RISINGEDGE       SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P05_RISINGEDGE       SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P06_RISINGEDGE       SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P07_RISINGEDGE       SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P10_RISINGEDGE       SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P11_RISINGEDGE       SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P12_RISINGEDGE       SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P13_RISINGEDGE       SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P14_RISINGEDGE       SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P15_RISINGEDGE       SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P16_RISINGEDGE       SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P17_RISINGEDGE       SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P20_RISINGEDGE       SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P21_RISINGEDGE       SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P22_RISINGEDGE       SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P23_RISINGEDGE       SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P24_RISINGEDGE       SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P25_RISINGEDGE       SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P30_RISINGEDGE       SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P31_RISINGEDGE       SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P32_RISINGEDGE       SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P33_RISINGEDGE       SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P34_RISINGEDGE       SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P35_RISINGEDGE       SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P36_RISINGEDGE       SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P37_RISINGEDGE       SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+
+#define    DISABLE_PIT7_P00_BOTHEDGE         SFRS=2;PIPS7=0x00;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P01_BOTHEDGE         SFRS=2;PIPS7=0x01;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P02_BOTHEDGE         SFRS=2;PIPS7=0x02;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P03_BOTHEDGE         SFRS=2;PIPS7=0x03;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P04_BOTHEDGE         SFRS=2;PIPS7=0x04;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P05_BOTHEDGE         SFRS=2;PIPS7=0x05;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P06_BOTHEDGE         SFRS=2;PIPS7=0x06;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P07_BOTHEDGE         SFRS=2;PIPS7=0x07;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P10_BOTHEDGE         SFRS=2;PIPS7=0x10;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P11_BOTHEDGE         SFRS=2;PIPS7=0x11;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P12_BOTHEDGE         SFRS=2;PIPS7=0x12;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P13_BOTHEDGE         SFRS=2;PIPS7=0x13;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P14_BOTHEDGE         SFRS=2;PIPS7=0x14;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P15_BOTHEDGE         SFRS=2;PIPS7=0x15;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P16_BOTHEDGE         SFRS=2;PIPS7=0x16;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P17_BOTHEDGE         SFRS=2;PIPS7=0x17;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P20_BOTHEDGE         SFRS=2;PIPS7=0x20;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P21_BOTHEDGE         SFRS=2;PIPS7=0x21;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P22_BOTHEDGE         SFRS=2;PIPS7=0x22;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P23_BOTHEDGE         SFRS=2;PIPS7=0x23;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P24_BOTHEDGE         SFRS=2;PIPS7=0x24;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P25_BOTHEDGE         SFRS=2;PIPS7=0x25;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P30_BOTHEDGE         SFRS=2;PIPS7=0x30;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P31_BOTHEDGE         SFRS=2;PIPS7=0x31;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P32_BOTHEDGE         SFRS=2;PIPS7=0x32;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P33_BOTHEDGE         SFRS=2;PIPS7=0x33;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P34_BOTHEDGE         SFRS=2;PIPS7=0x34;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P35_BOTHEDGE         SFRS=2;PIPS7=0x35;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P36_BOTHEDGE         SFRS=2;PIPS7=0x36;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+#define    DISABLE_PIT7_P37_BOTHEDGE         SFRS=2;PIPS7=0x37;SFRS=0;PICON|=SET_BIT7;PINEN&=CLR_BIT7;PIPEN&=CLR_BIT7
+
+#define    DISABLE_ALL_PIT                   SFRS=2;PIPS0=0;PIPS1=0;PIPS2=0;PIPS3=0;PIPS4=0; \
+                                                    PIPS5=0;PIPS6=0;PIPS7=0; \
+                                                    SFRS=0;PICON=0;PINEN=0;PIPEN=0
+
+/*****************************************************************************************/
+/* For GPIO Mode setting                                                                 */
+/*****************************************************************************************/
+/*------------------- Define Port as Quasi mode  -------------------*/
+#define    P00_QUASI_MODE         SFRS=0;P0M1&=0xFE;P0M2&=0xFE
+#define    P01_QUASI_MODE         SFRS=0;P0M1&=0xFD;P0M2&=0xFD
+#define    P02_QUASI_MODE         SFRS=0;P0M1&=0xFB;P0M2&=0xFB
+#define    P03_QUASI_MODE         SFRS=0;P0M1&=0xF7;P0M2&=0xF7
+#define    P04_QUASI_MODE         SFRS=0;P0M1&=0xEF;P0M2&=0xEF
+#define    P05_QUASI_MODE         SFRS=0;P0M1&=0xDF;P0M2&=0xDF
+#define    P06_QUASI_MODE         SFRS=0;P0M1&=0xBF;P0M2&=0xBF
+#define    P07_QUASI_MODE         SFRS=0;P0M1&=0x7F;P0M2&=0x7F
+#define    P10_QUASI_MODE         SFRS=0;P1M1&=0xFE;P1M2&=0xFE
+#define    P11_QUASI_MODE         SFRS=0;P1M1&=0xFD;P1M2&=0xFD
+#define    P12_QUASI_MODE         SFRS=0;P1M1&=0xFB;P1M2&=0xFB
+#define    P13_QUASI_MODE         SFRS=0;P1M1&=0xF7;P1M2&=0xF7
+#define    P14_QUASI_MODE         SFRS=0;P1M1&=0xEF;P1M2&=0xEF
+#define    P15_QUASI_MODE         SFRS=0;P1M1&=0xDF;P1M2&=0xDF
+#define    P16_QUASI_MODE         SFRS=0;P1M1&=0xBF;P1M2&=0xBF
+#define    P17_QUASI_MODE         SFRS=0;P1M1&=0x7F;P1M2&=0x7F
+#define    P20_QUASI_MODE         SFRS=2;P2M1&=0xFE;P2M2&=0xFE
+#define    P21_QUASI_MODE         SFRS=2;P2M1&=0xFD;P2M2&=0xFD
+#define    P22_QUASI_MODE         SFRS=2;P2M1&=0xFB;P2M2&=0xFB
+#define    P23_QUASI_MODE         SFRS=2;P2M1&=0xF7;P2M2&=0xF7
+#define    P24_QUASI_MODE         SFRS=2;P2M1&=0xEF;P2M2&=0xEF
+#define    P25_QUASI_MODE         SFRS=2;P2M1&=0xDF;P2M2&=0xDF
+#define    P30_QUASI_MODE         SFRS=0;P3M1&=0xFE;P3M2&=0xFE
+#define    P31_QUASI_MODE         SFRS=0;P3M1&=0xFD;P3M2&=0xFD
+#define    P32_QUASI_MODE         SFRS=0;P3M1&=0xFB;P3M2&=0xFB
+#define    P33_QUASI_MODE         SFRS=0;P3M1&=0xF7;P3M2&=0xF7
+#define    P34_QUASI_MODE         SFRS=0;P3M1&=0xEF;P3M2&=0xEF
+#define    P35_QUASI_MODE         SFRS=0;P3M1&=0xDF;P3M2&=0xDF
+#define    P36_QUASI_MODE         SFRS=0;P3M1&=0xBF;P3M2&=0xBF
+#define    P37_QUASI_MODE         SFRS=0;P3M1&=0x7F;P3M2&=0x7F
+#define    ALL_GPIO_QUASI_MODE         SFRS=0;P0M1=0x00;P0M2=0x00;P1M1=0x00;P1M2=0x00;\
+                                       SFRS=2;P2M1=0x00;P2M2=0x00;SFRS=0;P3M1=0x00;P3M2=0x00
+//------------------- Define Port as Push Pull mode -------------------*/
+#define    P00_PUSHPULL_MODE      SFRS=0;P0M1&=0xFE;P0M2|=0x01
+#define    P01_PUSHPULL_MODE      SFRS=0;P0M1&=0xFD;P0M2|=0x02
+#define    P02_PUSHPULL_MODE      SFRS=0;P0M1&=0xFB;P0M2|=0x04
+#define    P03_PUSHPULL_MODE      SFRS=0;P0M1&=0xF7;P0M2|=0x08
+#define    P04_PUSHPULL_MODE      SFRS=0;P0M1&=0xEF;P0M2|=0x10
+#define    P05_PUSHPULL_MODE      SFRS=0;P0M1&=0xDF;P0M2|=0x20
+#define    P06_PUSHPULL_MODE      SFRS=0;P0M1&=0xBF;P0M2|=0x40
+#define    P07_PUSHPULL_MODE      SFRS=0;P0M1&=0x7F;P0M2|=0x80
+#define    P10_PUSHPULL_MODE      SFRS=0;P1M1&=0xFE;P1M2|=0x01
+#define    P11_PUSHPULL_MODE      SFRS=0;P1M1&=0xFD;P1M2|=0x02
+#define    P12_PUSHPULL_MODE      SFRS=0;P1M1&=0xFB;P1M2|=0x04
+#define    P13_PUSHPULL_MODE      SFRS=0;P1M1&=0xF7;P1M2|=0x08
+#define    P14_PUSHPULL_MODE      SFRS=0;P1M1&=0xEF;P1M2|=0x10
+#define    P15_PUSHPULL_MODE      SFRS=0;P1M1&=0xDF;P1M2|=0x20
+#define    P16_PUSHPULL_MODE      SFRS=0;P1M1&=0xBF;P1M2|=0x40
+#define    P17_PUSHPULL_MODE      SFRS=0;P1M1&=0x7F;P1M2|=0x80
+#define    P20_PUSHPULL_MODE      SFRS=2;P2M1&=0xFE;P2M2|=0x01
+#define    P21_PUSHPULL_MODE      SFRS=2;P2M1&=0xFD;P2M2|=0x02
+#define    P22_PUSHPULL_MODE      SFRS=2;P2M1&=0xFB;P2M2|=0x04
+#define    P23_PUSHPULL_MODE      SFRS=2;P2M1&=0xF7;P2M2|=0x08
+#define    P24_PUSHPULL_MODE      SFRS=2;P2M1&=0xEF;P2M2|=0x10
+#define    P25_PUSHPULL_MODE      SFRS=2;P2M1&=0xDF;P2M2|=0x20
+#define    P30_PUSHPULL_MODE      SFRS=0;P3M1&=0xFE;P3M2|=0x01
+#define    P31_PUSHPULL_MODE      SFRS=0;P3M1&=0xFD;P3M2|=0x02
+#define    P32_PUSHPULL_MODE      SFRS=0;P3M1&=0xFB;P3M2|=0x04
+#define    P33_PUSHPULL_MODE      SFRS=0;P3M1&=0xF7;P3M2|=0x08
+#define    P34_PUSHPULL_MODE      SFRS=0;P3M1&=0xEF;P3M2|=0x10
+#define    P35_PUSHPULL_MODE      SFRS=0;P3M1&=0xDF;P3M2|=0x20
+#define    P36_PUSHPULL_MODE      SFRS=0;P3M1&=0xBF;P3M2|=0x40
+#define    P37_PUSHPULL_MODE      SFRS=0;P3M1&=0x7F;P3M2|=0x80
+#define    ALL_GPIO_PUSHPULL_MODE         SFRS=0;P0M1=0x00;P0M2=0xFF;P1M1=0x00;P1M2=0xFF;\
+                                          SFRS=2;P2M1=0x00;P2M2=0xFF;SFRS=0;P3M1=0x00;P3M2=0xFF
+//------------------- Define Port as Input Only mode -------------------*/
+#define    P00_INPUT_MODE         SFRS=0;P0M1|=0x01;P0M2&=0xFE
+#define    P01_INPUT_MODE         SFRS=0;P0M1|=0x02;P0M2&=0xFD
+#define    P02_INPUT_MODE         SFRS=0;P0M1|=0x04;P0M2&=0xFB
+#define    P03_INPUT_MODE         SFRS=0;P0M1|=0x08;P0M2&=0xF7
+#define    P04_INPUT_MODE         SFRS=0;P0M1|=0x10;P0M2&=0xEF
+#define    P05_INPUT_MODE         SFRS=0;P0M1|=0x20;P0M2&=0xDF
+#define    P06_INPUT_MODE         SFRS=0;P0M1|=0x40;P0M2&=0xBF
+#define    P07_INPUT_MODE         SFRS=0;P0M1|=0x80;P0M2&=0x7F
+#define    P10_INPUT_MODE         SFRS=0;P1M1|=0x01;P1M2&=0xFE
+#define    P11_INPUT_MODE         SFRS=0;P1M1|=0x02;P1M2&=0xFD
+#define    P12_INPUT_MODE         SFRS=0;P1M1|=0x04;P1M2&=0xFB
+#define    P13_INPUT_MODE         SFRS=0;P1M1|=0x08;P1M2&=0xF7
+#define    P14_INPUT_MODE         SFRS=0;P1M1|=0x10;P1M2&=0xEF
+#define    P15_INPUT_MODE         SFRS=0;P1M1|=0x20;P1M2&=0xDF
+#define    P16_INPUT_MODE         SFRS=0;P1M1|=0x40;P1M2&=0xBF
+#define    P17_INPUT_MODE         SFRS=0;P1M1|=0x80;P1M2&=0x7F
+#define    P20_INPUT_MODE         SFRS=2;P2M1|=0x01;P2M2&=0xFE
+#define    P21_INPUT_MODE         SFRS=2;P2M1|=0x02;P2M2&=0xFD
+#define    P22_INPUT_MODE         SFRS=2;P2M1|=0x04;P2M2&=0xFB
+#define    P23_INPUT_MODE         SFRS=2;P2M1|=0x08;P2M2&=0xF7
+#define    P24_INPUT_MODE         SFRS=2;P2M1|=0x10;P2M2&=0xEF
+#define    P25_INPUT_MODE         SFRS=2;P2M1|=0x20;P2M2&=0xDF
+#define    P26_INPUT_MODE         SFRS=2;P2M1|=0x40;P2M2&=0xBF
+#define    P27_INPUT_MODE         SFRS=2;P2M1|=0x80;P2M2&=0x7F
+#define    P30_INPUT_MODE         SFRS=0;P3M1|=0x01;P3M2&=0xFE
+#define    P31_INPUT_MODE         SFRS=0;P3M1|=0x02;P3M2&=0xFD
+#define    P32_INPUT_MODE         SFRS=0;P3M1|=0x04;P3M2&=0xFB
+#define    P33_INPUT_MODE         SFRS=0;P3M1|=0x08;P3M2&=0xF7
+#define    P34_INPUT_MODE         SFRS=0;P3M1|=0x10;P3M2&=0xEF
+#define    P35_INPUT_MODE         SFRS=0;P3M1|=0x20;P3M2&=0xDF
+#define    P36_INPUT_MODE         SFRS=0;P3M1|=0x40;P3M2&=0xBF
+#define    P37_INPUT_MODE         SFRS=0;P3M1|=0x80;P3M2&=0x7F
+#define    ALL_GPIO_INPUT_MODE         SFRS=0;P0M1=0xFF;P0M2=0x00;P1M1=0xFF;P1M2=0x00;\
+                                       SFRS=2;P2M1=0xFF;P2M2=0x00;SFRS=0;P3M1=0xFF;P3M2=0x00
+//-------------------Define Port as Open Drain mode -------------------*/
+#define    P00_OPENDRAIN_MODE     SFRS=0;P0M1|=0x01;P0M2|=0x01
+#define    P01_OPENDRAIN_MODE     SFRS=0;P0M1|=0x02;P0M2|=0x02
+#define    P02_OPENDRAIN_MODE     SFRS=0;P0M1|=0x04;P0M2|=0x04
+#define    P03_OPENDRAIN_MODE     SFRS=0;P0M1|=0x08;P0M2|=0x08
+#define    P04_OPENDRAIN_MODE     SFRS=0;P0M1|=0x10;P0M2|=0x10
+#define    P05_OPENDRAIN_MODE     SFRS=0;P0M1|=0x20;P0M2|=0x20
+#define    P06_OPENDRAIN_MODE     SFRS=0;P0M1|=0x40;P0M2|=0x40
+#define    P07_OPENDRAIN_MODE     SFRS=0;P0M1|=0x80;P0M2|=0x80
+#define    P10_OPENDRAIN_MODE     SFRS=0;P1M1|=0x01;P1M2|=0x01
+#define    P11_OPENDRAIN_MODE     SFRS=0;P1M1|=0x02;P1M2|=0x02
+#define    P12_OPENDRAIN_MODE     SFRS=0;P1M1|=0x04;P1M2|=0x04
+#define    P13_OPENDRAIN_MODE     SFRS=0;P1M1|=0x08;P1M2|=0x08
+#define    P14_OPENDRAIN_MODE     SFRS=0;P1M1|=0x10;P1M2|=0x10
+#define    P15_OPENDRAIN_MODE     SFRS=0;P1M1|=0x20;P1M2|=0x20
+#define    P16_OPENDRAIN_MODE     SFRS=0;P1M1|=0x40;P1M2|=0x40
+#define    P17_OPENDRAIN_MODE     SFRS=0;P1M1|=0x80;P1M2|=0x80
+#define    P20_OPENDRAIN_MODE     SFRS=2;P2M1|=0x01;P2M2|=0x01
+#define    P21_OPENDRAIN_MODE     SFRS=2;P2M1|=0x02;P2M2|=0x02
+#define    P22_OPENDRAIN_MODE     SFRS=2;P2M1|=0x04;P2M2|=0x04
+#define    P23_OPENDRAIN_MODE     SFRS=2;P2M1|=0x08;P2M2|=0x08
+#define    P24_OPENDRAIN_MODE     SFRS=2;P2M1|=0x10;P2M2|=0x10
+#define    P25_OPENDRAIN_MODE     SFRS=2;P2M1|=0x20;P2M2|=0x20
+#define    P30_OPENDRAIN_MODE     SFRS=0;P3M1|=0x01;P3M2|=0x01
+#define    P31_OPENDRAIN_MODE     SFRS=0;P3M1|=0x02;P3M2|=0x02
+#define    P32_OPENDRAIN_MODE     SFRS=0;P3M1|=0x04;P3M2|=0x04
+#define    P33_OPENDRAIN_MODE     SFRS=0;P3M1|=0x08;P3M2|=0x08
+#define    P34_OPENDRAIN_MODE     SFRS=0;P3M1|=0x10;P3M2|=0x10
+#define    P35_OPENDRAIN_MODE     SFRS=0;P3M1|=0x20;P3M2|=0x20
+#define    P36_OPENDRAIN_MODE     SFRS=0;P3M1|=0x40;P3M2|=0x40
+#define    P37_OPENDRAIN_MODE     SFRS=0;P3M1|=0x80;P3M2|=0x80
+#define    ALL_GPIO_OPENDRAIN_MODE         SFRS=0;P0M1=0xFF;P0M2=0xFF;P1M1=0xFF;P1M2=0xFF;\
+                                           SFRS=2;P2M1=0xFF;P2M2=0xFF;SFRS=0;P3M1=0xFF;P3M2=0xFF
+/*****************************************************************************************/
+/* For GPIO internal pull up/pull down setting                                           */
+/*****************************************************************************************/
+/*------------------- GPIO pull up enable -------------------*/  
+#define    P00_PULLUP_ENABLE       set_P0UP_0
+#define    P01_PULLUP_ENABLE       set_P0UP_1
+#define    P02_PULLUP_ENABLE       set_P0UP_2
+#define    P03_PULLUP_ENABLE       set_P0UP_3
+#define    P04_PULLUP_ENABLE       set_P0UP_4
+#define    P05_PULLUP_ENABLE       set_P0UP_5
+#define    P06_PULLUP_ENABLE       set_P0UP_6
+#define    P07_PULLUP_ENABLE       set_P0UP_7
+#define    P10_PULLUP_ENABLE       set_P1UP_0
+#define    P11_PULLUP_ENABLE       set_P1UP_1
+#define    P12_PULLUP_ENABLE       set_P1UP_2
+#define    P13_PULLUP_ENABLE       set_P1UP_3
+#define    P14_PULLUP_ENABLE       set_P1UP_4
+#define    P15_PULLUP_ENABLE       set_P1UP_5
+#define    P16_PULLUP_ENABLE       set_P1UP_6
+#define    P17_PULLUP_ENABLE       set_P1UP_7
+#define    P20_PULLUP_ENABLE       set_P2UP_0
+#define    P21_PULLUP_ENABLE       set_P2UP_1
+#define    P22_PULLUP_ENABLE       set_P2UP_2
+#define    P23_PULLUP_ENABLE       set_P2UP_3
+#define    P24_PULLUP_ENABLE       set_P2UP_4
+#define    P25_PULLUP_ENABLE       set_P2UP_5
+#define    P30_PULLUP_ENABLE       set_P3UP_0
+#define    P31_PULLUP_ENABLE       set_P3UP_1
+#define    P32_PULLUP_ENABLE       set_P3UP_2
+#define    P33_PULLUP_ENABLE       set_P3UP_3
+#define    P34_PULLUP_ENABLE       set_P3UP_4
+#define    P35_PULLUP_ENABLE       set_P3UP_5
+#define    P36_PULLUP_ENABLE       set_P3UP_6
+#define    P37_PULLUP_ENABLE       set_P3UP_7
+/*------------------- GPIO pull up disable -------------------*/                              
+#define    P00_PULLUP_DISABLE      clr_P0UP_0
+#define    P01_PULLUP_DISABLE      clr_P0UP_1
+#define    P02_PULLUP_DISABLE      clr_P0UP_2
+#define    P03_PULLUP_DISABLE      clr_P0UP_3
+#define    P04_PULLUP_DISABLE      clr_P0UP_4
+#define    P05_PULLUP_DISABLE      clr_P0UP_5
+#define    P06_PULLUP_DISABLE      clr_P0UP_6
+#define    P07_PULLUP_DISABLE      clr_P0UP_7
+#define    P10_PULLUP_DISABLE      clr_P1UP_0
+#define    P11_PULLUP_DISABLE      clr_P1UP_1
+#define    P12_PULLUP_DISABLE      clr_P1UP_2
+#define    P13_PULLUP_DISABLE      clr_P1UP_3
+#define    P14_PULLUP_DISABLE      clr_P1UP_4
+#define    P15_PULLUP_DISABLE      clr_P1UP_5
+#define    P16_PULLUP_DISABLE      clr_P1UP_6
+#define    P17_PULLUP_DISABLE      clr_P1UP_7
+#define    P20_PULLUP_DISABLE      clr_P2UP_0
+#define    P21_PULLUP_DISABLE      clr_P2UP_1
+#define    P22_PULLUP_DISABLE      clr_P2UP_2
+#define    P23_PULLUP_DISABLE      clr_P2UP_3
+#define    P24_PULLUP_DISABLE      clr_P2UP_4
+#define    P25_PULLUP_DISABLE      clr_P2UP_5
+#define    P30_PULLUP_DISABLE      clr_P3UP_0
+#define    P31_PULLUP_DISABLE      clr_P3UP_1
+#define    P32_PULLUP_DISABLE      clr_P3UP_2
+#define    P33_PULLUP_DISABLE      clr_P3UP_3
+#define    P34_PULLUP_DISABLE      clr_P3UP_4
+#define    P35_PULLUP_DISABLE      clr_P3UP_5
+#define    P36_PULLUP_DISABLE      clr_P3UP_6
+#define    P37_PULLUP_DISABLE      clr_P3UP_7
+/*------------------- GPIO pull down enable -------------------*/  
+#define    P00_PULLDOWN_ENABLE     set_P0DW_0
+#define    P01_PULLDOWN_ENABLE     set_P0DW_1
+#define    P02_PULLDOWN_ENABLE     set_P0DW_2
+#define    P03_PULLDOWN_ENABLE     set_P0DW_3
+#define    P04_PULLDOWN_ENABLE     set_P0DW_4
+#define    P05_PULLDOWN_ENABLE     set_P0DW_5
+#define    P06_PULLDOWN_ENABLE     set_P0DW_6
+#define    P07_PULLDOWN_ENABLE     set_P0DW_7
+#define    P10_PULLDOWN_ENABLE     set_P1DW_0
+#define    P11_PULLDOWN_ENABLE     set_P1DW_1
+#define    P12_PULLDOWN_ENABLE     set_P1DW_2
+#define    P13_PULLDOWN_ENABLE     set_P1DW_3
+#define    P14_PULLDOWN_ENABLE     set_P1DW_4
+#define    P15_PULLDOWN_ENABLE     set_P1DW_5
+#define    P16_PULLDOWN_ENABLE     set_P1DW_6
+#define    P17_PULLDOWN_ENABLE     set_P1DW_7
+#define    P20_PULLDOWN_ENABLE     set_P2DW_0
+#define    P21_PULLDOWN_ENABLE     set_P2DW_1
+#define    P22_PULLDOWN_ENABLE     set_P2DW_2
+#define    P23_PULLDOWN_ENABLE     set_P2DW_3
+#define    P24_PULLDOWN_ENABLE     set_P2DW_4
+#define    P25_PULLDOWN_ENABLE     set_P2DW_5
+#define    P30_PULLDOWN_ENABLE     set_P3DW_0
+#define    P31_PULLDOWN_ENABLE     set_P3DW_1
+#define    P32_PULLDOWN_ENABLE     set_P3DW_2
+#define    P33_PULLDOWN_ENABLE     set_P3DW_3
+#define    P34_PULLDOWN_ENABLE     set_P3DW_4
+#define    P35_PULLDOWN_ENABLE     set_P3DW_5
+#define    P36_PULLDOWN_ENABLE     set_P3DW_6
+#define    P37_PULLDOWN_ENABLE     set_P3DW_7
+/*------------------ GPIO pull down disable -------------------*/
+#define    P00_PULLDOWN_DISABLE    clr_P0DW_0
+#define    P01_PULLDOWN_DISABLE    clr_P0DW_1
+#define    P02_PULLDOWN_DISABLE    clr_P0DW_2
+#define    P03_PULLDOWN_DISABLE    clr_P0DW_3
+#define    P04_PULLDOWN_DISABLE    clr_P0DW_4
+#define    P05_PULLDOWN_DISABLE    clr_P0DW_5
+#define    P06_PULLDOWN_DISABLE    clr_P0DW_6
+#define    P07_PULLDOWN_DISABLE    clr_P0DW_7
+#define    P10_PULLDOWN_DISABLE    clr_P1DW_0
+#define    P11_PULLDOWN_DISABLE    clr_P1DW_1
+#define    P12_PULLDOWN_DISABLE    clr_P1DW_2
+#define    P13_PULLDOWN_DISABLE    clr_P1DW_3
+#define    P14_PULLDOWN_DISABLE    clr_P1DW_4
+#define    P15_PULLDOWN_DISABLE    clr_P1DW_5
+#define    P16_PULLDOWN_DISABLE    clr_P1DW_6
+#define    P17_PULLDOWN_DISABLE    clr_P1DW_7
+#define    P20_PULLDOWN_DISABLE    clr_P2DW_0
+#define    P21_PULLDOWN_DISABLE    clr_P2DW_1
+#define    P22_PULLDOWN_DISABLE    clr_P2DW_2
+#define    P23_PULLDOWN_DISABLE    clr_P2DW_3
+#define    P24_PULLDOWN_DISABLE    clr_P2DW_4
+#define    P25_PULLDOWN_DISABLE    clr_P2DW_5
+#define    P30_PULLDOWN_DISABLE    clr_P3DW_0
+#define    P31_PULLDOWN_DISABLE    clr_P3DW_1
+#define    P32_PULLDOWN_DISABLE    clr_P3DW_2
+#define    P33_PULLDOWN_DISABLE    clr_P3DW_3
+#define    P34_PULLDOWN_DISABLE    clr_P3DW_4
+#define    P35_PULLDOWN_DISABLE    clr_P3DW_5
+#define    P36_PULLDOWN_DISABLE    clr_P3DW_6
+#define    P37_PULLDOWN_DISABLE    clr_P3DW_7
+
+/*****************************************************************************************
+*  GPIO TTL/Schmitt Trig Type Define
+*****************************************************************************************/
+//------------------- Enable GPIO Schmitt Trigger Mode  -------------------
+#define    P00_ST_ENABLE          SFRS=1;P0S|=0x01
+#define    P01_ST_ENABLE          SFRS=1;P0S|=0x02
+#define    P02_ST_ENABLE          SFRS=1;P0S|=0x04
+#define    P03_ST_ENABLE          SFRS=1;P0S|=0x08
+#define    P04_ST_ENABLE          SFRS=1;P0S|=0x10
+#define    P05_ST_ENABLE          SFRS=1;P0S|=0x20
+#define    P06_ST_ENABLE          SFRS=1;P0S|=0x40
+#define    P07_ST_ENABLE          SFRS=1;P0S|=0x80
+#define    P10_ST_ENABLE          SFRS=1;P1S|=0x01
+#define    P11_ST_ENABLE          SFRS=1;P1S|=0x02
+#define    P12_ST_ENABLE          SFRS=1;P1S|=0x04
+#define    P13_ST_ENABLE          SFRS=1;P1S|=0x08
+#define    P14_ST_ENABLE          SFRS=1;P1S|=0x10
+#define    P15_ST_ENABLE          SFRS=1;P1S|=0x20
+#define    P16_ST_ENABLE          SFRS=1;P1S|=0x40
+#define    P17_ST_ENABLE          SFRS=1;P1S|=0x80
+#define    P20_ST_ENABLE          SFRS=1;P2S|=0x01
+#define    P21_ST_ENABLE          SFRS=1;P2S|=0x02
+#define    P22_ST_ENABLE          SFRS=1;P2S|=0x04
+#define    P23_ST_ENABLE          SFRS=1;P2S|=0x08
+#define    P24_ST_ENABLE          SFRS=1;P2S|=0x10
+#define    P25_ST_ENABLE          SFRS=1;P2S|=0x20
+#define    P26_ST_ENABLE          SFRS=1;P2S|=0x40
+#define    P27_ST_ENABLE          SFRS=1;P2S|=0x80
+#define    P30_ST_ENABLE          SFRS=1;P3S|=0x01
+#define    P31_ST_ENABLE          SFRS=1;P3S|=0x02
+#define    P32_ST_ENABLE          SFRS=1;P3S|=0x04
+#define    P33_ST_ENABLE          SFRS=1;P3S|=0x08
+#define    P34_ST_ENABLE          SFRS=1;P3S|=0x10
+#define    P35_ST_ENABLE          SFRS=1;P3S|=0x20
+#define    P36_ST_ENABLE          SFRS=1;P3S|=0x40
+#define    P37_ST_ENABLE          SFRS=1;P3S|=0x80
+#define    P40_ST_ENABLE          SFRS=1;P4S|=0x01
+#define    P41_ST_ENABLE          SFRS=1;P4S|=0x02
+#define    P42_ST_ENABLE          SFRS=1;P4S|=0x04
+#define    P43_ST_ENABLE          SFRS=1;P4S|=0x08
+#define    P44_ST_ENABLE          SFRS=1;P4S|=0x10
+#define    P45_ST_ENABLE          SFRS=1;P4S|=0x20
+#define    P46_ST_ENABLE          SFRS=1;P4S|=0x40
+#define    P47_ST_ENABLE          SFRS=1;P4S|=0x80
+#define    P50_ST_ENABLE          SFRS=1;P5S|=0x01
+#define    P51_ST_ENABLE          SFRS=1;P5S|=0x02
+#define    P52_ST_ENABLE          SFRS=1;P5S|=0x04
+#define    P53_ST_ENABLE          SFRS=1;P5S|=0x08
+#define    P54_ST_ENABLE          SFRS=1;P5S|=0x10
+#define    P55_ST_ENABLE          SFRS=1;P5S|=0x20
+#define    P56_ST_ENABLE          SFRS=1;P5S|=0x40
+#define    P57_ST_ENABLE          SFRS=1;P5S|=0x80
+#define    P60_ST_ENABLE          SFRS=2;P6S|=0x01
+#define    P61_ST_ENABLE          SFRS=2;P6S|=0x02
+#define    P62_ST_ENABLE          SFRS=2;P6S|=0x04
+#define    P63_ST_ENABLE          SFRS=2;P6S|=0x08
+#define    P64_ST_ENABLE          SFRS=2;P6S|=0x10
+#define    P65_ST_ENABLE          SFRS=2;P6S|=0x20
+#define    P66_ST_ENABLE          SFRS=2;P6S|=0x40
+#define    P67_ST_ENABLE          SFRS=2;P6S|=0x80
+
+//------------------- Enable GPIO TTL Mode  -------------------
+#define    P00_TTL_ENABLE          SFRS=1;P0S&=0xFE
+#define    P01_TTL_ENABLE          SFRS=1;P0S&=0xFD
+#define    P02_TTL_ENABLE          SFRS=1;P0S&=0xFB
+#define    P03_TTL_ENABLE          SFRS=1;P0S&=0xF7
+#define    P04_TTL_ENABLE          SFRS=1;P0S&=0xEF
+#define    P05_TTL_ENABLE          SFRS=1;P0S&=0xDF
+#define    P06_TTL_ENABLE          SFRS=1;P0S&=0xBF
+#define    P07_TTL_ENABLE          SFRS=1;P0S&=0x7F
+#define    P10_TTL_ENABLE          SFRS=1;P1S&=0xFE
+#define    P11_TTL_ENABLE          SFRS=1;P1S&=0xFD
+#define    P12_TTL_ENABLE          SFRS=1;P1S&=0xFB
+#define    P13_TTL_ENABLE          SFRS=1;P1S&=0xF7
+#define    P14_TTL_ENABLE          SFRS=1;P1S&=0xEF
+#define    P15_TTL_ENABLE          SFRS=1;P1S&=0xDF
+#define    P16_TTL_ENABLE          SFRS=1;P1S&=0xBF
+#define    P17_TTL_ENABLE          SFRS=1;P1S&=0x7F
+#define    P20_TTL_ENABLE          SFRS=1;P2S&=0xFE
+#define    P21_TTL_ENABLE          SFRS=1;P2S&=0xFD
+#define    P22_TTL_ENABLE          SFRS=1;P2S&=0xFB
+#define    P23_TTL_ENABLE          SFRS=1;P2S&=0xF7
+#define    P24_TTL_ENABLE          SFRS=1;P2S&=0xEF
+#define    P25_TTL_ENABLE          SFRS=1;P2S&=0xDF
+#define    P26_TTL_ENABLE          SFRS=1;P2S&=0xBF
+#define    P27_TTL_ENABLE          SFRS=1;P2S&=0x7F
+#define    P30_TTL_ENABLE          SFRS=1;P3S&=0xFE
+#define    P31_TTL_ENABLE          SFRS=1;P3S&=0xFD
+#define    P32_TTL_ENABLE          SFRS=1;P3S&=0xFB
+#define    P33_TTL_ENABLE          SFRS=1;P3S&=0xF7
+#define    P34_TTL_ENABLE          SFRS=1;P3S&=0xEF
+#define    P35_TTL_ENABLE          SFRS=1;P3S&=0xDF
+#define    P36_TTL_ENABLE          SFRS=1;P3S&=0xBF
+#define    P37_TTL_ENABLE          SFRS=1;P3S&=0x7F
+#define    P40_TTL_ENABLE          SFRS=1;P4S&=0xFE
+#define    P41_TTL_ENABLE          SFRS=1;P4S&=0xFD
+#define    P42_TTL_ENABLE          SFRS=1;P4S&=0xFB
+#define    P43_TTL_ENABLE          SFRS=1;P4S&=0xF7
+#define    P44_TTL_ENABLE          SFRS=1;P4S&=0xEF
+#define    P45_TTL_ENABLE          SFRS=1;P4S&=0xDF
+#define    P46_TTL_ENABLE          SFRS=1;P4S&=0xBF
+#define    P47_TTL_ENABLE          SFRS=1;P4S&=0x7F
+#define    P50_TTL_ENABLE          SFRS=1;P5S&=0xFE
+#define    P51_TTL_ENABLE          SFRS=1;P5S&=0xFD
+#define    P52_TTL_ENABLE          SFRS=1;P5S&=0xFB
+#define    P53_TTL_ENABLE          SFRS=1;P5S&=0xF7
+#define    P54_TTL_ENABLE          SFRS=1;P5S&=0xEF
+#define    P55_TTL_ENABLE          SFRS=1;P5S&=0xDF
+#define    P56_TTL_ENABLE          SFRS=1;P5S&=0xBF
+#define    P57_TTL_ENABLE          SFRS=1;P5S&=0x7F
+#define    P60_TTL_ENABLE          SFRS=2;P6S&=0xFE
+#define    P61_TTL_ENABLE          SFRS=2;P6S&=0xFD
+#define    P62_TTL_ENABLE          SFRS=2;P6S&=0xFB
+#define    P63_TTL_ENABLE          SFRS=2;P6S&=0xF7
+#define    P64_TTL_ENABLE          SFRS=2;P6S&=0xEF
+#define    P65_TTL_ENABLE          SFRS=2;P6S&=0xDF
+#define    P66_TTL_ENABLE          SFRS=2;P6S&=0xBF
+#define    P67_TTL_ENABLE          SFRS=2;P6S&=0x7F
+
+/***** SPI multiple function pin define */
+#define    MFP_P15_SPI0_SS         SFRS=2;AUXR7&=0xE7
+#define    MFP_P35_SPI0_SS         SFRS=2;AUXR7&=0xE7;AUXR7|=0x10
+#define    MFP_P00_SPI0_MOSI       SFRS=2;AUXR7&=CLR_BIT2
+#define    MFP_P30_SPI0_MOSI       SFRS=2;AUXR7|=SET_BIT2
+#define    MFP_P01_SPI0_MISO       SFRS=2;AUXR7&=CLR_BIT1
+#define    MFP_P25_SPI0_MISO       SFRS=2;AUXR7|=SET_BIT1
+#define    MFP_P10_SPI0_CLK        SFRS=2;AUXR7&=CLR_BIT0
+#define    MFP_P17_SPI0_CLK        SFRS=2;AUXR7|=SET_BIT0

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_iar.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_iar.h
@@ -1,0 +1,669 @@
+/*--------------------------------------------------------------------------*/
+/* ms51_32k_iar.h                                                           */
+/*                                                                          */
+/* Header file for Nuvoton MS51 IAR format                                  */
+/* -------------------------------------------------------------------------*/
+
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "sfr_macro_ms51_32k.h"
+
+/*  BYTE Registers  */
+/*  SFR page 0      */
+__sfr __no_init volatile union
+{
+  unsigned char P0; /* Port 0 */
+  struct /* Port 0 */
+  { 
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P0_bit;
+} @ 0x80;
+__sfr __no_init volatile unsigned char  SP          @ 0x81;
+__sfr __no_init volatile unsigned char  DPL         @ 0x82;
+__sfr __no_init volatile unsigned char  DPH         @ 0x83;
+__sfr __no_init volatile unsigned char  RCTRIM0     @ 0x84;
+__sfr __no_init volatile unsigned char  RCTRIM1     @ 0x85;  
+__sfr __no_init volatile unsigned char  RWKL        @ 0x86;
+__sfr __no_init volatile unsigned char  PCON        @ 0x87;
+
+__sfr __no_init volatile union
+{
+  unsigned char TCON; /* Timer Control */
+  struct /* Timer Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } TCON_bit;
+} @ 0x88;                            
+__sfr __no_init volatile unsigned char  TMOD        @ 0x89;
+__sfr __no_init volatile unsigned char  TL0         @ 0x8A;
+__sfr __no_init volatile unsigned char  TL1         @ 0x8B;
+__sfr __no_init volatile unsigned char  TH0         @ 0x8C;
+__sfr __no_init volatile unsigned char  TH1         @ 0x8D;
+__sfr __no_init volatile unsigned char  CKCON       @ 0x8E;
+__sfr __no_init volatile unsigned char  WKCON       @ 0x8F;
+                                              
+
+__sfr __no_init volatile union
+{
+  unsigned char P1; /* Port 1 */
+  struct /* Port 1 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } P1_bit;
+} @ 0x90;
+__sfr __no_init volatile unsigned char SFRS        @ 0x91; 
+__sfr __no_init volatile unsigned char CAPCON0     @ 0x92;
+__sfr __no_init volatile unsigned char CAPCON1     @ 0x93;
+__sfr __no_init volatile unsigned char CAPCON2     @ 0x94;
+__sfr __no_init volatile unsigned char CKDIV       @ 0x95;
+__sfr __no_init volatile unsigned char CKSWT       @ 0x96; //TA Protection
+__sfr __no_init volatile unsigned char CKEN        @ 0x97; //TA Protection
+
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON; /* Serial Control */
+  struct /* Serial Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_bit;
+} @ 0x98;
+__sfr __no_init volatile unsigned char SBUF        @ 0x99;
+__sfr __no_init volatile unsigned char SBUF_1      @ 0x9A;
+__sfr __no_init volatile unsigned char EIE         @ 0x9B;
+__sfr __no_init volatile unsigned char EIE1        @ 0x9C;
+__sfr __no_init volatile unsigned char CHPCON      @ 0x9F; //TA Protection
+   
+__sfr __no_init volatile union
+{
+  unsigned char P2; /* Port 2 */
+  struct /* Port 2 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P2_bit;
+} @ 0xA0;
+__sfr __no_init volatile unsigned char AUXR1       @ 0xA2;
+__sfr __no_init volatile unsigned char BODCON0     @ 0xA3; //TA Protection
+__sfr __no_init volatile unsigned char IAPTRG      @ 0xA4; //TA Protection
+__sfr __no_init volatile unsigned char IAPUEN      @ 0xA5;  //TA Protection
+__sfr __no_init volatile unsigned char IAPAL       @ 0xA6;
+__sfr __no_init volatile unsigned char IAPAH       @ 0xA7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IE; /* Interrupt Enable */
+  struct /* Interrupt Enable */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IE_bit;
+} @ 0xA8;
+__sfr __no_init volatile unsigned char SADDR       @ 0xA9;
+__sfr __no_init volatile unsigned char WDCON       @ 0xAA; //TA Protection
+__sfr __no_init volatile unsigned char BODCON1     @ 0xAB; //TA Protection
+__sfr __no_init volatile unsigned char P3M1        @ 0xAC;
+__sfr __no_init volatile unsigned char P3M2        @ 0xAD;
+__sfr __no_init volatile unsigned char IAPFD       @ 0xAE;
+__sfr __no_init volatile unsigned char IAPCN       @ 0xAF;
+
+__sfr __no_init volatile union
+{
+  unsigned char P3; /* Port 3 */
+  struct /* Port 3 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P3_bit;
+} @ 0xB0;
+__sfr __no_init volatile unsigned char P0M1       @ 0xB1;
+__sfr __no_init volatile unsigned char P0M2       @ 0xB2;
+__sfr __no_init volatile unsigned char P1M1       @ 0xB3;
+__sfr __no_init volatile unsigned char P1M2       @ 0xB4;
+__sfr __no_init volatile unsigned char TOE        @ 0xB5; 
+__sfr __no_init volatile unsigned char IPH        @ 0xB7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IP; /* IP  */
+  struct /* IP  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IP_bit;
+} @ 0xB8;
+__sfr __no_init volatile unsigned char SADEN       @ 0xB9;
+__sfr __no_init volatile unsigned char SADEN_1     @ 0xBA;
+__sfr __no_init volatile unsigned char SADDR_1     @ 0xBB;
+__sfr __no_init volatile unsigned char I2DAT       @ 0xBC;
+__sfr __no_init volatile unsigned char I2STAT      @ 0xBD;
+__sfr __no_init volatile unsigned char I2CLK       @ 0xBE;
+__sfr __no_init volatile unsigned char I2TOC       @ 0xBF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char I2CON; /* I2CON  */
+  struct /* I2CON  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } I2CON_bit;
+} @ 0xC0;
+__sfr __no_init volatile unsigned char I2ADDR      @ 0xC1;
+__sfr __no_init volatile unsigned char ADCRL       @ 0xC2;
+__sfr __no_init volatile unsigned char ADCRH       @ 0xC3;
+__sfr __no_init volatile unsigned char T3CON       @ 0xC4;
+__sfr __no_init volatile unsigned char RL3         @ 0xC5;
+__sfr __no_init volatile unsigned char RH3         @ 0xC6;
+__sfr __no_init volatile unsigned char TA          @ 0xC7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char T2CON; /* Timer 2 Control */
+  struct /* Timer 2 Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } T2CON_bit;
+} @ 0xC8;
+__sfr __no_init volatile unsigned char T2MOD       @ 0xC9;
+__sfr __no_init volatile unsigned char RCMP2L      @ 0xCA;
+__sfr __no_init volatile unsigned char RCMP2H      @ 0xCB;
+__sfr __no_init volatile unsigned char TL2         @ 0xCC; 
+__sfr __no_init volatile unsigned char TH2         @ 0xCD;
+__sfr __no_init volatile unsigned char ADCMPL      @ 0xCE;
+__sfr __no_init volatile unsigned char ADCMPH      @ 0xCF;
+
+__sfr __no_init volatile union
+{
+  unsigned char PSW; /* Program Status Word */
+  struct /* Program Status Word */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PSW_bit;
+} @ 0xD0;
+__sfr __no_init volatile unsigned char PWM0PH         @ 0xD1;
+__sfr __no_init volatile unsigned char PWM0C0H        @ 0xD2;
+__sfr __no_init volatile unsigned char PWM0C1H        @ 0xD3;
+__sfr __no_init volatile unsigned char PWM0C2H        @ 0xD4;
+__sfr __no_init volatile unsigned char PWM0C3H        @ 0xD5;
+__sfr __no_init volatile unsigned char PNP            @ 0xD6;
+__sfr __no_init volatile unsigned char PWM0FBD        @ 0xD7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char PWM0CON0; /* PWMCON0  */
+  struct /* PWMCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PWMCON0_bit;
+} @ 0xD8;
+__sfr __no_init volatile unsigned char PWM0PL        @ 0xD9;
+__sfr __no_init volatile unsigned char PWM0C0L       @ 0xDA;
+__sfr __no_init volatile unsigned char PWM0C1L       @ 0xDB;
+__sfr __no_init volatile unsigned char PWM0C2L       @ 0xDC;
+__sfr __no_init volatile unsigned char PWM0C3L       @ 0xDD;
+__sfr __no_init volatile unsigned char PIOCON0       @ 0xDE;
+__sfr __no_init volatile unsigned char PWM0CON1      @ 0xDF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ACC; /* Accumulator */
+  struct /* Accumulator */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } ACC_bit;
+} @ 0xE0;
+__sfr __no_init volatile unsigned char ADCCON1     @ 0xE1;
+__sfr __no_init volatile unsigned char ADCCON2     @ 0xE2;
+__sfr __no_init volatile unsigned char ADCDLY      @ 0xE3;
+__sfr __no_init volatile unsigned char C0L         @ 0xE4;
+__sfr __no_init volatile unsigned char C0H         @ 0xE5;
+__sfr __no_init volatile unsigned char C1L         @ 0xE6;
+__sfr __no_init volatile unsigned char C1H         @ 0xE7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ADCCON0; /* ADCCON0  */
+  struct /* ADCCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } ADCCON0_bit;
+} @ 0xE8;
+__sfr __no_init volatile unsigned char PICON       @ 0xE9;
+__sfr __no_init volatile unsigned char PINEN       @ 0xEA;
+__sfr __no_init volatile unsigned char PIPEN       @ 0xEB;
+__sfr __no_init volatile unsigned char PIF         @ 0xEC;
+__sfr __no_init volatile unsigned char C2L         @ 0xED;
+__sfr __no_init volatile unsigned char C2H         @ 0xEE;
+__sfr __no_init volatile unsigned char EIP         @ 0xEF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char B; /* B Register */
+  struct /* B Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } B_bit;
+} @ 0xF0;
+__sfr __no_init volatile unsigned char CAPCON3       @ 0xF1;
+__sfr __no_init volatile unsigned char CAPCON4       @ 0xF2;
+__sfr __no_init volatile unsigned char SPCR          @ 0xF3;
+__sfr __no_init volatile unsigned char SPSR          @ 0xF4;
+__sfr __no_init volatile unsigned char SPDR          @ 0xF5;
+__sfr __no_init volatile unsigned char AINDIDS0      @ 0xF6;
+__sfr __no_init volatile unsigned char EIPH          @ 0xF7;
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON_1 ; /* SCON_1  Register */
+  struct /* SCON_1  Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_1_bit;
+} @ 0xF8;
+__sfr __no_init volatile unsigned char PWM0DTEN       @ 0xF9; //TA Protection
+__sfr __no_init volatile unsigned char PWM0DTCNT      @ 0xFA; //TA Protection
+__sfr __no_init volatile unsigned char PWM0MEN        @ 0xFB;
+__sfr __no_init volatile unsigned char PWM0MD         @ 0xFC;
+__sfr __no_init volatile unsigned char PORDIS         @ 0xFD;
+__sfr __no_init volatile unsigned char EIP1           @ 0xFE;
+__sfr __no_init volatile unsigned char EIPH1          @ 0xFF;
+   
+/*  SFR page 1      */
+__sfr __no_init volatile unsigned char P3S            @ 0xAC; 
+__sfr __no_init volatile unsigned char P3SR           @ 0xAD; 
+                                                        
+__sfr __no_init volatile unsigned char P0S            @ 0xB1; 
+__sfr __no_init volatile unsigned char P0SR           @ 0xB2; 
+__sfr __no_init volatile unsigned char P1S            @ 0xB3; 
+__sfr __no_init volatile unsigned char P1SR           @ 0xB4; 
+__sfr __no_init volatile unsigned char PWM0INTC       @ 0xB7; 
+                                                        
+__sfr __no_init volatile unsigned char PWM0C4H        @ 0xC4; 
+__sfr __no_init volatile unsigned char PWM0C5H        @ 0xC5; 
+__sfr __no_init volatile unsigned char PIOCON1        @ 0xC6; 
+                                                        
+__sfr __no_init volatile unsigned char PWM0C4L        @ 0xCC; 
+__sfr __no_init volatile unsigned char PWM0C5L        @ 0xCD; 
+                                                        
+__sfr __no_init volatile unsigned char SPCR2          @ 0xF3; 
+                                      
+__sfr __no_init volatile unsigned char LVRDIS         @ 0xFF; 
+                                      
+/* MS51_32K SFR BYTE page 2  */       
+__sfr __no_init volatile unsigned char ADCBAL         @ 0x84; 
+__sfr __no_init volatile unsigned char ADCBAH         @ 0x85; 
+__sfr __no_init volatile unsigned char ADCCON3        @ 0x86; 
+                                      
+__sfr __no_init volatile unsigned char P2M1           @ 0x89; 
+__sfr __no_init volatile unsigned char P2M2           @ 0x8A; 
+__sfr __no_init volatile unsigned char P2SR           @ 0x8B; 
+__sfr __no_init volatile unsigned char P2S            @ 0x8C; 
+__sfr __no_init volatile unsigned char ADCSN          @ 0x8D; 
+__sfr __no_init volatile unsigned char ADCCN          @ 0x8E; 
+__sfr __no_init volatile unsigned char ADCSR          @ 0x8F; 
+                                      
+__sfr __no_init volatile unsigned char P0UP           @ 0x92; 
+__sfr __no_init volatile unsigned char P1UP           @ 0x93; 
+__sfr __no_init volatile unsigned char P2UP           @ 0x94; 
+__sfr __no_init volatile unsigned char P3UP           @ 0x95; 
+__sfr __no_init volatile unsigned char RWKH           @ 0x97; 
+                                      
+__sfr __no_init volatile unsigned char AINDIDS1       @ 0x99; 
+__sfr __no_init volatile unsigned char P0DW           @ 0x9A; 
+__sfr __no_init volatile unsigned char P1DW           @ 0x9B; 
+__sfr __no_init volatile unsigned char P2DW           @ 0x9C; 
+__sfr __no_init volatile unsigned char P3DW           @ 0x9D; 
+                                      
+__sfr __no_init volatile unsigned char AUXR2          @ 0xA1; 
+__sfr __no_init volatile unsigned char AUXR3          @ 0xA2; 
+__sfr __no_init volatile unsigned char AUXR4          @ 0xA3; 
+__sfr __no_init volatile unsigned char AUXR5          @ 0xA4; 
+__sfr __no_init volatile unsigned char AUXR6          @ 0xA5; 
+__sfr __no_init volatile unsigned char AUXR7          @ 0xA6; 
+__sfr __no_init volatile unsigned char AUXR8          @ 0xA7; 
+                                      
+__sfr __no_init volatile unsigned char PWM1PH         @ 0xA9; 
+__sfr __no_init volatile unsigned char PWM1C0H        @ 0xAA; 
+__sfr __no_init volatile unsigned char PWM1C1H        @ 0xAB; 
+__sfr __no_init volatile unsigned char PWM1MD         @ 0xAC; 
+__sfr __no_init volatile unsigned char PWM1MEN        @ 0xAD; 
+                                      
+__sfr __no_init volatile unsigned char PWM1PL         @ 0xB1; 
+__sfr __no_init volatile unsigned char PWM1C0L        @ 0xB2; 
+__sfr __no_init volatile unsigned char PWM1C1L        @ 0xB3; 
+__sfr __no_init volatile unsigned char PWM1CON0       @ 0xB4; 
+__sfr __no_init volatile unsigned char PWM1CON1       @ 0xB5; 
+__sfr __no_init volatile unsigned char PWM1INTC       @ 0xB6; 
+__sfr __no_init volatile unsigned char PIOCON2        @ 0xB7; 
+                                      
+__sfr __no_init volatile unsigned char PWM2PH         @ 0xB9; 
+__sfr __no_init volatile unsigned char PWM2C0H        @ 0xBA; 
+__sfr __no_init volatile unsigned char PWM2C1H        @ 0xBB; 
+__sfr __no_init volatile unsigned char PWM2MD         @ 0xBC; 
+__sfr __no_init volatile unsigned char PWM2MEN        @ 0xBD; 
+                                      
+__sfr __no_init volatile unsigned char PWM2PL         @ 0xC1; 
+__sfr __no_init volatile unsigned char PWM2C0L        @ 0xC2; 
+__sfr __no_init volatile unsigned char PWM2C1L        @ 0xC3; 
+__sfr __no_init volatile unsigned char PWM2CON0       @ 0xC4; 
+__sfr __no_init volatile unsigned char PWM2CON1       @ 0xC5; 
+__sfr __no_init volatile unsigned char PWM2INTC       @ 0xC6; 
+                                      
+__sfr __no_init volatile unsigned char PWM3PH         @ 0xC9; 
+__sfr __no_init volatile unsigned char PWM3C0H        @ 0xCA; 
+__sfr __no_init volatile unsigned char PWM3C1H        @ 0xCB; 
+__sfr __no_init volatile unsigned char PWM3MD         @ 0xCC; 
+__sfr __no_init volatile unsigned char PWM3MEN        @ 0xCD; 
+__sfr __no_init volatile unsigned char EIP2           @ 0xCE; 
+__sfr __no_init volatile unsigned char EIPH2          @ 0xCF; 
+                                      
+__sfr __no_init volatile unsigned char PWM3PL         @ 0xD1; 
+__sfr __no_init volatile unsigned char PWM3C0L        @ 0xD2; 
+__sfr __no_init volatile unsigned char PWM3C1L        @ 0xD3; 
+__sfr __no_init volatile unsigned char PWM3CON0       @ 0xD4; 
+__sfr __no_init volatile unsigned char PWM3CON1       @ 0xD5; 
+__sfr __no_init volatile unsigned char PWM3INTC       @ 0xD6; 
+__sfr __no_init volatile unsigned char XTLCON         @ 0xD7; 
+                                      
+__sfr __no_init volatile unsigned char SC0DR          @ 0xD9; 
+__sfr __no_init volatile unsigned char SC0EGT         @ 0xDA; 
+__sfr __no_init volatile unsigned char SC0ETURD0      @ 0xDB; 
+__sfr __no_init volatile unsigned char SC0ETURD1      @ 0xDC; 
+__sfr __no_init volatile unsigned char SC0IE          @ 0xDD; 
+__sfr __no_init volatile unsigned char SC0IS          @ 0xDE; 
+__sfr __no_init volatile unsigned char SC0TSR         @ 0xDF; 
+                                      
+__sfr __no_init volatile unsigned char SC1DR          @ 0xE1; 
+__sfr __no_init volatile unsigned char SC1EGT         @ 0xE2; 
+__sfr __no_init volatile unsigned char SC1ETURD0      @ 0xE3; 
+__sfr __no_init volatile unsigned char SC1ETURD1      @ 0xE4; 
+__sfr __no_init volatile unsigned char SC1IE          @ 0xE5; 
+__sfr __no_init volatile unsigned char SC1IS          @ 0xE6; 
+__sfr __no_init volatile unsigned char SC1TSR         @ 0xE7; 
+                                      
+__sfr __no_init volatile unsigned char SC2DR          @ 0xE9; 
+__sfr __no_init volatile unsigned char SC2EGT         @ 0xEA; 
+__sfr __no_init volatile unsigned char SC2ETURD0      @ 0xEB; 
+__sfr __no_init volatile unsigned char SC2ETURD1      @ 0xEC; 
+__sfr __no_init volatile unsigned char SC2IE          @ 0xED; 
+__sfr __no_init volatile unsigned char SC2IS          @ 0xEE; 
+__sfr __no_init volatile unsigned char SC2TSR         @ 0xEF; 
+                                      
+__sfr __no_init volatile unsigned char SC0CR0         @ 0xF1; 
+__sfr __no_init volatile unsigned char SC0CR1         @ 0xF2; 
+__sfr __no_init volatile unsigned char SC1CR0         @ 0xF3; 
+__sfr __no_init volatile unsigned char SC1CR1         @ 0xF4; 
+__sfr __no_init volatile unsigned char SC2CR0         @ 0xF5; 
+__sfr __no_init volatile unsigned char SC2CR1         @ 0xF6; 
+__sfr __no_init volatile unsigned char PIPS7          @ 0xF7; 
+                                      
+__sfr __no_init volatile unsigned char PIPS0          @ 0xF9; 
+__sfr __no_init volatile unsigned char PIPS1          @ 0xFA; 
+__sfr __no_init volatile unsigned char PIPS2          @ 0xFB; 
+__sfr __no_init volatile unsigned char PIPS3          @ 0xFC; 
+__sfr __no_init volatile unsigned char PIPS4          @ 0xFD; 
+__sfr __no_init volatile unsigned char PIPS5          @ 0xFE; 
+__sfr __no_init volatile unsigned char PIPS6          @ 0xFF; 
+
+
+
+/*  BIT Registers  */
+/*  P0  */
+#define P07         P0_bit.BIT7
+#define P06         P0_bit.BIT6
+#define P05         P0_bit.BIT5
+#define P04         P0_bit.BIT4
+#define P03         P0_bit.BIT3
+#define P02         P0_bit.BIT2
+#define P01         P0_bit.BIT1
+#define P00         P0_bit.BIT0
+
+/*  TCON  */
+#define TF1         TCON_bit.BIT7
+#define TR1         TCON_bit.BIT6
+#define TF0         TCON_bit.BIT5
+#define TR0         TCON_bit.BIT4
+#define IE1         TCON_bit.BIT3
+#define IT1         TCON_bit.BIT2
+#define IE0         TCON_bit.BIT1
+#define IT0         TCON_bit.BIT0
+                    
+/*  P1  */
+#define P17         P1_bit.BIT7
+#define P16         P1_bit.BIT6
+#define P15         P1_bit.BIT5
+#define P14         P1_bit.BIT4
+#define P13         P1_bit.BIT3
+#define P12         P1_bit.BIT2
+#define P11         P1_bit.BIT1
+#define P10         P1_bit.BIT0
+
+/*  SCON  */
+#define SM0         SCON_bit.BIT7 
+#define FE          SCON_bit.BIT7 
+#define SM1         SCON_bit.BIT6 
+#define SM2         SCON_bit.BIT5 
+#define REN         SCON_bit.BIT4 
+#define TB8         SCON_bit.BIT3 
+#define RB8         SCON_bit.BIT2 
+#define TI          SCON_bit.BIT1 
+#define RI          SCON_bit.BIT0 
+
+/*  P2  */ 
+#define P20	    P2_bit.BIT0
+#define P21	    P2_bit.BIT1
+#define P22	    P2_bit.BIT2
+#define P23	    P2_bit.BIT3
+#define P24	    P2_bit.BIT4
+#define P25	    P2_bit.BIT5
+#define P26	    P2_bit.BIT6
+#define P27	    P2_bit.BIT7
+
+/*  IE  */
+#define EA          IE_bit.BIT7
+#define EADC        IE_bit.BIT6
+#define EBOD        IE_bit.BIT5
+#define ES          IE_bit.BIT4
+#define ET1         IE_bit.BIT3
+#define EX1         IE_bit.BIT2
+#define ET0         IE_bit.BIT1
+#define EX0         IE_bit.BIT0
+
+/*  P3  */  
+#define P30	    P3_bit.BIT0
+#define P31	    P3_bit.BIT1
+#define P32	    P3_bit.BIT2
+#define P33	    P3_bit.BIT3
+#define P34	    P3_bit.BIT4
+#define P35	    P3_bit.BIT5
+#define P36	    P3_bit.BIT6
+#define P37	    P3_bit.BIT7
+/*  IP  */
+#define PADC        IP_bit.BIT6
+#define PBOD        IP_bit.BIT5
+#define PS          IP_bit.BIT4
+#define PT1         IP_bit.BIT3
+#define PX1         IP_bit.BIT2
+#define PT0         IP_bit.BIT1
+#define PX0         IP_bit.BIT0
+
+/*  I2CON  */
+#define I2CEN       I2CON_bit.BIT6
+#define STA         I2CON_bit.BIT5
+#define STO         I2CON_bit.BIT4
+#define SI          I2CON_bit.BIT3
+#define AA          I2CON_bit.BIT2
+#define I2CPX	    I2CON_bit.BIT0
+
+/*  T2CON  */
+#define TF2         T2CON_bit.BIT7
+#define TR2         T2CON_bit.BIT2
+#define CM_RL2      T2CON_bit.BIT0
+
+/*  PSW */
+#define CY          PSW.BIT7
+#define AC          PSW.BIT6
+#define F0          PSW.BIT5
+#define RS1         PSW.BIT4
+#define RS0         PSW.BIT3
+#define OV          PSW.BIT2
+#define P           PSW.BIT0
+
+/*  PWMCON0  */
+#define PWMRUN      PWMCON0_bit.BIT7
+#define LOAD        PWMCON0_bit.BIT6
+#define PWMF        PWMCON0_bit.BIT5
+#define CLRPWM      PWMCON0_bit.BIT4
+
+/*  ADCCON0  */
+#define ADCF        ADCCON0_bit.BIT7
+#define ADCS        ADCCON0_bit.BIT6
+#define ETGSEL1     ADCCON0_bit.BIT5
+#define ETGSEL0     ADCCON0_bit.BIT4
+#define ADCHS3      ADCCON0_bit.BIT3
+#define ADCHS2      ADCCON0_bit.BIT2
+#define ADCHS1      ADCCON0_bit.BIT1
+#define ADCHS0      ADCCON0_bit.BIT0
+
+/*  SCON_1  */
+#define SM0_1       SCON_1_bit.BIT7
+#define FE_1        SCON_1_bit.BIT7 
+#define SM1_1       SCON_1_bit.BIT6 
+#define SM2_1       SCON_1_bit.BIT5 
+#define REN_1       SCON_1_bit.BIT4 
+#define TB8_1       SCON_1_bit.BIT3 
+#define RB8_1       SCON_1_bit.BIT2 
+#define TI_1        SCON_1_bit.BIT1 
+#define RI_1        SCON_1_bit.BIT0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_keil.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_keil.h
@@ -1,0 +1,432 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+#include "sfr_macro_ms51_32k.h"
+
+/*--------------------------------------------------------------------------
+ms51_32k.h
+Nuvoton MG51 64k Series Header file for Keil 
+--------------------------------------------------------------------------*/
+/* MS51_32K SFR BYTE page 0  */
+sfr P0                         =0x80;
+sfr SP                         =0x81;
+sfr DPL                        =0x82;
+sfr DPH                        =0x83;
+sfr RCTRIM0                    =0x84;
+sfr RCTRIM1                    =0x85;
+sfr RWKL                       =0x86;
+sfr PCON                       =0x87;
+
+sfr TCON                       =0x88;
+sfr TMOD                       =0x89;
+sfr TL0                        =0x8A;
+sfr TL1                        =0x8B;
+sfr TH0                        =0x8C;
+sfr TH1                        =0x8D;
+sfr CKCON                      =0x8E;
+sfr WKCON                      =0x8F;
+
+sfr P1                         =0x90;
+sfr SFRS                       =0x91;
+sfr CAPCON0                    =0x92;
+sfr CAPCON1                    =0x93;
+sfr CAPCON2                    =0x94;
+sfr CKDIV                      =0x95;
+sfr CKSWT                      =0x96;
+sfr CKEN                       =0x97;
+
+sfr SCON                       =0x98;
+sfr SBUF                       =0x99;
+sfr SBUF_1                     =0x9A;
+sfr EIE                        =0x9B;
+sfr EIE1                       =0x9C;
+sfr CHPCON                     =0x9F;
+
+sfr P2                        =0xA0;
+sfr AUXR1                      =0xA2;
+sfr BODCON0                    =0xA3;
+sfr IAPTRG                     =0xA4;
+sfr IAPUEN                     =0xA5;
+sfr IAPAL                      =0xA6;
+sfr IAPAH                      =0xA7;
+
+sfr IE                         =0xA8;
+sfr SADDR                      =0xA9;
+sfr WDCON                      =0xAA;
+sfr BODCON1                    =0xAB;
+sfr P3M1                       =0xAC;
+sfr P3M2                       =0xAD;
+sfr IAPFD                      =0xAE;
+sfr IAPCN                      =0xAF;
+
+sfr P3                         =0xB0;
+sfr P0M1                       =0xB1;
+sfr P0M2                       =0xB2;
+sfr P1M1                       =0xB3;
+sfr P1M2                       =0xB4;
+sfr TOE                        =0xB5;
+sfr IPH                        =0xB7;
+
+sfr IP                         =0xB8;
+sfr SADEN                      =0xB9;
+sfr SADEN_1                    =0xBA;
+sfr SADDR_1                    =0xBB;
+sfr I2DAT                      =0xBC;
+sfr I2STAT                     =0xBD;
+sfr I2CLK                      =0xBE;
+sfr I2TOC                      =0xBF;
+
+sfr I2CON                      =0xC0;
+sfr I2ADDR                     =0xC1;
+sfr ADCRL                      =0xC2;
+sfr ADCRH                      =0xC3;
+sfr T3CON                      =0xC4;
+sfr RL3                        =0xC5;
+sfr RH3                        =0xC6;
+sfr TA                         =0xC7;
+
+sfr T2CON                      =0xC8;
+sfr T2MOD                      =0xC9;
+sfr RCMP2L                     =0xCA;
+sfr RCMP2H                     =0xCB;
+sfr TL2                        =0xCC;
+sfr TH2                        =0xCD;
+sfr ADCMPL                     =0xCE;
+sfr ADCMPH                     =0xCF;
+
+sfr PSW                        =0xD0;
+sfr PWM0PH                     =0xD1;
+sfr PWM0C0H                    =0xD2;
+sfr PWM0C1H                    =0xD3;
+sfr PWM0C2H                    =0xD4;
+sfr PWM0C3H                    =0xD5;
+sfr PNP                        =0xD6;
+sfr PWM0FBD                    =0xD7;
+
+sfr PWM0CON0                   =0xD8;
+sfr PWM0PL                     =0xD9;
+sfr PWM0C0L                    =0xDA;
+sfr PWM0C1L                    =0xDB;
+sfr PWM0C2L                    =0xDC;
+sfr PWM0C3L                    =0xDD;
+sfr PIOCON0                    =0xDE;
+sfr PWM0CON1                   =0xDF;
+
+sfr ACC                        =0xE0;
+sfr ADCCON1                    =0xE1;
+sfr ADCCON2                    =0xE2;
+sfr ADCDLY                     =0xE3;
+sfr C0L                        =0xE4;
+sfr C0H                        =0xE5;
+sfr C1L                        =0xE6;
+sfr C1H                        =0xE7;
+
+sfr ADCCON0                    =0xE8;
+sfr PICON                      =0xE9;
+sfr PINEN                      =0xEA;
+sfr PIPEN                      =0xEB;
+sfr PIF                        =0xEC;
+sfr C2L                        =0xED;
+sfr C2H                        =0xEE;
+sfr EIP                        =0xEF;
+
+sfr B                          =0xF0;
+sfr CAPCON3                    =0xF1;
+sfr CAPCON4                    =0xF2;
+sfr SPCR                       =0xF3;
+sfr SPSR                       =0xF4;
+sfr SPDR                       =0xF5;
+sfr AINDIDS0                    =0xF6;
+sfr EIPH                       =0xF7;
+
+sfr SCON_1                     =0xF8;
+sfr PWM0DTEN                   =0xF9;
+sfr PWM0DTCNT                  =0xFA;
+sfr PWM0MEN                    =0xFB;
+sfr PWM0MD                     =0xFC;
+sfr PORDIS                     =0xFD;
+sfr EIP1                       =0xFE;
+sfr EIPH1                      =0xFF;
+
+/* MS51_32K SFR BYTE page 1  */
+sfr P3S                        =0xAC;
+sfr P3SR                       =0xAD;
+
+
+sfr P0S                        =0xB1;
+sfr P0SR                       =0xB2;
+sfr P1S                        =0xB3;
+sfr P1SR                       =0xB4;
+sfr PWM0INTC                   =0xB7;
+
+sfr PWM0C4H                    =0xC4;
+sfr PWM0C5H                    =0xC5;
+sfr PIOCON1                    =0xC6;
+
+sfr PWM0C4L                    =0xCC;
+sfr PWM0C5L                    =0xCD;
+
+sfr SPCR2                      =0xF3;
+
+sfr LVRDIS                     =0xFF;
+
+/* MS51_32K SFR BYTE page 2  */
+sfr ADCBAL                     =0x84;
+sfr ADCBAH                     =0x85;
+sfr ADCCON3                    =0x86;
+
+sfr P2M1                       =0x89;
+sfr P2M2                       =0x8A;
+sfr P2SR                       =0x8B;
+sfr P2S                        =0x8C;
+sfr ADCSN                      =0x8D;
+sfr ADCCN                      =0x8E;
+sfr ADCSR                      =0x8F;
+
+sfr P0UP                       =0x92;
+sfr P1UP                       =0x93;
+sfr P2UP                       =0x94;
+sfr P3UP                       =0x95;
+sfr RWKH                       =0x97;
+
+sfr AINDIDS1                   =0x99;
+sfr P0DW                       =0x9A;
+sfr P1DW                       =0x9B;
+sfr P2DW                       =0x9C;
+sfr P3DW                       =0x9D;
+
+sfr AUXR2                      =0xA1;
+sfr AUXR3                      =0xA2;
+sfr AUXR4                      =0xA3;
+sfr AUXR5                      =0xA4;
+sfr AUXR6                      =0xA5;
+sfr AUXR7                      =0xA6;
+sfr AUXR8                      =0xA7;
+
+sfr PWM1PH                     =0xA9;
+sfr PWM1C0H                    =0xAA;
+sfr PWM1C1H                    =0xAB;
+sfr PWM1MD                     =0xAC;
+sfr PWM1MEN                    =0xAD;
+
+sfr PWM1PL                     =0xB1;
+sfr PWM1C0L                    =0xB2;
+sfr PWM1C1L                    =0xB3;
+sfr PWM1CON0                   =0xB4;
+sfr PWM1CON1                   =0xB5;
+sfr PWM1INTC                   =0xB6;
+sfr PIOCON2                    =0xB7;
+
+sfr PWM2PH                     =0xB9;
+sfr PWM2C0H                    =0xBA;
+sfr PWM2C1H                    =0xBB;
+sfr PWM2MD                     =0xBC;
+sfr PWM2MEN                    =0xBD;
+
+sfr PWM2PL                     =0xC1;
+sfr PWM2C0L                    =0xC2;
+sfr PWM2C1L                    =0xC3;
+sfr PWM2CON0                   =0xC4;
+sfr PWM2CON1                   =0xC5;
+sfr PWM2INTC                   =0xC6;
+
+sfr PWM3PH                     =0xC9;
+sfr PWM3C0H                    =0xCA;
+sfr PWM3C1H                    =0xCB;
+sfr PWM3MD                     =0xCC;
+sfr PWM3MEN                    =0xCD;
+sfr EIP2                       =0xCE;
+sfr EIPH2                      =0xCF;
+
+sfr PWM3PL                     =0xD1;
+sfr PWM3C0L                    =0xD2;
+sfr PWM3C1L                    =0xD3;
+sfr PWM3CON0                   =0xD4;
+sfr PWM3CON1                   =0xD5;
+sfr PWM3INTC                   =0xD6;
+sfr XTLCON                     =0xD7;
+
+sfr SC0DR                      =0xD9;
+sfr SC0EGT                     =0xDA;
+sfr SC0ETURD0                  =0xDB;
+sfr SC0ETURD1                  =0xDC;
+sfr SC0IE                      =0xDD;
+sfr SC0IS                      =0xDE;
+sfr SC0TSR                     =0xDF;
+
+sfr SC1DR                      =0xE1;
+sfr SC1EGT                     =0xE2;
+sfr SC1ETURD0                  =0xE3;
+sfr SC1ETURD1                  =0xE4;
+sfr SC1IE                      =0xE5;
+sfr SC1IS                      =0xE6;
+sfr SC1TSR                     =0xE7;
+
+sfr SC2DR                      =0xE9;
+sfr SC2EGT                     =0xEA;
+sfr SC2ETURD0                  =0xEB;
+sfr SC2ETURD1                  =0xEC;
+sfr SC2IE                      =0xED;
+sfr SC2IS                      =0xEE;
+sfr SC2TSR                     =0xEF;
+
+sfr SC0CR0                     =0xF1;
+sfr SC0CR1                     =0xF2;
+sfr SC1CR0                     =0xF3;
+sfr SC1CR1                     =0xF4;
+sfr SC2CR0                     =0xF5;
+sfr SC2CR1                     =0xF6;
+sfr PIPS7                      =0xF7;
+
+sfr PIPS0                      =0xF9;
+sfr PIPS1                      =0xFA;
+sfr PIPS2                      =0xFB;
+sfr PIPS3                      =0xFC;
+sfr PIPS4                      =0xFD;
+sfr PIPS5                      =0xFE;
+sfr PIPS6                      =0xFF;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+sbit SM0_1      = SCON_1^7;
+sbit FE_1       = SCON_1^7; 
+sbit SM1_1      = SCON_1^6; 
+sbit SM2_1      = SCON_1^5; 
+sbit REN_1      = SCON_1^4; 
+sbit TB8_1      = SCON_1^3; 
+sbit RB8_1      = SCON_1^2; 
+sbit TI_1       = SCON_1^1; 
+sbit RI_1       = SCON_1^0; 
+
+/*  ADCCON0  */
+sbit ADCF       = ADCCON0^7;
+sbit ADCS       = ADCCON0^6;
+sbit ETGSEL1    = ADCCON0^5;
+sbit ETGSEL0    = ADCCON0^4;
+sbit ADCHS3     = ADCCON0^3;
+sbit ADCHS2     = ADCCON0^2;
+sbit ADCHS1     = ADCCON0^1;
+sbit ADCHS0     = ADCCON0^0;
+
+/*  PWMCON0  */
+sbit PWMRUN     = PWM0CON0^7;
+sbit LOAD       = PWM0CON0^6;
+sbit PWMF       = PWM0CON0^5;
+sbit CLRPWM     = PWM0CON0^4;
+
+
+/*  PSW */
+sbit CY         = PSW^7;
+sbit AC         = PSW^6;
+sbit F0         = PSW^5;
+sbit RS1        = PSW^4;
+sbit RS0        = PSW^3;
+sbit OV         = PSW^2;
+sbit P          = PSW^0;
+
+/*  T2CON  */
+sbit TF2        = T2CON^7;
+sbit TR2        = T2CON^2;
+sbit CM_RL2     = T2CON^0;
+ 
+/*  I2CON  */
+sbit I2CEN      = I2CON^6;
+sbit STA        = I2CON^5;
+sbit STO        = I2CON^4;
+sbit SI         = I2CON^3;
+sbit AA         = I2CON^2;
+sbit I2CPX  = I2CON^0;
+
+/*  IP  */  
+sbit PADC       = IP^6;
+sbit PBOD       = IP^5;
+sbit PS         = IP^4;
+sbit PT1        = IP^3;
+sbit PX1        = IP^2;
+sbit PT0        = IP^1;
+sbit PX0        = IP^0;
+
+/*  P3  */  
+sbit P37  = P3^7;
+sbit P36  = P3^6;
+sbit P35  = P3^5;
+sbit P34  = P3^4;
+sbit P33  = P3^3;
+sbit P32  = P3^2; 
+sbit P31  = P3^1;
+sbit P30  = P3^0;
+
+/*  IE  */
+sbit EA         = IE^7;
+sbit EADC       = IE^6;
+sbit EBOD       = IE^5;
+sbit ES         = IE^4;
+sbit ET1        = IE^3;
+sbit EX1        = IE^2;
+sbit ET0        = IE^1;
+sbit EX0        = IE^0;
+
+/*  P2  */  
+sbit P27  = P2^7;
+sbit P26  = P2^6;
+sbit P25  = P2^5;
+sbit P24  = P2^4;
+sbit P23  = P2^3;
+sbit P22  = P2^2; 
+sbit P21  = P2^1;
+sbit P20  = P2^0;
+
+/*  SCON  */
+sbit SM0        = SCON^7;
+sbit FE         = SCON^7; 
+sbit SM1        = SCON^6; 
+sbit SM2        = SCON^5; 
+sbit REN        = SCON^4; 
+sbit TB8        = SCON^3; 
+sbit RB8        = SCON^2; 
+sbit TI         = SCON^1; 
+sbit RI         = SCON^0; 
+
+/*  P1  */     
+sbit P17  = P1^7;
+sbit P16  = P1^6;
+sbit TXD_1  = P1^6; 
+sbit P15  = P1^5;
+sbit P14  = P1^4;
+sbit SDA  = P1^4;    
+sbit P13  = P1^3;
+sbit SCL  = P1^3;  
+sbit P12        = P1^2; 
+sbit P11        = P1^1;
+sbit P10        = P1^0;
+
+/*  TCON  */
+sbit TF1        = TCON^7;
+sbit TR1        = TCON^6;
+sbit TF0        = TCON^5;
+sbit TR0        = TCON^4;
+sbit IE1        = TCON^3;
+sbit IT1        = TCON^2;
+sbit IE0        = TCON^1;
+sbit IT0        = TCON^0;
+
+/*  P0  */  
+
+sbit P07        = P0^7;
+sbit RXD        = P0^7;
+sbit P06        = P0^6;
+sbit TXD        = P0^6;
+sbit P05        = P0^5;
+sbit P04        = P0^4;
+sbit STADC      = P0^4;
+sbit P03        = P0^3;
+sbit P02        = P0^2;
+sbit RXD_1      = P0^2;
+sbit P01        = P0^1;
+sbit MISO       = P0^1;
+sbit P00        = P0^0;
+sbit MOSI       = P0^0;
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_sdcc.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/ms51_32k_sdcc.h
@@ -1,0 +1,430 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+
+/***********************************************************************************************************/
+/*  MS51_32K_SDCC.H                                                                                        */
+/*                                                                                                         */
+/*  Header file of Nuvoton MS51 32k Series for SDCC                                                        */
+/***********************************************************************************************************/
+#include "sfr_macro_ms51_32k.h"
+
+/******************************************************************************/
+/*                         Macro define header files                          */
+/******************************************************************************/
+
+/* MS51_32K SFR BYTE page 0  */
+__sfr __at  (0x80)  P0        ;
+__sfr __at  (0x81)  SP        ;
+__sfr __at  (0x82)  DPL       ;
+__sfr __at  (0x83)  DPH       ;
+__sfr __at  (0x84)  RCTRIM0   ;
+__sfr __at  (0x85)  RCTRIM1   ;
+__sfr __at  (0x86)  RWKL      ;
+__sfr __at  (0x87)  PCON      ;
+                  
+__sfr __at  (0x88)  TCON      ;
+__sfr __at  (0x89)  TMOD      ;
+__sfr __at  (0x8A)  TL0       ;
+__sfr __at  (0x8B)  TL1       ;
+__sfr __at  (0x8C)  TH0       ;
+__sfr __at  (0x8D)  TH1       ;
+__sfr __at  (0x8E)  CKCON     ;
+__sfr __at  (0x8F)  WKCON     ;
+                  
+__sfr __at  (0x90)  P1        ;
+__sfr __at  (0x91)  SFRS      ;
+__sfr __at  (0x92)  CAPCON0   ;
+__sfr __at  (0x93)  CAPCON1   ;
+__sfr __at  (0x94)  CAPCON2   ;
+__sfr __at  (0x95)  CKDIV     ;
+__sfr __at  (0x96)  CKSWT     ;
+__sfr __at  (0x97)  CKEN      ;
+                  
+__sfr __at  (0x98)  SCON      ;
+__sfr __at  (0x99)  SBUF      ;
+__sfr __at  (0x9A)  SBUF_1    ;
+__sfr __at  (0x9B)  EIE       ;
+__sfr __at  (0x9C)  EIE1      ;
+__sfr __at  (0x9F)  CHPCON    ;
+                  
+__sfr __at  (0xA0)  P2        ;
+__sfr __at  (0xA2)  AUXR1     ;
+__sfr __at  (0xA3)  BODCON0   ;
+__sfr __at  (0xA4)  IAPTRG    ;
+__sfr __at  (0xA5)  IAPUEN    ;
+__sfr __at  (0xA6)  IAPAL     ;
+__sfr __at  (0xA7)  IAPAH     ;
+                  
+__sfr __at  (0xA8)  IE        ;
+__sfr __at  (0xA9)  SADDR     ;
+__sfr __at  (0xAA)  WDCON     ;
+__sfr __at  (0xAB)  BODCON1   ;
+__sfr __at  (0xAC)  P3M1      ;
+__sfr __at  (0xAD)  P3M2      ;
+__sfr __at  (0xAE)  IAPFD     ;
+__sfr __at  (0xAF)  IAPCN     ;
+                  
+__sfr __at  (0xB0)  P3        ;
+__sfr __at  (0xB1)  P0M1      ;
+__sfr __at  (0xB2)  P0M2      ;
+__sfr __at  (0xB3)  P1M1      ;
+__sfr __at  (0xB4)  P1M2      ;
+__sfr __at  (0xB5)  TOE       ;
+__sfr __at  (0xB7)  IPH       ;
+                  
+__sfr __at  (0xB8)  IP        ;
+__sfr __at  (0xB9)  SADEN     ;
+__sfr __at  (0xBA)  SADEN_1   ;
+__sfr __at  (0xBB)  SADDR_1   ;
+__sfr __at  (0xBC)  I2DAT     ;
+__sfr __at  (0xBD)  I2STAT    ;
+__sfr __at  (0xBE)  I2CLK     ;
+__sfr __at  (0xBF)  I2TOC     ;
+                  
+__sfr __at  (0xC0)  I2CON     ;
+__sfr __at  (0xC1)  I2ADDR    ;
+__sfr __at  (0xC2)  ADCRL     ;
+__sfr __at  (0xC3)  ADCRH     ;
+__sfr __at  (0xC4)  T3CON     ;
+__sfr __at  (0xC5)  RL3       ;
+__sfr __at  (0xC6)  RH3       ;
+__sfr __at  (0xC7)  TA        ;
+                  
+__sfr __at  (0xC8)  T2CON     ;
+__sfr __at  (0xC9)  T2MOD     ;
+__sfr __at  (0xCA)  RCMP2L    ;
+__sfr __at  (0xCB)  RCMP2H    ;
+__sfr __at  (0xCC)  TL2       ;
+__sfr __at  (0xCD)  TH2       ;
+__sfr __at  (0xCE)  ADCMPL    ;
+__sfr __at  (0xCF)  ADCMPH    ;
+                  
+__sfr __at  (0xD0)  PSW       ;
+__sfr __at  (0xD1)  PWM0PH    ;
+__sfr __at  (0xD2)  PWM0C0H   ;
+__sfr __at  (0xD3)  PWM0C1H   ;
+__sfr __at  (0xD4)  PWM0C2H   ;
+__sfr __at  (0xD5)  PWM0C3H   ;
+__sfr __at  (0xD6)  PNP       ;
+__sfr __at  (0xD7)  PWM0FBD   ;
+                  
+__sfr __at  (0xD8)  PWM0CON0  ;
+__sfr __at  (0xD9)  PWM0PL    ;
+__sfr __at  (0xDA)  PWM0C0L   ;
+__sfr __at  (0xDB)  PWM0C1L   ;
+__sfr __at  (0xDC)  PWM0C2L   ;
+__sfr __at  (0xDD)  PWM0C3L   ;
+__sfr __at  (0xDE)  PIOCON0   ;
+__sfr __at  (0xDF)  PWM0CON1  ;
+                  
+__sfr __at  (0xE0)  ACC       ;
+__sfr __at  (0xE1)  ADCCON1   ;
+__sfr __at  (0xE2)  ADCCON2   ;
+__sfr __at  (0xE3)  ADCDLY    ;
+__sfr __at  (0xE4)  C0L       ;
+__sfr __at  (0xE5)  C0H       ;
+__sfr __at  (0xE6)  C1L       ;
+__sfr __at  (0xE7)  C1H       ;
+                  
+__sfr __at  (0xE8)  ADCCON0   ;
+__sfr __at  (0xE9)  PICON     ;
+__sfr __at  (0xEA)  PINEN     ;
+__sfr __at  (0xEB)  PIPEN     ;
+__sfr __at  (0xEC)  PIF       ;
+__sfr __at  (0xED)  C2L       ;
+__sfr __at  (0xEE)  C2H       ;
+__sfr __at  (0xEF)  EIP       ;
+                  
+__sfr __at  (0xF0)  B         ;
+__sfr __at  (0xF1)  CAPCON3   ;
+__sfr __at  (0xF2)  CAPCON4   ;
+__sfr __at  (0xF3)  SPCR      ;
+__sfr __at  (0xF4)  SPSR      ;
+__sfr __at  (0xF5)  SPDR      ;
+__sfr __at  (0xF6)  AINDIDS0  ;
+__sfr __at  (0xF7)  EIPH      ;
+                  
+__sfr __at  (0xF8)  SCON_1    ;
+__sfr __at  (0xF9)  PWM0DTEN  ;
+__sfr __at  (0xFA)  PWM0DTCNT ;
+__sfr __at  (0xFB)  PWM0MEN   ;
+__sfr __at  (0xFC)  PWM0MD    ;
+__sfr __at  (0xFD)  PORDIS    ;
+__sfr __at  (0xFE)  EIP1      ;
+__sfr __at  (0xFF)  EIPH1     ;
+                  
+/* MS51_32K       SFR BYTE page 1  */
+__sfr __at  (0xAC)  P3S       ;
+__sfr __at  (0xAD)  P3SR      ;
+                  
+                  
+__sfr __at  (0xB1)  P0S       ;
+__sfr __at  (0xB2)  P0SR      ;
+__sfr __at  (0xB3)  P1S       ;
+__sfr __at  (0xB4)  P1SR      ;
+__sfr __at  (0xB7)  PWM0INTC  ;
+                  
+__sfr __at  (0xC4)  PWM0C4H   ;
+__sfr __at  (0xC5)  PWM0C5H   ;
+__sfr __at  (0xC6)  PIOCON1   ;
+                  
+__sfr __at  (0xCC)  PWM0C4L   ;
+__sfr __at  (0xCD)  PWM0C5L   ;
+                  
+__sfr __at  (0xF3)  SPCR2     ;
+                  
+__sfr __at  (0xFF)  LVRDIS    ;
+                  
+/* MS51_32K       SFR BYTE page 2  */
+__sfr __at  (0x84)  ADCBAL    ;
+__sfr __at  (0x85)  ADCBAH    ;
+__sfr __at  (0x86)  ADCCON3   ;
+                  
+__sfr __at  (0x89)  P2M1      ;
+__sfr __at  (0x8A)  P2M2      ;
+__sfr __at  (0x8B)  P2SR      ;
+__sfr __at  (0x8C)  P2S       ;
+__sfr __at  (0x8D)  ADCSN     ;
+__sfr __at  (0x8E)  ADCCN     ;
+__sfr __at  (0x8F)  ADCSR     ;
+                  
+__sfr __at  (0x92)  P0UP      ;
+__sfr __at  (0x93)  P1UP      ;
+__sfr __at  (0x94)  P2UP      ;
+__sfr __at  (0x95)  P3UP      ;
+__sfr __at  (0x97)  RWKH      ;
+                  
+__sfr __at  (0x99)  AINDIDS1  ;
+__sfr __at  (0x9A)  P0DW      ;
+__sfr __at  (0x9B)  P1DW      ;
+__sfr __at  (0x9C)  P2DW      ;
+__sfr __at  (0x9D)  P3DW      ;
+                  
+__sfr __at  (0xA1)  AUXR2     ;
+__sfr __at  (0xA2)  AUXR3     ;
+__sfr __at  (0xA3)  AUXR4     ;
+__sfr __at  (0xA4)  AUXR5     ;
+__sfr __at  (0xA5)  AUXR6     ;
+__sfr __at  (0xA6)  AUXR7     ;
+__sfr __at  (0xA7)  AUXR8     ;
+                  
+__sfr __at  (0xA9)  PWM1PH    ;
+__sfr __at  (0xAA)  PWM1C0H   ;
+__sfr __at  (0xAB)  PWM1C1H   ;
+__sfr __at  (0xAC)  PWM1MD    ;
+__sfr __at  (0xAD)  PWM1MEN   ;
+                  
+__sfr __at  (0xB1)  PWM1PL    ;
+__sfr __at  (0xB2)  PWM1C0L   ;
+__sfr __at  (0xB3)  PWM1C1L   ;
+__sfr __at  (0xB4)  PWM1CON0  ;
+__sfr __at  (0xB5)  PWM1CON1  ;
+__sfr __at  (0xB6)  PWM1INTC  ;
+__sfr __at  (0xB7)  PIOCON2   ;
+                  
+__sfr __at  (0xB9)  PWM2PH    ;
+__sfr __at  (0xBA)  PWM2C0H   ;
+__sfr __at  (0xBB)  PWM2C1H   ;
+__sfr __at  (0xBC)  PWM2MD    ;
+__sfr __at  (0xBD)  PWM2MEN   ;
+                  
+__sfr __at  (0xC1)  PWM2PL    ;
+__sfr __at  (0xC2)  PWM2C0L   ;
+__sfr __at  (0xC3)  PWM2C1L   ;
+__sfr __at  (0xC4)  PWM2CON0  ;
+__sfr __at  (0xC5)  PWM2CON1  ;
+__sfr __at  (0xC6)  PWM2INTC  ;
+                  
+__sfr __at  (0xC9)  PWM3PH    ;
+__sfr __at  (0xCA)  PWM3C0H   ;
+__sfr __at  (0xCB)  PWM3C1H   ;
+__sfr __at  (0xCC)  PWM3MD    ;
+__sfr __at  (0xCD)  PWM3MEN   ;
+__sfr __at  (0xCE)  EIP2      ;
+__sfr __at  (0xCF)  EIPH2     ;
+                  
+__sfr __at  (0xD1)  PWM3PL    ;
+__sfr __at  (0xD2)  PWM3C0L   ;
+__sfr __at  (0xD3)  PWM3C1L   ;
+__sfr __at  (0xD4)  PWM3CON0  ;
+__sfr __at  (0xD5)  PWM3CON1  ;
+__sfr __at  (0xD6)  PWM3INTC  ;
+__sfr __at  (0xD7)  XTLCON    ;
+                  
+__sfr __at  (0xD9)  SC0DR     ;
+__sfr __at  (0xDA)  SC0EGT    ;
+__sfr __at  (0xDB)  SC0ETURD0 ;
+__sfr __at  (0xDC)  SC0ETURD1 ;
+__sfr __at  (0xDD)  SC0IE     ;
+__sfr __at  (0xDE)  SC0IS     ;
+__sfr __at  (0xDF)  SC0TSR    ;
+                  
+__sfr __at  (0xE1)  SC1DR     ;
+__sfr __at  (0xE2)  SC1EGT    ;
+__sfr __at  (0xE3)  SC1ETURD0 ;
+__sfr __at  (0xE4)  SC1ETURD1 ;
+__sfr __at  (0xE5)  SC1IE     ;
+__sfr __at  (0xE6)  SC1IS     ;
+__sfr __at  (0xE7)  SC1TSR    ;
+                  
+__sfr __at  (0xE9)  SC2DR     ;
+__sfr __at  (0xEA)  SC2EGT    ;
+__sfr __at  (0xEB)  SC2ETURD0 ;
+__sfr __at  (0xEC)  SC2ETURD1 ;
+__sfr __at  (0xED)  SC2IE     ;
+__sfr __at  (0xEE)  SC2IS     ;
+__sfr __at  (0xEF)  SC2TSR    ;
+                  
+__sfr __at  (0xF1)  SC0CR0    ;
+__sfr __at  (0xF2)  SC0CR1    ;
+__sfr __at  (0xF3)  SC1CR0    ;
+__sfr __at  (0xF4)  SC1CR1    ;
+__sfr __at  (0xF5)  SC2CR0    ;
+__sfr __at  (0xF6)  SC2CR1    ;
+__sfr __at  (0xF7)  PIPS7     ;
+                  
+__sfr __at  (0xF9)  PIPS0     ;
+__sfr __at  (0xFA)  PIPS1     ;
+__sfr __at  (0xFB)  PIPS2     ;
+__sfr __at  (0xFC)  PIPS3     ;
+__sfr __at  (0xFD)  PIPS4     ;
+__sfr __at  (0xFE)  PIPS5     ;
+__sfr __at  (0xFF)  PIPS6     ;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+__sbit  __at (0xF8+7) SM0_1   ; //SCON_1^7;
+__sbit  __at (0xF8+7) FE_1    ; //SCON_1^7
+__sbit  __at (0xF8+6) SM1_1   ; //SCON_1^6
+__sbit  __at (0xF8+5) SM2_1   ; //SCON_1^5
+__sbit  __at (0xF8+4) REN_1   ; //SCON_1^4
+__sbit  __at (0xF8+3) TB8_1   ; //SCON_1^3
+__sbit  __at (0xF8+2) RB8_1   ; //SCON_1^2
+__sbit  __at (0xF8+1) TI_1    ; //SCON_1^1
+__sbit  __at (0xF8+0) RI_1    ; //SCON_1^0
+
+/*  ADCCON0  */
+__sbit  __at (0xE8+7) ADCF    ; //ADCCON0^7
+__sbit  __at (0xE8+6) ADCS    ; //ADCCON0^6
+__sbit  __at (0xE8+5) ETGSEL1 ; //ADCCON0^5
+__sbit  __at (0xE8+4) ETGSEL0 ; //ADCCON0^4
+__sbit  __at (0xE8+3) ADCHS3  ; //ADCCON0^3
+__sbit  __at (0xE8+2) ADCHS2  ; //ADCCON0^2
+__sbit  __at (0xE8+1) ADCHS1  ; //ADCCON0^1
+__sbit  __at (0xE8+0) ADCHS0  ; //ADCCON0^0
+
+/*  PWMCON0  */
+__sbit  __at (0xD8+7) PWMRUN  ; //PWMCON0^7
+__sbit  __at (0xD8+6) LOAD    ; //PWMCON0^6
+__sbit  __at (0xD8+5) PWMF    ; //PWMCON0^5
+__sbit  __at (0xD8+4) CLRPWM  ; //PWMCON0^4
+
+
+/*  PSW */
+__sbit  __at (0xD0+7) CY       ; //PSW^7
+__sbit  __at (0xD0+6) AC       ; //PSW^6
+__sbit  __at (0xD0+5) F0       ; //PSW^5
+__sbit  __at (0xD0+4) RS1      ; //PSW^4
+__sbit  __at (0xD0+3) RS0      ; //PSW^3
+__sbit  __at (0xD0+2) OV       ; //PSW^2
+__sbit  __at (0xD0+0) P        ; //PSW^0
+
+/*  T2CON  */
+__sbit  __at (0xC8+7) TF2      ; //T2CON^7
+__sbit  __at (0xC8+2) TR2      ; //T2CON^2
+__sbit  __at (0xC8+0) CM_RL2   ; //T2CON^0
+ 
+/*  I2CON  */
+__sbit  __at (0xC0+6) I2CEN    ; //I2CON^6
+__sbit  __at (0xC0+5) STA      ; //I2CON^5
+__sbit  __at (0xC0+4) STO      ; //I2CON^4
+__sbit  __at (0xC0+3) SI       ; //I2CON^3
+__sbit  __at (0xC0+2) AA       ; //I2CON^2
+__sbit  __at (0xC0+0) I2CPX    ; //I2CON^0
+
+/*  IP  */  
+__sbit  __at (0xB8+6) PADC     ; //IP^6
+__sbit  __at (0xB8+5) PBOD     ; //IP^5
+__sbit  __at (0xB8+4) PS       ; //IP^4
+__sbit  __at (0xB8+3) PT1      ; //IP^3
+__sbit  __at (0xB8+2) PX1      ; //IP^2
+__sbit  __at (0xB8+1) PT0      ; //IP^1
+__sbit  __at (0xB8+0) PX0      ; //IP^0
+
+/*  P3  */  
+__sbit  __at (0xB0+7) P37      ; // P3^7
+__sbit  __at (0xB0+6) P36      ; // P3^6
+__sbit  __at (0xB0+5) P35      ; // P3^5
+__sbit  __at (0xB0+4) P34      ; // P3^4
+__sbit  __at (0xB0+3) P33      ; // P3^3
+__sbit  __at (0xB0+2) P32      ; // P3^2 
+__sbit  __at (0xB0+1) P31      ; // P3^1
+__sbit  __at (0xB0+0) P30      ; // P3^0
+
+/*  IE  */
+__sbit  __at (0xA8+7) EA       ; //IE^7
+__sbit  __at (0xA8+6) EADC     ; //IE^6
+__sbit  __at (0xA8+5) EBOD     ; //IE^5
+__sbit  __at (0xA8+4) ES       ; //IE^4
+__sbit  __at (0xA8+3) ET1      ; //IE^3
+__sbit  __at (0xA8+2) EX1      ; //IE^2
+__sbit  __at (0xA8+1) ET0      ; //IE^1
+__sbit  __at (0xA8+0) EX0      ; //IE^0
+
+/*  P2  */ 
+__sbit  __at (0xA0+0) P20      ; //P2^0
+
+/*  SCON  */
+__sbit  __at (0x98+7) SM0      ; //SCON^7
+__sbit  __at (0x98+7) FE       ; //SCON^7
+__sbit  __at (0x98+6) SM1      ; //SCON^6
+__sbit  __at (0x98+5) SM2      ; //SCON^5
+__sbit  __at (0x98+4) REN      ; //SCON^4
+__sbit  __at (0x98+3) TB8      ; //SCON^3
+__sbit  __at (0x98+2) RB8      ; //SCON^2
+__sbit  __at (0x98+1) TI       ; //SCON^1
+__sbit  __at (0x98+0) RI       ; //SCON^0
+
+/*  P1  */     
+__sbit  __at (0x90+7) P17      ; //P1^7
+__sbit  __at (0x90+6) P16      ; //P1^6
+__sbit  __at (0x90+6) TXD_1    ; //P1^6
+__sbit  __at (0x90+5) P15      ; //P1^5
+__sbit  __at (0x90+4) P14      ; //P1^4
+__sbit  __at (0x90+4) SDA      ; //P1^4
+__sbit  __at (0x90+3) P13      ; //P1^3
+__sbit  __at (0x90+3) SCL      ; //P1^3
+__sbit  __at (0x90+2) P12      ; //P1^2
+__sbit  __at (0x90+1) P11      ; //P1^1
+__sbit  __at (0x90+0) P10      ; //P1^0
+
+/*  TCON  */
+__sbit  __at (0x88+7) TF1      ; //TCON^7
+__sbit  __at (0x88+6) TR1      ; //TCON^6
+__sbit  __at (0x88+5) TF0      ; //TCON^5
+__sbit  __at (0x88+4) TR0      ; //TCON^4
+__sbit  __at (0x88+3) IE1      ; //TCON^3
+__sbit  __at (0x88+2) IT1      ; //TCON^2
+__sbit  __at (0x88+1) IE0      ; //TCON^1
+__sbit  __at (0x88+0) IT0      ; //TCON^0
+
+/*  P0  */  
+__sbit  __at (0x80+7) P07      ; //P0^7
+__sbit  __at (0x80+7) RXD      ; //P0^7
+__sbit  __at (0x80+6) P06      ; //P0^6
+__sbit  __at (0x80+6) TXD      ; //P0^6
+__sbit  __at (0x80+5) P05      ; //P0^5
+__sbit  __at (0x80+4) P04      ; //P0^4
+__sbit  __at (0x80+4) STADC    ; //P0^4
+__sbit  __at (0x80+3) P03      ; //P0^3
+__sbit  __at (0x80+2) P02      ; //P0^2
+__sbit  __at (0x80+2) RXD_1    ; //P0^2
+__sbit  __at (0x80+1) P01      ; //P0^1
+__sbit  __at (0x80+1) MISO     ; //P0^1
+__sbit  __at (0x80+0) P00      ; //P0^0
+__sbit  __at (0x80+0) MOSI     ; //P0^0
+

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/numicro_8051.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/numicro_8051.h
@@ -1,0 +1,14 @@
+
+/* for Keil */
+#if defined __C51__
+#include "ms51_32k_keil.h"
+
+/* for IAR */
+#elif defined __ICC8051__
+#include "ms51_32k_iar.h"
+
+/* for SDCC */
+#elif defined __SDCC__
+#include "ms51_32k_sdcc.h"
+
+#endif

--- a/hardware/victims/firmware/numicro8051/inc/MS5132K/sfr_macro_ms51_32k.h
+++ b/hardware/victims/firmware/numicro8051/inc/MS5132K/sfr_macro_ms51_32k.h
@@ -1,0 +1,2403 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2024 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+#if defined __C51__
+#include <stdio.h>
+#include <string.h>
+#include <absacc.h>
+#include <intrins.h>
+
+#elif defined __ICC8051__
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+
+#elif defined __SDCC__
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <float.h>
+
+#endif
+
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "function_define_ms51_32k.h"
+
+#ifdef INC_STD_DRIVER
+#include "adc.h"
+#include "bod.h"
+#include "capture.h"
+#include "common.h"
+#include "delay.h"
+#include "eeprom_sprom.h"
+#include "eeprom.h"
+#include "eeprom_sprom.h"
+#include "gpio.h"
+#include "i2c.h" 
+#include "iap.h"
+#include "iap_sprom.h"
+#include "isr.h"
+#include "pwm0.h"
+#include "pwm123.h"
+#include "spi.h"
+#include "sys.h"
+#include "timer.h"
+#include "uart.h"
+#include "uart2.h"
+#include "uart3.h"
+#include "uart4.h"
+#include "wdt.h"
+#include "wkt.h"
+#endif
+
+/********SFR ALL PAGES*************/
+/********************************************************************/
+/*  <Define rule I> set or clr _ regsiter name _ register bit name  */
+/********************************************************************/
+/**** P0  80H  PAGE A ****/
+#define set_P0_7                         P0|=0x80
+#define set_P0_6                         P0|=0x40
+#define set_P0_5                         P0|=0x20
+#define set_P0_4                         P0|=0x10
+#define set_P0_3                         P0|=0x08
+#define set_P0_2                         P0|=0x04
+#define set_P0_1                         P0|=0x02
+#define set_P0_0                         P0|=0x01
+
+#define clr_P0_7                         P0&=0x7F
+#define clr_P0_6                         P0&=0xBF
+#define clr_P0_5                         P0&=0xDF
+#define clr_P0_4                         P0&=0xEF
+#define clr_P0_3                         P0&=0xF7
+#define clr_P0_2                         P0&=0xFB
+#define clr_P0_1                         P0&=0xFD
+#define clr_P0_0                         P0&=0xFE
+
+/****  87H  PAGE A ****/
+#define set_PCON_SMOD                    PCON|=0x80
+#define set_PCON_SMOD0                   PCON|=0x40
+#define set_PCON_POF                     PCON|=0x10
+#define set_PCON_GF1                     PCON|=0x08
+#define set_PCON_GF0                     PCON|=0x04
+#define set_PCON_PD                      PCON|=0x02
+#define set_PCON_IDLE                    PCON|=0x01
+
+#define clr_PCON_SMOD                    PCON&=0x7F
+#define clr_PCON_SMOD0                   PCON&=0xBF
+#define clr_PCON_POF                     PCON&=0xEF
+#define clr_PCON_GF1                     PCON&=0xF7
+#define clr_PCON_GF0                     PCON&=0xFB
+#define clr_PCON_PD                      PCON&=0xFD
+#define clr_PCON_IDLE                    PCON&=0xFE
+
+/**** TCON  88H  PAGE A ****/
+#define set_TCON_TF1                     TCON|=0x80
+#define set_TCON_TR1                     TCON|=0x40
+#define set_TCON_TF0                     TCON|=0x20
+#define set_TCON_TR0                     TCON|=0x10
+#define set_TCON_IE1                     TCON|=0x08
+#define set_TCON_IT1                     TCON|=0x04
+#define set_TCON_IE0                     TCON|=0x02
+#define set_TCON_IT0                     TCON|=0x01
+
+#define clr_TCON_TF1                     TCON&=0x7F
+#define clr_TCON_TR1                     TCON&=0xBF
+#define clr_TCON_TF0                     TCON&=0xDF
+#define clr_TCON_TR0                     TCON&=0xEF
+#define clr_TCON_IE1                     TCON&=0xF7
+#define clr_TCON_IT1                     TCON&=0xFB
+#define clr_TCON_IE0                     TCON&=0xFD
+#define clr_TCON_IT0                     TCON&=0xFE
+
+/**** P1  90H  PAGE A ****/
+#define set_P1_7                         P1|=0x80
+#define set_P1_6                         P1|=0x40
+#define set_P1_5                         P1|=0x20
+#define set_P1_4                         P1|=0x10
+#define set_P1_3                         P1|=0x08
+#define set_P1_2                         P1|=0x04
+#define set_P1_1                         P1|=0x02
+#define set_P1_0                         P1|=0x01
+
+#define clr_P1_7                         P1&=0x7F
+#define clr_P1_6                         P1&=0xBF
+#define clr_P1_5                         P1&=0xDF
+#define clr_P1_4                         P1&=0xEF
+#define clr_P1_3                         P1&=0xF7
+#define clr_P1_2                         P1&=0xFB
+#define clr_P1_1                         P1&=0xFD
+#define clr_P1_0                         P1&=0xFE
+
+/**** SFRS  91H  PAGE A ****/
+#define set_SFRS_SFRPSEL1                SFRS|=0x02
+#define set_SFRS_SFRPSEL0                SFRS|=0x01
+
+#define clr_SFRS_SFRPSEL1                SFRS&=0xFD
+#define clr_SFRS_SFRPSEL0                SFRS&=0xFE
+
+/**** SCON  98H  PAGE A ****/
+#define set_SCON_SM0                     SCON|=0x80
+#define set_SCON_FE                      SCON|=0x80
+#define set_SCON_SM1                     SCON|=0x40
+#define set_SCON_SM2                     SCON|=0x20
+#define set_SCON_REN                     SCON|=0x10
+#define set_SCON_TB8                     SCON|=0x08
+#define set_SCON_RB8                     SCON|=0x04
+#define set_SCON_TI                      SCON|=0x02
+#define set_SCON_RI                      SCON|=0x01
+
+#define clr_SCON_SM0                     SCON&=0x7F
+#define clr_SCON_FE                      SCON&=0x7F
+#define clr_SCON_SM1                     SCON&=0xBF
+#define clr_SCON_SM2                     SCON&=0xDF
+#define clr_SCON_REN                     SCON&=0xEF
+#define clr_SCON_TB8                     SCON&=0xF7
+#define clr_SCON_RB8                     SCON&=0xFB
+#define clr_SCON_TI                      SCON&=0xFD
+#define clr_SCON_RI                      SCON&=0xFE
+
+/**** P2  A0H  PAGE A ****/
+#define set_P2_7                         P2|=0x80
+#define set_P2_6                         P2|=0x40
+#define set_P2_5                         P2|=0x20
+#define set_P2_4                         P2|=0x10
+#define set_P2_3                         P2|=0x08
+#define set_P2_2                         P2|=0x04
+#define set_P2_1                         P2|=0x02
+#define set_P2_0                         P2|=0x01
+
+#define clr_P2_7                         P2&=0x7F
+#define clr_P2_6                         P2&=0xBF
+#define clr_P2_5                         P2&=0xDF
+#define clr_P2_4                         P2&=0xEF
+#define clr_P2_3                         P2&=0xF7
+#define clr_P2_2                         P2&=0xFB
+#define clr_P2_1                         P2&=0xFD
+#define clr_P2_0                         P2&=0xFE
+
+/**** IE  A8H  PAGE A ****/
+#define set_IE_EA                        IE|=0x80
+#define set_IE_EADC                      IE|=0x40
+#define set_IE_EBOD                      IE|=0x20
+#define set_IE_ES                        IE|=0x10
+#define set_IE_ET1                       IE|=0x08
+#define set_IE_EX1                       IE|=0x04
+#define set_IE_ET0                       IE|=0x02
+#define set_IE_EX0                       IE|=0x01
+
+#define clr_IE_EA                        IE&=0x7F
+#define clr_IE_EADC                      IE&=0xBF
+#define clr_IE_EBOD                      IE&=0xDF
+#define clr_IE_ES                        IE&=0xEF
+#define clr_IE_ET1                       IE&=0xF7
+#define clr_IE_EX1                       IE&=0xFB
+#define clr_IE_ET0                       IE&=0xFD
+#define clr_IE_EX0                       IE&=0xFE
+
+/**** P3  B0H  PAGE A ****/
+#define set_P3_7                         P3|=0x80
+#define set_P3_6                         P3|=0x40
+#define set_P3_5                         P3|=0x20
+#define set_P3_4                         P3|=0x10
+#define set_P3_3                         P3|=0x08
+#define set_P3_2                         P3|=0x04
+#define set_P3_1                         P3|=0x02
+#define set_P3_0                         P3|=0x01
+
+#define clr_P3_7                         P3&=0x7F
+#define clr_P3_6                         P3&=0xBF
+#define clr_P3_5                         P3&=0xDF
+#define clr_P3_4                         P3&=0xEF
+#define clr_P3_3                         P3&=0xF7
+#define clr_P3_2                         P3&=0xFB
+#define clr_P3_1                         P3&=0xFD
+#define clr_P3_0                         P3&=0xFE
+
+/**** IP  B8H  PAGE A ****/
+#define set_IP_PADC                      IP|=0x40
+#define set_IP_PBOD                      IP|=0x20
+#define set_IP_PS                        IP|=0x10
+#define set_IP_PT1                       IP|=0x08
+#define set_IP_PX1                       IP|=0x04
+#define set_IP_PT0                       IP|=0x02
+#define set_IP_PX0                       IP|=0x01
+
+#define clr_IP_PADC                      IP&=0xBF
+#define clr_IP_PBOD                      IP&=0xDF
+#define clr_IP_PS                        IP&=0xEF
+#define clr_IP_PT1                       IP&=0xF7
+#define clr_IP_PX1                       IP&=0xFB
+#define clr_IP_PT0                       IP&=0xFD
+#define clr_IP_PX0                       IP&=0xFE
+
+/**** I2CON  C0H  PAGE A ****/
+#define set_I2CON_I2CEN                  I2CON|=0x40
+#define set_I2CON_STA                    I2CON|=0x20
+#define set_I2CON_STO                    I2CON|=0x10
+#define set_I2CON_SI                     I2CON|=0x08
+#define set_I2CON_AA                     I2CON|=0x04
+#define set_I2CON_I2CPX                  I2CON|=0x01
+
+#define clr_I2CON_I2CEN                  I2CON&=0xBF
+#define clr_I2CON_STA                    I2CON&=0xDF
+#define clr_I2CON_STO                    I2CON&=0xEF
+#define clr_I2CON_SI                     I2CON&=0xF7
+#define clr_I2CON_AA                     I2CON&=0xFB
+#define clr_I2CON_I2CPX                  I2CON&=0xFE
+
+/**** T2CON  C8H  PAGE A ****/
+#define set_T2CON_TF2                    T2CON|=0x80
+#define set_T2CON_TR2                    T2CON|=0x04
+#define set_T2CON_CMRL2                  T2CON|=0x01
+
+#define clr_T2CON_TF2                    T2CON&=0x7F
+#define clr_T2CON_TR2                    T2CON&=0xFB
+#define clr_T2CON_CMRL2                  T2CON&=0xFE
+
+/**** PSW  D0H  PAGE A ****/
+#define set_PSW_CY                       PSW|=0x80
+#define set_PSW_AC                       PSW|=0x40
+#define set_PSW_F0                       PSW|=0x20
+#define set_PSW_RS1                      PSW|=0x10
+#define set_PSW_RS0                      PSW|=0x08
+#define set_PSW_OV                       PSW|=0x04
+#define set_PSW_P                        PSW|=0x01
+
+#define clr_PSW_CY                       PSW&=0x7F
+#define clr_PSW_AC                       PSW&=0xBF
+#define clr_PSW_F0                       PSW&=0xDF
+#define clr_PSW_RS1                      PSW&=0xEF
+#define clr_PSW_RS0                      PSW&=0xF7
+#define clr_PSW_OV                       PSW&=0xFB
+#define clr_PSW_P                        PSW&=0xFE
+
+/**** PWM0CON0  D8H  PAGE A ****/
+#define set_PWM0CON0_PWM0RUN             PWM0CON0|=0x80
+#define set_PWM0CON0_LOAD                PWM0CON0|=0x40
+#define set_PWM0CON0_PWMF                PWM0CON0|=0x20
+#define set_PWM0CON0_CLRPWM              PWM0CON0|=0x10
+#define set_PWM0CON0_PWM3RUN             PWM0CON0|=0x08
+#define set_PWM0CON0_PWM2RUN             PWM0CON0|=0x04
+#define set_PWM0CON0_PWM1RUN             PWM0CON0|=0x02
+#define set_PWM0CON0_P33FBINEN           PWM0CON0|=0x01
+
+#define clr_PWM0CON0_PWM0RUN             PWM0CON0&=0x7F
+#define clr_PWM0CON0_LOAD                PWM0CON0&=0xBF
+#define clr_PWM0CON0_PWMF                PWM0CON0&=0xDF
+#define clr_PWM0CON0_CLRPWM              PWM0CON0&=0xEF
+#define clr_PWM0CON0_PWM3RUN             PWM0CON0&=0xF7
+#define clr_PWM0CON0_PWM2RUN             PWM0CON0&=0xFB
+#define clr_PWM0CON0_PWM1RUN             PWM0CON0&=0xFD
+#define clr_PWM0CON0_P33FBINEN           PWM0CON0&=0xFE
+
+/**** ACC  E0H  PAGE A ****/
+#define set_ACC_7                        ACC|=0x80
+#define set_ACC_6                        ACC|=0x40
+#define set_ACC_5                        ACC|=0x20
+#define set_ACC_4                        ACC|=0x10
+#define set_ACC_3                        ACC|=0x08
+#define set_ACC_2                        ACC|=0x04
+#define set_ACC_1                        ACC|=0x02
+#define set_ACC_0                        ACC|=0x01
+
+#define clr_ACC_7                        ACC&=0x7F
+#define clr_ACC_6                        ACC&=0xBF
+#define clr_ACC_5                        ACC&=0xDF
+#define clr_ACC_4                        ACC&=0xEF
+#define clr_ACC_3                        ACC&=0xF7
+#define clr_ACC_2                        ACC&=0xFB
+#define clr_ACC_1                        ACC&=0xFD
+#define clr_ACC_0                        ACC&=0xFE
+
+/**** ADCCON0  E8H  PAGE A ****/
+#define set_ADCCON0_ADCF                 SFRS=0;ADCCON0|=0x80
+#define set_ADCCON0_ADCS                 SFRS=0;ADCCON0|=0x40
+#define set_ADCCON0_ETGSEL1              SFRS=0;ADCCON0|=0x20
+#define set_ADCCON0_ETGSEL0              SFRS=0;ADCCON0|=0x10
+#define set_ADCCON0_ADCHS3               SFRS=0;ADCCON0|=0x08
+#define set_ADCCON0_ADCHS2               SFRS=0;ADCCON0|=0x04
+#define set_ADCCON0_ADCHS1               SFRS=0;ADCCON0|=0x02
+#define set_ADCCON0_ADCHS0               SFRS=0;ADCCON0|=0x01
+
+#define clr_ADCCON0_ADCF                 SFRS=0;ADCCON0&=0x7F
+#define clr_ADCCON0_ADCS                 SFRS=0;ADCCON0&=0xBF
+#define clr_ADCCON0_ETGSEL1              SFRS=0;ADCCON0&=0xDF
+#define clr_ADCCON0_ETGSEL0              SFRS=0;ADCCON0&=0xEF
+#define clr_ADCCON0_ADCHS3               SFRS=0;ADCCON0&=0xF7
+#define clr_ADCCON0_ADCHS2               SFRS=0;ADCCON0&=0xFB
+#define clr_ADCCON0_ADCHS1               SFRS=0;ADCCON0&=0xFD
+#define clr_ADCCON0_ADCHS0               SFRS=0;ADCCON0&=0xFE
+
+/**** B  F0H  PAGE A ****/
+#define set_B_7                          B|=0x80
+#define set_B_6                          B|=0x40
+#define set_B_5                          B|=0x20
+#define set_B_4                          B|=0x10
+#define set_B_3                          B|=0x08
+#define set_B_2                          B|=0x04
+#define set_B_1                          B|=0x02
+#define set_B_0                          B|=0x01
+
+#define clr_B_7                          B&=0x7F
+#define clr_B_6                          B&=0xBF
+#define clr_B_5                          B&=0xDF
+#define clr_B_4                          B&=0xEF
+#define clr_B_3                          B&=0xF7
+#define clr_B_2                          B&=0xFB
+#define clr_B_1                          B&=0xFD
+#define clr_B_0                          B&=0xFE
+
+/**** SCON_1  F8H  PAGE A ****/
+#define set_SCON_1_SM0_1                 SCON_1|=0x80
+#define set_SCON_1_FE_1                  SCON_1|=0x80
+#define set_SCON_1_SM1_1                 SCON_1|=0x40
+#define set_SCON_1_SM2_1                 SCON_1|=0x20
+#define set_SCON_1_REN_1                 SCON_1|=0x10
+#define set_SCON_1_TB8_1                 SCON_1|=0x08
+#define set_SCON_1_RB8_1                 SCON_1|=0x04
+#define set_SCON_1_TI_1                  SCON_1|=0x02
+#define set_SCON_1_RI_1                  SCON_1|=0x01
+
+#define clr_SCON_1_SM0_1                 SCON_1&=0x7F
+#define clr_SCON_1_FE_1                  SCON_1&=0x7F
+#define clr_SCON_1_SM1_1                 SCON_1&=0xBF
+#define clr_SCON_1_SM2_1                 SCON_1&=0xDF
+#define clr_SCON_1_REN_1                 SCON_1&=0xEF
+#define clr_SCON_1_TB8_1                 SCON_1&=0xF7
+#define clr_SCON_1_RB8_1                 SCON_1&=0xFB
+#define clr_SCON_1_TI_1                  SCON_1&=0xFD
+#define clr_SCON_1_RI_1                  SCON_1&=0xFE
+
+/********SFR PAGE 0*************/
+/**** RCTRIM1  85H  PAGE 0 TA protect register ****/
+#define set_RCTRIM1_HIRC24               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;RCTRIM1|=0x10;EA=BIT_TMP
+#define set_RCTRIM1_HIRCTRIM_0           SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;RCTRIM1|=0x01;EA=BIT_TMP
+
+#define clr_RCTRIM1_HIRC24               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;RCTRIM1&=0xEF;EA=BIT_TMP
+#define clr_RCTRIM1_HIRCTRIM_0           SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;RCTRIM1&=0xFE;EA=BIT_TMP
+
+/**** TMOD  89H  PAGE 0 ****/
+/**** CKCON  8EH  PAGE 0 ****/
+
+#define set_CKCON_PWMCKS                 SFRS=0;CKCON|=0x40
+#define set_CKCON_T1M                    SFRS=0;CKCON|=0x10
+#define set_CKCON_T0M                    SFRS=0;CKCON|=0x08
+#define set_CKCON_CLOEN                  SFRS=0;CKCON|=0x02
+
+
+#define clr_CKCON_PWMCKS                 SFRS=0;CKCON&=0xBF
+#define clr_CKCON_T1M                    SFRS=0;CKCON&=0xEF
+#define clr_CKCON_T0M                    SFRS=0;CKCON&=0xF7
+#define clr_CKCON_CLOEN                  SFRS=0;CKCON&=0xFD
+
+/**** WKCON  8FH  PAGE 0 ****/
+#define set_WKCON_WKTF                   SFRS=0;WKCON|=0x10
+#define set_WKCON_WKTR                   SFRS=0;WKCON|=0x08
+#define set_WKCON_WKPS2                  SFRS=0;WKCON|=0x04
+#define set_WKCON_WKPS1                  SFRS=0;WKCON|=0x02
+#define set_WKCON_WKPS0                  SFRS=0;WKCON|=0x01
+
+#define clr_WKCON_WKTF                   SFRS=0;WKCON&=0xEF
+#define clr_WKCON_WKTR                   SFRS=0;WKCON&=0xF7
+#define clr_WKCON_WKPS2                  SFRS=0;WKCON&=0xFB
+#define clr_WKCON_WKPS1                  SFRS=0;WKCON&=0xFD
+#define clr_WKCON_WKPS0                  SFRS=0;WKCON&=0xFE
+
+/**** CAPCON0  92H  PAGE 0 ****/
+#define set_CAPCON0_CAPEN2               SFRS=0;CAPCON0|=0x40
+#define set_CAPCON0_CAPEN1               SFRS=0;CAPCON0|=0x20
+#define set_CAPCON0_CAPEN0               SFRS=0;CAPCON0|=0x10
+#define set_CAPCON0_CAPF2                SFRS=0;CAPCON0|=0x04
+#define set_CAPCON0_CAPF1                SFRS=0;CAPCON0|=0x02
+#define set_CAPCON0_CAPF0                SFRS=0;CAPCON0|=0x01
+
+#define clr_CAPCON0_CAPEN2               SFRS=0;CAPCON0&=0xBF
+#define clr_CAPCON0_CAPEN1               SFRS=0;CAPCON0&=0xDF
+#define clr_CAPCON0_CAPEN0               SFRS=0;CAPCON0&=0xEF
+#define clr_CAPCON0_CAPF2                SFRS=0;CAPCON0&=0xFB
+#define clr_CAPCON0_CAPF1                SFRS=0;CAPCON0&=0xFD
+#define clr_CAPCON0_CAPF0                SFRS=0;CAPCON0&=0xFE
+
+/**** CAPCON1  93H  PAGE 0 ****/
+#define set_CAPCON1_CAP2LS1              SFRS=0;CAPCON1|=0x20
+#define set_CAPCON1_CAP2LS0              SFRS=0;CAPCON1|=0x10
+#define set_CAPCON1_CAP1LS1              SFRS=0;CAPCON1|=0x08
+#define set_CAPCON1_CAP1LS0              SFRS=0;CAPCON1|=0x04
+#define set_CAPCON1_CAP0LS1              SFRS=0;CAPCON1|=0x02
+#define set_CAPCON1_CAP0LS0              SFRS=0;CAPCON1|=0x01
+
+#define clr_CAPCON1_CAP2LS1              SFRS=0;CAPCON1&=0xDF
+#define clr_CAPCON1_CAP2LS0              SFRS=0;CAPCON1&=0xEF
+#define clr_CAPCON1_CAP1LS1              SFRS=0;CAPCON1&=0xF7
+#define clr_CAPCON1_CAP1LS0              SFRS=0;CAPCON1&=0xFB
+#define clr_CAPCON1_CAP0LS1              SFRS=0;CAPCON1&=0xFD
+#define clr_CAPCON1_CAP0LS0              SFRS=0;CAPCON1&=0xFE
+
+/**** CAPCON2  94H  PAGE 0 ****/
+#define set_CAPCON2_ENF2                 SFRS=0;CAPCON2|=0x40
+#define set_CAPCON2_ENF1                 SFRS=0;CAPCON2|=0x20
+#define set_CAPCON2_ENF0                 SFRS=0;CAPCON2|=0x10
+
+#define clr_CAPCON2_ENF2                 SFRS=0;CAPCON2&=0xBF
+#define clr_CAPCON2_ENF1                 SFRS=0;CAPCON2&=0xDF
+#define clr_CAPCON2_ENF0                 SFRS=0;CAPCON2&=0xEF
+
+/**** CKSWT  96H  PAGE 0 TA protect register ****/
+#define set_CKSWT_HXTST                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x80;EA=BIT_TMP
+#define set_CKSWT_ECKP00ST               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x40;EA=BIT_TMP
+#define set_CKSWT_HIRCST                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_CKSWT_ECKP30ST               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_CKSWT_OSC1                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_CKSWT_OSC0                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+
+#define clr_CKSWT_HXTST                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0x7F;EA=BIT_TMP
+#define clr_CKSWT_ECKP00ST               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xBF;EA=BIT_TMP
+#define clr_CKSWT_HIRCST                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_CKSWT_ECKP30ST               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_CKSWT_OSC1                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_CKSWT_OSC0                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN  97H  PAGE 0 TA protect register ****/
+#define set_CKEN_EXTEN1                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_CKEN_EXTEN0                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_CKEN_HIRCEN                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKEN_LIRCEN                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x10;EA=BIT_TMP
+#define set_CKEN_CKSWTF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+
+#define clr_CKEN_EXTEN1                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_CKEN_EXTEN0                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_CKEN_HIRCEN                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKEN_LIRCEN                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xEF;EA=BIT_TMP
+#define clr_CKEN_CKSWTF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** EIE  9BH  PAGE 0 ****/
+#define set_EIE_ET2                      SFRS=0;EIE|=0x80
+#define set_EIE_ESPI                     SFRS=0;EIE|=0x40
+#define set_EIE_EFB                      SFRS=0;EIE|=0x20
+#define set_EIE_EWDT                     SFRS=0;EIE|=0x10
+#define set_EIE_EPWM0                    SFRS=0;EIE|=0x08
+#define set_EIE_ECAP                     SFRS=0;EIE|=0x04
+#define set_EIE_EPI                      SFRS=0;EIE|=0x02
+#define set_EIE_EI2C                     SFRS=0;EIE|=0x01
+
+#define clr_EIE_ET2                      SFRS=0;EIE&=0x7F
+#define clr_EIE_ESPI                     SFRS=0;EIE&=0xBF
+#define clr_EIE_EFB                      SFRS=0;EIE&=0xDF
+#define clr_EIE_EWDT                     SFRS=0;EIE&=0xEF
+#define clr_EIE_EPWM0                    SFRS=0;EIE&=0xF7
+#define clr_EIE_ECAP                     SFRS=0;EIE&=0xFB
+#define clr_EIE_EPI                      SFRS=0;EIE&=0xFD
+#define clr_EIE_EI2C                     SFRS=0;EIE&=0xFE
+
+/**** EIE1  9CH  PAGE 0 ****/
+#define set_EIE1_EPWM3                   SFRS=0;EIE1|=0x20
+#define set_EIE1_EPWM2                   SFRS=0;EIE1|=0x10
+#define set_EIE1_EPWM1                   SFRS=0;EIE1|=0x08
+#define set_EIE1_EWKT                    SFRS=0;EIE1|=0x04
+#define set_EIE1_ET3                     SFRS=0;EIE1|=0x02
+#define set_EIE1_ES_1                    SFRS=0;EIE1|=0x01
+
+#define clr_EIE1_EPWM3                   SFRS=0;EIE1&=0xDF
+#define clr_EIE1_EPWM2                   SFRS=0;EIE1&=0xEF
+#define clr_EIE1_EPWM1                   SFRS=0;EIE1&=0xF7
+#define clr_EIE1_EWKT                    SFRS=0;EIE1&=0xFB
+#define clr_EIE1_ET3                     SFRS=0;EIE1&=0xFD
+#define clr_EIE1_ES_1                    SFRS=0;EIE1&=0xFE
+
+/**** CHPCON  9FH  PAGE 0 TA protect register ****/
+#define set_CHPCON_SWRST                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_CHPCON_IAPFF                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_CHPCON_BS                    SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_CHPCON_IAPEN                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+
+#define clr_CHPCON_SWRST                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_CHPCON_IAPFF                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_CHPCON_BS                    SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_CHPCON_IAPEN                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** AUXR1  A2H  PAGE 0 ****/
+#define set_AUXR1_SWRF                   SFRS=0;AUXR1|=0x80
+#define set_AUXR1_RSTPINF                SFRS=0;AUXR1|=0x40
+#define set_AUXR1_HardF                  SFRS=0;AUXR1|=0x20
+#define set_AUXR1_GF2                    SFRS=0;AUXR1|=0x08
+#define set_AUXR1_UART0PX                SFRS=0;AUXR1|=0x04
+#define set_AUXR1_0                      SFRS=0;AUXR1|=0x02
+#define set_AUXR1_DPS                    SFRS=0;AUXR1|=0x01
+
+#define clr_AUXR1_SWRF                   SFRS=0;AUXR1&=0x7F
+#define clr_AUXR1_RSTPINF                SFRS=0;AUXR1&=0xBF
+#define clr_AUXR1_HardF                  SFRS=0;AUXR1&=0xDF
+#define clr_AUXR1_GF2                    SFRS=0;AUXR1&=0xF7
+#define clr_AUXR1_UART0PX                SFRS=0;AUXR1&=0xFB
+#define clr_AUXR1_0                      SFRS=0;AUXR1&=0xFD
+#define clr_AUXR1_DPS                    SFRS=0;AUXR1&=0xFE
+
+/**** BODCON0  A3H  PAGE 0 TA protect register ****/
+#define set_BODCON0_BODEN                SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BODCON0_BOV1                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BODCON0_BOV0                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BODCON0_BOF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BODCON0_BORST                SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BODCON0_BORF                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BODCON0_BOS                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+
+#define clr_BODCON0_BODEN                SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BODCON0_BOV1                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BODCON0_BOV0                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BODCON0_BOF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BODCON0_BORST                SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BODCON0_BORF                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BODCON0_BOS                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG  A4H  PAGE 0 TA protect register ****/
+#define set_IAPTRG_IAPGO                 SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define set_IAPTRG_IAPGO_WDCLR           SFRS=0;BIT_TMP=EA;EA=0;set_WDCON_WDCLR;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+
+/**** IAPUEN  A5H  PAGE 0 TA protect register ****/
+#define set_IAPUEN_SPMEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x10;EA=BIT_TMP
+#define set_IAPUEN_SPUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x08;EA=BIT_TMP
+#define set_IAPUEN_CFUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_IAPUEN_LDUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_IAPUEN_APUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+ 
+#define clr_IAPUEN_SPMEM   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xEF;EA=BIT_TMP
+#define clr_IAPUEN_SPUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xF7;EA=BIT_TMP
+#define clr_IAPUEN_CFUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_IAPUEN_LDUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_IAPUEN_APUEN   BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** WDCON  AAH  PAGE 0 TA protect register ****/
+#define set_WDCON_WDTR                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCON_WDCLR                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDCON_WDTF                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WDCON_WIDPD                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDCON_WDTRF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WDCON_WDPS2                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WDCON_WDPS1                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WDCON_WDPS0                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+
+#define clr_WDCON_WDTR                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCON_WDCLR                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDCON_WDTF                   SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDCON_WIDPD                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xEF;EA=BIT_TMP
+#define clr_WDCON_WDTRF                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WDCON_WDPS2                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WDCON_WDPS1                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WDCON_WDPS0                  SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1  ABH  PAGE 0 TA protect register ****/
+#define set_BODCON1_LPBOD1               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_BODCON1_LPBOD0               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODCON1_BODFLT               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+
+#define clr_BODCON1_LPBOD1               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_BODCON1_LPBOD0               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODCON1_BODFLT               SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** P3M1  ACH  PAGE 0 ****/
+#define set_P3M1_7                       SFRS=0;P3M1|=0x80
+#define set_P3M1_6                       SFRS=0;P3M1|=0x40
+#define set_P3M1_5                       SFRS=0;P3M1|=0x20
+#define set_P3M1_4                       SFRS=0;P3M1|=0x10
+#define set_P3M1_3                       SFRS=0;P3M1|=0x08
+#define set_P3M1_2                       SFRS=0;P3M1|=0x04
+#define set_P3M1_1                       SFRS=0;P3M1|=0x02
+#define set_P3M1_0                       SFRS=0;P3M1|=0x01
+
+#define clr_P3M1_7                       SFRS=0;P3M1&=0x7F
+#define clr_P3M1_6                       SFRS=0;P3M1&=0xBF
+#define clr_P3M1_5                       SFRS=0;P3M1&=0xDF
+#define clr_P3M1_4                       SFRS=0;P3M1&=0xEF
+#define clr_P3M1_3                       SFRS=0;P3M1&=0xF7
+#define clr_P3M1_2                       SFRS=0;P3M1&=0xFB
+#define clr_P3M1_1                       SFRS=0;P3M1&=0xFD
+#define clr_P3M1_0                       SFRS=0;P3M1&=0xFE
+
+/**** P3M2  ADH  PAGE 0 ****/
+#define set_P3M2_7                       SFRS=0;P3M2|=0x80
+#define set_P3M2_6                       SFRS=0;P3M2|=0x40
+#define set_P3M2_5                       SFRS=0;P3M2|=0x20
+#define set_P3M2_4                       SFRS=0;P3M2|=0x10
+#define set_P3M2_3                       SFRS=0;P3M2|=0x08
+#define set_P3M2_2                       SFRS=0;P3M2|=0x04
+#define set_P3M2_1                       SFRS=0;P3M2|=0x02
+#define set_P3M2_0                       SFRS=0;P3M2|=0x01
+
+#define clr_P3M2_7                       SFRS=0;P3M2&=0x7F
+#define clr_P3M2_6                       SFRS=0;P3M2&=0xBF
+#define clr_P3M2_5                       SFRS=0;P3M2&=0xDF
+#define clr_P3M2_4                       SFRS=0;P3M2&=0xEF
+#define clr_P3M2_3                       SFRS=0;P3M2&=0xF7
+#define clr_P3M2_2                       SFRS=0;P3M2&=0xFB
+#define clr_P3M2_1                       SFRS=0;P3M2&=0xFD
+#define clr_P3M2_0                       SFRS=0;P3M2&=0xFE
+
+/**** IAPCN  AFH  PAGE 0 ****/
+#define set_IAPCN_IAPA17                 SFRS=0;IAPCN|=0x80
+#define set_IAPCN_IAPA16                 SFRS=0;IAPCN|=0x40
+#define set_IAPCN_FOEN                   SFRS=0;IAPCN|=0x20
+#define set_IAPCN_FCEN                   SFRS=0;IAPCN|=0x10
+#define set_IAPCN_FCTRL3                 SFRS=0;IAPCN|=0x08
+#define set_IAPCN_FCTRL2                 SFRS=0;IAPCN|=0x04
+#define set_IAPCN_FCTRL1                 SFRS=0;IAPCN|=0x02
+#define set_IAPCN_FCTRL0                 SFRS=0;IAPCN|=0x01
+
+#define clr_IAPCN_IAPA17                 SFRS=0;IAPCN&=0x7F
+#define clr_IAPCN_IAPA16                 SFRS=0;IAPCN&=0xBF
+#define clr_IAPCN_FOEN                   SFRS=0;IAPCN&=0xDF
+#define clr_IAPCN_FCEN                   SFRS=0;IAPCN&=0xEF
+#define clr_IAPCN_FCTRL3                 SFRS=0;IAPCN&=0xF7
+#define clr_IAPCN_FCTRL2                 SFRS=0;IAPCN&=0xFB
+#define clr_IAPCN_FCTRL1                 SFRS=0;IAPCN&=0xFD
+#define clr_IAPCN_FCTRL0                 SFRS=0;IAPCN&=0xFE
+
+/**** P0M1  B1H  PAGE 0 ****/
+#define set_P0M1_7                       SFRS=0;P0M1|=0x80
+#define set_P0M1_6                       SFRS=0;P0M1|=0x40
+#define set_P0M1_5                       SFRS=0;P0M1|=0x20
+#define set_P0M1_4                       SFRS=0;P0M1|=0x10
+#define set_P0M1_3                       SFRS=0;P0M1|=0x08
+#define set_P0M1_2                       SFRS=0;P0M1|=0x04
+#define set_P0M1_1                       SFRS=0;P0M1|=0x02
+#define set_P0M1_0                       SFRS=0;P0M1|=0x01
+
+#define clr_P0M1_7                       SFRS=0;P0M1&=0x7F
+#define clr_P0M1_6                       SFRS=0;P0M1&=0xBF
+#define clr_P0M1_5                       SFRS=0;P0M1&=0xDF
+#define clr_P0M1_4                       SFRS=0;P0M1&=0xEF
+#define clr_P0M1_3                       SFRS=0;P0M1&=0xF7
+#define clr_P0M1_2                       SFRS=0;P0M1&=0xFB
+#define clr_P0M1_1                       SFRS=0;P0M1&=0xFD
+#define clr_P0M1_0                       SFRS=0;P0M1&=0xFE
+
+/**** P0M2  B2H  PAGE 0 ****/
+#define set_P0M2_7                       SFRS=0;P0M2|=0x80
+#define set_P0M2_6                       SFRS=0;P0M2|=0x40
+#define set_P0M2_5                       SFRS=0;P0M2|=0x20
+#define set_P0M2_4                       SFRS=0;P0M2|=0x10
+#define set_P0M2_3                       SFRS=0;P0M2|=0x08
+#define set_P0M2_2                       SFRS=0;P0M2|=0x04
+#define set_P0M2_1                       SFRS=0;P0M2|=0x02
+#define set_P0M2_0                       SFRS=0;P0M2|=0x01
+
+#define clr_P0M2_7                       SFRS=0;P0M2&=0x7F
+#define clr_P0M2_6                       SFRS=0;P0M2&=0xBF
+#define clr_P0M2_5                       SFRS=0;P0M2&=0xDF
+#define clr_P0M2_4                       SFRS=0;P0M2&=0xEF
+#define clr_P0M2_3                       SFRS=0;P0M2&=0xF7
+#define clr_P0M2_2                       SFRS=0;P0M2&=0xFB
+#define clr_P0M2_1                       SFRS=0;P0M2&=0xFD
+#define clr_P0M2_0                       SFRS=0;P0M2&=0xFE
+
+/**** P1M1  B3H  PAGE 0 ****/
+#define set_P1M1_7                       SFRS=0;P1M1|=0x80
+#define set_P1M1_6                       SFRS=0;P1M1|=0x40
+#define set_P1M1_5                       SFRS=0;P1M1|=0x20
+#define set_P1M1_4                       SFRS=0;P1M1|=0x10
+#define set_P1M1_3                       SFRS=0;P1M1|=0x08
+#define set_P1M1_2                       SFRS=0;P1M1|=0x04
+#define set_P1M1_1                       SFRS=0;P1M1|=0x02
+#define set_P1M1_0                       SFRS=0;P1M1|=0x01
+
+#define clr_P1M1_7                       SFRS=0;P1M1&=0x7F
+#define clr_P1M1_6                       SFRS=0;P1M1&=0xBF
+#define clr_P1M1_5                       SFRS=0;P1M1&=0xDF
+#define clr_P1M1_4                       SFRS=0;P1M1&=0xEF
+#define clr_P1M1_3                       SFRS=0;P1M1&=0xF7
+#define clr_P1M1_2                       SFRS=0;P1M1&=0xFB
+#define clr_P1M1_1                       SFRS=0;P1M1&=0xFD
+#define clr_P1M1_0                       SFRS=0;P1M1&=0xFE
+
+/**** P1M2  B4H  PAGE 0 ****/
+#define set_P1M2_7                       SFRS=0;P1M2|=0x80
+#define set_P1M2_6                       SFRS=0;P1M2|=0x40
+#define set_P1M2_5                       SFRS=0;P1M2|=0x20
+#define set_P1M2_4                       SFRS=0;P1M2|=0x10
+#define set_P1M2_3                       SFRS=0;P1M2|=0x08
+#define set_P1M2_2                       SFRS=0;P1M2|=0x04
+#define set_P1M2_1                       SFRS=0;P1M2|=0x02
+#define set_P1M2_0                       SFRS=0;P1M2|=0x01
+
+#define clr_P1M2_7                       SFRS=0;P1M2&=0x7F
+#define clr_P1M2_6                       SFRS=0;P1M2&=0xBF
+#define clr_P1M2_5                       SFRS=0;P1M2&=0xDF
+#define clr_P1M2_4                       SFRS=0;P1M2&=0xEF
+#define clr_P1M2_3                       SFRS=0;P1M2&=0xF7
+#define clr_P1M2_2                       SFRS=0;P1M2&=0xFB
+#define clr_P1M2_1                       SFRS=0;P1M2&=0xFD
+#define clr_P1M2_0                       SFRS=0;P1M2&=0xFE
+
+/**** TOE  B5H  PAGE 0 ****/
+#define set_TOE_T1OE                     SFRS=0;TOE|=0x08
+#define set_TOE_T0OE                     SFRS=0;TOE|=0x04
+
+#define clr_TOE_T1OE                     SFRS=0;TOE&=0xF7
+#define clr_TOE_T0OE                     SFRS=0;TOE&=0xFB
+
+/**** IPH  B7H  PAGE 0 ****/
+#define set_IPH_PADCH                    SFRS=0;IPH|=0x40
+#define set_IPH_PBODH                    SFRS=0;IPH|=0x20
+#define set_IPH_PSH                      SFRS=0;IPH|=0x10
+#define set_IPH_PT1H                     SFRS=0;IPH|=0x08
+#define set_IPH_PX1H                     SFRS=0;IPH|=0x04
+#define set_IPH_PT0H                     SFRS=0;IPH|=0x02
+#define set_IPH_PX0H                     SFRS=0;IPH|=0x01
+
+#define clr_IPH_PADCH                    SFRS=0;IPH&=0xBF
+#define clr_IPH_PBODH                    SFRS=0;IPH&=0xDF
+#define clr_IPH_PSH                      SFRS=0;IPH&=0xEF
+#define clr_IPH_PT1H                     SFRS=0;IPH&=0xF7
+#define clr_IPH_PX1H                     SFRS=0;IPH&=0xFB
+#define clr_IPH_PT0H                     SFRS=0;IPH&=0xFD
+#define clr_IPH_PX0H                     SFRS=0;IPH&=0xFE
+
+/**** I2STAT  BDH  PAGE 0 ****/
+#define set_I2STAT_I2STAT7               SFRS=0;I2STAT|=0x80
+#define set_I2STAT_I2STAT6               SFRS=0;I2STAT|=0x40
+#define set_I2STAT_I2STAT5               SFRS=0;I2STAT|=0x20
+#define set_I2STAT_I2STAT4               SFRS=0;I2STAT|=0x10
+#define set_I2STAT_I2STAT3               SFRS=0;I2STAT|=0x08
+
+
+#define clr_I2STAT_I2STAT7               SFRS=0;I2STAT&=0x7F
+#define clr_I2STAT_I2STAT6               SFRS=0;I2STAT&=0xBF
+#define clr_I2STAT_I2STAT5               SFRS=0;I2STAT&=0xDF
+#define clr_I2STAT_I2STAT4               SFRS=0;I2STAT&=0xEF
+#define clr_I2STAT_I2STAT3               SFRS=0;I2STAT&=0xF7
+
+
+/**** I2TOC  BFH  PAGE 0 ****/
+#define set_I2TOC_I2TOCEN                SFRS=0;I2TOC|=0x04
+#define set_I2TOC_DIV                    SFRS=0;I2TOC|=0x02
+#define set_I2TOC_I2TOF                  SFRS=0;I2TOC|=0x01
+
+#define clr_I2TOC_I2TOCEN                SFRS=0;I2TOC&=0xFB
+#define clr_I2TOC_DIV                    SFRS=0;I2TOC&=0xFD
+#define clr_I2TOC_I2TOF                  SFRS=0;I2TOC&=0xFE
+
+/**** I2ADDR  C1H  PAGE 0 ****/
+#define set_I2ADDR_I2ADDR7               SFRS=0;I2ADDR|=0x80
+#define set_I2ADDR_I2ADDR6               SFRS=0;I2ADDR|=0x40
+#define set_I2ADDR_I2ADDR5               SFRS=0;I2ADDR|=0x20
+#define set_I2ADDR_I2ADDR4               SFRS=0;I2ADDR|=0x10
+#define set_I2ADDR_I2ADDR3               SFRS=0;I2ADDR|=0x08
+#define set_I2ADDR_I2ADDR2               SFRS=0;I2ADDR|=0x04
+#define set_I2ADDR_I2ADDR1               SFRS=0;I2ADDR|=0x02
+#define set_I2ADDR_GC                    SFRS=0;I2ADDR|=0x01
+
+#define clr_I2ADDR_I2ADDR7               SFRS=0;I2ADDR&=0x7F
+#define clr_I2ADDR_I2ADDR6               SFRS=0;I2ADDR&=0xBF
+#define clr_I2ADDR_I2ADDR5               SFRS=0;I2ADDR&=0xDF
+#define clr_I2ADDR_I2ADDR4               SFRS=0;I2ADDR&=0xEF
+#define clr_I2ADDR_I2ADDR3               SFRS=0;I2ADDR&=0xF7
+#define clr_I2ADDR_I2ADDR2               SFRS=0;I2ADDR&=0xFB
+#define clr_I2ADDR_I2ADDR1               SFRS=0;I2ADDR&=0xFD
+#define clr_I2ADDR_GC                    SFRS=0;I2ADDR&=0xFE
+
+/**** ADCRL  C2H  PAGE 0 ****/
+#define set_ADCRL_ADCR3                  SFRS=0;ADCRL|=0x08
+#define set_ADCRL_ADCR2                  SFRS=0;ADCRL|=0x04
+#define set_ADCRL_ADCR1                  SFRS=0;ADCRL|=0x02
+#define set_ADCRL_ADCR0                  SFRS=0;ADCRL|=0x01
+
+#define clr_ADCRL_ADCR3                  SFRS=0;ADCRL&=0xF7
+#define clr_ADCRL_ADCR2                  SFRS=0;ADCRL&=0xFB
+#define clr_ADCRL_ADCR1                  SFRS=0;ADCRL&=0xFD
+#define clr_ADCRL_ADCR0                  SFRS=0;ADCRL&=0xFE
+
+/**** T3CON  C4H  PAGE 0 ****/
+#define set_T3CON_SMOD_1                 SFRS=0;T3CON|=0x80
+#define set_T3CON_SMOD0_1                SFRS=0;T3CON|=0x40
+#define set_T3CON_BRCK                   SFRS=0;T3CON|=0x20
+#define set_T3CON_TF3                    SFRS=0;T3CON|=0x10
+#define set_T3CON_TR3                    SFRS=0;T3CON|=0x08
+#define set_T3CON_T3PS2                  SFRS=0;T3CON|=0x04
+#define set_T3CON_T3PS1                  SFRS=0;T3CON|=0x02
+#define set_T3CON_T3PS0                  SFRS=0;T3CON|=0x01
+
+#define clr_T3CON_SMOD_1                 SFRS=0;T3CON&=0x7F
+#define clr_T3CON_SMOD0_1                SFRS=0;T3CON&=0xBF
+#define clr_T3CON_BRCK                   SFRS=0;T3CON&=0xDF
+#define clr_T3CON_TF3                    SFRS=0;T3CON&=0xEF
+#define clr_T3CON_TR3                    SFRS=0;T3CON&=0xF7
+#define clr_T3CON_T3PS2                  SFRS=0;T3CON&=0xFB
+#define clr_T3CON_T3PS1                  SFRS=0;T3CON&=0xFD
+#define clr_T3CON_T3PS0                  SFRS=0;T3CON&=0xFE
+
+/**** T2MOD  C9H  PAGE 0 ****/
+#define set_T2MOD_LDEN                   SFRS=0;T2MOD|=0x80
+#define set_T2MOD_T2DIV2                 SFRS=0;T2MOD|=0x40
+#define set_T2MOD_T2DIV1                 SFRS=0;T2MOD|=0x20
+#define set_T2MOD_T2DIV0                 SFRS=0;T2MOD|=0x10
+#define set_T2MOD_CAPCR                  SFRS=0;T2MOD|=0x08
+#define set_T2MOD_CMPCR                  SFRS=0;T2MOD|=0x04
+#define set_T2MOD_LDTS1                  SFRS=0;T2MOD|=0x02
+#define set_T2MOD_LDTS0                  SFRS=0;T2MOD|=0x01
+
+#define clr_T2MOD_LDEN                   SFRS=0;T2MOD&=0x7F
+#define clr_T2MOD_T2DIV2                 SFRS=0;T2MOD&=0xBF
+#define clr_T2MOD_T2DIV1                 SFRS=0;T2MOD&=0xDF
+#define clr_T2MOD_T2DIV0                 SFRS=0;T2MOD&=0xEF
+#define clr_T2MOD_CAPCR                  SFRS=0;T2MOD&=0xF7
+#define clr_T2MOD_CMPCR                  SFRS=0;T2MOD&=0xFB
+#define clr_T2MOD_LDTS1                  SFRS=0;T2MOD&=0xFD
+#define clr_T2MOD_LDTS0                  SFRS=0;T2MOD&=0xFE
+
+/**** ADCMPL  CEH  PAGE 0 ****/
+#define set_ADCMPL_ADCMP3                SFRS=0;ADCMPL|=0x08
+#define set_ADCMPL_ADCMP2                SFRS=0;ADCMPL|=0x04
+#define set_ADCMPL_ADCMP1                SFRS=0;ADCMPL|=0x02
+#define set_ADCMPL_ADCMP0                SFRS=0;ADCMPL|=0x01
+
+#define clr_ADCMPL_ADCMP3                SFRS=0;ADCMPL&=0xF7
+#define clr_ADCMPL_ADCMP2                SFRS=0;ADCMPL&=0xFB
+#define clr_ADCMPL_ADCMP1                SFRS=0;ADCMPL&=0xFD
+#define clr_ADCMPL_ADCMP0                SFRS=0;ADCMPL&=0xFE
+
+/**** PNP  D6H  PAGE 0 ****/
+#define set_PNP_PNP5                     SFRS=0;PNP|=0x20
+#define set_PNP_PNP4                     SFRS=0;PNP|=0x10
+#define set_PNP_PNP3                     SFRS=0;PNP|=0x08
+#define set_PNP_PNP2                     SFRS=0;PNP|=0x04
+#define set_PNP_PNP1                     SFRS=0;PNP|=0x02
+#define set_PNP_PNP0                     SFRS=0;PNP|=0x01
+
+#define clr_PNP_PNP5                     SFRS=0;PNP&=0xDF
+#define clr_PNP_PNP4                     SFRS=0;PNP&=0xEF
+#define clr_PNP_PNP3                     SFRS=0;PNP&=0xF7
+#define clr_PNP_PNP2                     SFRS=0;PNP&=0xFB
+#define clr_PNP_PNP1                     SFRS=0;PNP&=0xFD
+#define clr_PNP_PNP0                     SFRS=0;PNP&=0xFE
+
+/**** PWM0FBD  D7H  PAGE 0 ****/
+#define set_PWM0FBD_FBF                  SFRS=0;PWM0FBD|=0x80
+#define set_PWM0FBD_FBINLS               SFRS=0;PWM0FBD|=0x40
+#define set_PWM0FBD_FBD5                 SFRS=0;PWM0FBD|=0x20
+#define set_PWM0FBD_FBD4                 SFRS=0;PWM0FBD|=0x10
+#define set_PWM0FBD_FBD3                 SFRS=0;PWM0FBD|=0x08
+#define set_PWM0FBD_FBD2                 SFRS=0;PWM0FBD|=0x04
+#define set_PWM0FBD_FBD1                 SFRS=0;PWM0FBD|=0x02
+#define set_PWM0FBD_R                    SFRS=0;PWM0FBD|=0x01
+#define set_PWM0FBD_W                    SFRS=0;PWM0FBD|=0x01
+
+#define clr_PWM0FBD_FBF                  SFRS=0;PWM0FBD&=0x7F
+#define clr_PWM0FBD_FBINLS               SFRS=0;PWM0FBD&=0xBF
+#define clr_PWM0FBD_FBD5                 SFRS=0;PWM0FBD&=0xDF
+#define clr_PWM0FBD_FBD4                 SFRS=0;PWM0FBD&=0xEF
+#define clr_PWM0FBD_FBD3                 SFRS=0;PWM0FBD&=0xF7
+#define clr_PWM0FBD_FBD2                 SFRS=0;PWM0FBD&=0xFB
+#define clr_PWM0FBD_FBD1                 SFRS=0;PWM0FBD&=0xFD
+#define clr_PWM0FBD_R                    SFRS=0;PWM0FBD&=0xFE
+#define clr_PWM0FBD_W                    SFRS=0;PWM0FBD&=0xFE
+
+/**** PIOCON0  DEH  PAGE 0 ****/
+#define set_PIOCON0_PIO03           SFRS=0;PIOCON0|=0x20
+#define set_PIOCON0_PIO01           SFRS=0;PIOCON0|=0x10
+#define set_PIOCON0_PIO00           SFRS=0;PIOCON0|=0x08
+#define set_PIOCON0_PIO10           SFRS=0;PIOCON0|=0x04
+#define set_PIOCON0_PIO11           SFRS=0;PIOCON0|=0x02
+#define set_PIOCON0_PIO12           SFRS=0;PIOCON0|=0x01
+
+#define clr_PIOCON0_PIO03           SFRS=0;PIOCON0&=0xDF
+#define clr_PIOCON0_PIO01           SFRS=0;PIOCON0&=0xEF
+#define clr_PIOCON0_PIO00           SFRS=0;PIOCON0&=0xF7
+#define clr_PIOCON0_PIO10           SFRS=0;PIOCON0&=0xFB
+#define clr_PIOCON0_PIO11           SFRS=0;PIOCON0&=0xFD
+#define clr_PIOCON0_PIO12           SFRS=0;PIOCON0&=0xFE
+
+/**** PWM0CON1  DFH  PAGE 0 ****/
+#define set_PWM0CON1_PWMMOD1             SFRS=0;PWM0CON1|=0x80
+#define set_PWM0CON1_PWMMOD0             SFRS=0;PWM0CON1|=0x40
+#define set_PWM0CON1_GP                  SFRS=0;PWM0CON1|=0x20
+#define set_PWM0CON1_PWMTYP              SFRS=0;PWM0CON1|=0x10
+#define set_PWM0CON1_FBINEN              SFRS=0;PWM0CON1|=0x08
+#define set_PWM0CON1_PWMDIV2             SFRS=0;PWM0CON1|=0x04
+#define set_PWM0CON1_PWMDIV1             SFRS=0;PWM0CON1|=0x02
+#define set_PWM0CON1_PWMDIV0             SFRS=0;PWM0CON1|=0x01
+
+#define clr_PWM0CON1_PWMMOD1             SFRS=0;PWM0CON1&=0x7F
+#define clr_PWM0CON1_PWMMOD0             SFRS=0;PWM0CON1&=0xBF
+#define clr_PWM0CON1_GP                  SFRS=0;PWM0CON1&=0xDF
+#define clr_PWM0CON1_PWMTYP              SFRS=0;PWM0CON1&=0xEF
+#define clr_PWM0CON1_FBINEN              SFRS=0;PWM0CON1&=0xF7
+#define clr_PWM0CON1_PWMDIV2             SFRS=0;PWM0CON1&=0xFB
+#define clr_PWM0CON1_PWMDIV1             SFRS=0;PWM0CON1&=0xFD
+#define clr_PWM0CON1_PWMDIV0             SFRS=0;PWM0CON1&=0xFE
+
+/**** ADCCON1  E1H  PAGE 0 ****/
+#define set_ADCCON1_OCEN                 SFRS=0;ADCCON1|=0x80
+#define set_ADCCON1_STADCPX              SFRS=0;ADCCON1|=0x40
+#define set_ADCCON1_ADCDIV1              SFRS=0;ADCCON1|=0x20
+#define set_ADCCON1_ADCDIV0              SFRS=0;ADCCON1|=0x10
+#define set_ADCCON1_ETGTYP1              SFRS=0;ADCCON1|=0x08
+#define set_ADCCON1_ETGTYP0              SFRS=0;ADCCON1|=0x04
+#define set_ADCCON1_ADCEX                SFRS=0;ADCCON1|=0x02
+#define set_ADCCON1_ADCEN                SFRS=0;ADCCON1|=0x01
+
+#define clr_ADCCON1_OCEN                 SFRS=0;ADCCON1&=0x7F
+#define clr_ADCCON1_STADCPX              SFRS=0;ADCCON1&=0xBF
+#define clr_ADCCON1_ADCDIV1              SFRS=0;ADCCON1&=0xDF
+#define clr_ADCCON1_ADCDIV0              SFRS=0;ADCCON1&=0xEF
+#define clr_ADCCON1_ETGTYP1              SFRS=0;ADCCON1&=0xF7
+#define clr_ADCCON1_ETGTYP0              SFRS=0;ADCCON1&=0xFB
+#define clr_ADCCON1_ADCEX                SFRS=0;ADCCON1&=0xFD
+#define clr_ADCCON1_ADCEN                SFRS=0;ADCCON1&=0xFE
+
+/**** ADCCON2  E2H  PAGE 0 ****/
+#define set_ADCCON2_ADFBEN               SFRS=0;ADCCON2|=0x80
+#define set_ADCCON2_ADCMPOP              SFRS=0;ADCCON2|=0x40
+#define set_ADCCON2_ADCMPEN              SFRS=0;ADCCON2|=0x20
+#define set_ADCCON2_ADCMPO               SFRS=0;ADCCON2|=0x10
+#define set_ADCCON2_ADCAQT0_2            SFRS=0;ADCCON2|=0x08
+#define set_ADCCON2_ADCAQT0_1            SFRS=0;ADCCON2|=0x04
+#define set_ADCCON2_ADCAQT0_0            SFRS=0;ADCCON2|=0x02
+#define set_ADCCON2_ADCDLY_8             SFRS=0;ADCCON2|=0x01
+
+#define clr_ADCCON2_ADFBEN               SFRS=0;ADCCON2&=0x7F
+#define clr_ADCCON2_ADCMPOP              SFRS=0;ADCCON2&=0xBF
+#define clr_ADCCON2_ADCMPEN              SFRS=0;ADCCON2&=0xDF
+#define clr_ADCCON2_ADCMPO               SFRS=0;ADCCON2&=0xEF
+#define clr_ADCCON2_ADCAQT0_2            SFRS=0;ADCCON2&=0xF7
+#define clr_ADCCON2_ADCAQT0_1            SFRS=0;ADCCON2&=0xFB
+#define clr_ADCCON2_ADCAQT0_0            SFRS=0;ADCCON2&=0xFD
+#define clr_ADCCON2_ADCDLY_8             SFRS=0;ADCCON2&=0xFE
+
+/**** PICON  E9H  PAGE 0 ****/
+#define set_PICON_PIT7                   SFRS=0;PICON|=0x80
+#define set_PICON_PIT6                   SFRS=0;PICON|=0x40
+#define set_PICON_PIT5                   SFRS=0;PICON|=0x20
+#define set_PICON_PIT4                   SFRS=0;PICON|=0x10
+#define set_PICON_PIT3                   SFRS=0;PICON|=0x08
+#define set_PICON_PIT2                   SFRS=0;PICON|=0x04
+#define set_PICON_PIT1                   SFRS=0;PICON|=0x02
+#define set_PICON_PIT0                   SFRS=0;PICON|=0x01
+
+#define clr_PICON_PIT7                   SFRS=0;PICON&=0x7F
+#define clr_PICON_PIT6                   SFRS=0;PICON&=0xBF
+#define clr_PICON_PIT5                   SFRS=0;PICON&=0xDF
+#define clr_PICON_PIT4                   SFRS=0;PICON&=0xEF
+#define clr_PICON_PIT3                   SFRS=0;PICON&=0xF7
+#define clr_PICON_PIT2                   SFRS=0;PICON&=0xFB
+#define clr_PICON_PIT1                   SFRS=0;PICON&=0xFD
+#define clr_PICON_PIT0                   SFRS=0;PICON&=0xFE
+
+/**** PINEN  EAH  PAGE 0 ****/
+#define set_PINEN_PINEN7                 SFRS=0;PINEN|=0x80
+#define set_PINEN_PINEN6                 SFRS=0;PINEN|=0x40
+#define set_PINEN_PINEN5                 SFRS=0;PINEN|=0x20
+#define set_PINEN_PINEN4                 SFRS=0;PINEN|=0x10
+#define set_PINEN_PINEN3                 SFRS=0;PINEN|=0x08
+#define set_PINEN_PINEN2                 SFRS=0;PINEN|=0x04
+#define set_PINEN_PINEN1                 SFRS=0;PINEN|=0x02
+#define set_PINEN_PINEN0                 SFRS=0;PINEN|=0x01
+
+#define clr_PINEN_PINEN7                 SFRS=0;PINEN&=0x7F
+#define clr_PINEN_PINEN6                 SFRS=0;PINEN&=0xBF
+#define clr_PINEN_PINEN5                 SFRS=0;PINEN&=0xDF
+#define clr_PINEN_PINEN4                 SFRS=0;PINEN&=0xEF
+#define clr_PINEN_PINEN3                 SFRS=0;PINEN&=0xF7
+#define clr_PINEN_PINEN2                 SFRS=0;PINEN&=0xFB
+#define clr_PINEN_PINEN1                 SFRS=0;PINEN&=0xFD
+#define clr_PINEN_PINEN0                 SFRS=0;PINEN&=0xFE
+
+/**** PIPEN  EBH  PAGE 0 ****/
+#define set_PIPEN_PIPEN7                 SFRS=0;PIPEN|=0x80
+#define set_PIPEN_PIPEN6                 SFRS=0;PIPEN|=0x40
+#define set_PIPEN_PIPEN5                 SFRS=0;PIPEN|=0x20
+#define set_PIPEN_PIPEN4                 SFRS=0;PIPEN|=0x10
+#define set_PIPEN_PIPEN3                 SFRS=0;PIPEN|=0x08
+#define set_PIPEN_PIPEN2                 SFRS=0;PIPEN|=0x04
+#define set_PIPEN_PIPEN1                 SFRS=0;PIPEN|=0x02
+#define set_PIPEN_PIPEN0                 SFRS=0;PIPEN|=0x01
+
+#define clr_PIPEN_PIPEN7                 SFRS=0;PIPEN&=0x7F
+#define clr_PIPEN_PIPEN6                 SFRS=0;PIPEN&=0xBF
+#define clr_PIPEN_PIPEN5                 SFRS=0;PIPEN&=0xDF
+#define clr_PIPEN_PIPEN4                 SFRS=0;PIPEN&=0xEF
+#define clr_PIPEN_PIPEN3                 SFRS=0;PIPEN&=0xF7
+#define clr_PIPEN_PIPEN2                 SFRS=0;PIPEN&=0xFB
+#define clr_PIPEN_PIPEN1                 SFRS=0;PIPEN&=0xFD
+#define clr_PIPEN_PIPEN0                 SFRS=0;PIPEN&=0xFE
+
+/**** PIF  ECH  PAGE 0 ****/
+#define set_PIF_PIF7                     SFRS=0;PIF|=0x80
+#define set_PIF_PIF6                     SFRS=0;PIF|=0x40
+#define set_PIF_PIF5                     SFRS=0;PIF|=0x20
+#define set_PIF_PIF4                     SFRS=0;PIF|=0x10
+#define set_PIF_PIF3                     SFRS=0;PIF|=0x08
+#define set_PIF_PIF2                     SFRS=0;PIF|=0x04
+#define set_PIF_PIF1                     SFRS=0;PIF|=0x02
+#define set_PIF_PIF0                     SFRS=0;PIF|=0x01
+
+#define clr_PIF_PIF7                     SFRS=0;PIF&=0x7F
+#define clr_PIF_PIF6                     SFRS=0;PIF&=0xBF
+#define clr_PIF_PIF5                     SFRS=0;PIF&=0xDF
+#define clr_PIF_PIF4                     SFRS=0;PIF&=0xEF
+#define clr_PIF_PIF3                     SFRS=0;PIF&=0xF7
+#define clr_PIF_PIF2                     SFRS=0;PIF&=0xFB
+#define clr_PIF_PIF1                     SFRS=0;PIF&=0xFD
+#define clr_PIF_PIF0                     SFRS=0;PIF&=0xFE
+
+/**** EIP  EFH  PAGE 0 ****/
+#define set_EIP_PT2                      SFRS=0;EIP|=0x80
+#define set_EIP_PSPI                     SFRS=0;EIP|=0x40
+#define set_EIP_PFB                      SFRS=0;EIP|=0x20
+#define set_EIP_PWDT                     SFRS=0;EIP|=0x10
+#define set_EIP_PPWM                     SFRS=0;EIP|=0x08
+#define set_EIP_PCAP                     SFRS=0;EIP|=0x04
+#define set_EIP_PPI                      SFRS=0;EIP|=0x02
+#define set_EIP_PI2C                     SFRS=0;EIP|=0x01
+
+#define clr_EIP_PT2                      SFRS=0;EIP&=0x7F
+#define clr_EIP_PSPI                     SFRS=0;EIP&=0xBF
+#define clr_EIP_PFB                      SFRS=0;EIP&=0xDF
+#define clr_EIP_PWDT                     SFRS=0;EIP&=0xEF
+#define clr_EIP_PPWM                     SFRS=0;EIP&=0xF7
+#define clr_EIP_PCAP                     SFRS=0;EIP&=0xFB
+#define clr_EIP_PPI                      SFRS=0;EIP&=0xFD
+#define clr_EIP_PI2C                     SFRS=0;EIP&=0xFE
+
+/**** CAPCON3  F1H  PAGE 0 ****/
+#define set_CAPCON3_CAP13                SFRS=0;CAPCON3|=0x80
+#define set_CAPCON3_CAP12                SFRS=0;CAPCON3|=0x40
+#define set_CAPCON3_CAP11                SFRS=0;CAPCON3|=0x20
+#define set_CAPCON3_CAP10                SFRS=0;CAPCON3|=0x10
+#define set_CAPCON3_CAP03                SFRS=0;CAPCON3|=0x08
+#define set_CAPCON3_CAP02                SFRS=0;CAPCON3|=0x04
+#define set_CAPCON3_CAP01                SFRS=0;CAPCON3|=0x02
+#define set_CAPCON3_CAP00                SFRS=0;CAPCON3|=0x01
+
+#define clr_CAPCON3_CAP13                SFRS=0;CAPCON3&=0x7F
+#define clr_CAPCON3_CAP12                SFRS=0;CAPCON3&=0xBF
+#define clr_CAPCON3_CAP11                SFRS=0;CAPCON3&=0xDF
+#define clr_CAPCON3_CAP10                SFRS=0;CAPCON3&=0xEF
+#define clr_CAPCON3_CAP03                SFRS=0;CAPCON3&=0xF7
+#define clr_CAPCON3_CAP02                SFRS=0;CAPCON3&=0xFB
+#define clr_CAPCON3_CAP01                SFRS=0;CAPCON3&=0xFD
+#define clr_CAPCON3_CAP00                SFRS=0;CAPCON3&=0xFE
+
+/**** CAPCON4  F2H  PAGE 0 ****/
+#define set_CAPCON4_CAP23                SFRS=0;CAPCON4|=0x08
+#define set_CAPCON4_CAP22                SFRS=0;CAPCON4|=0x04
+#define set_CAPCON4_CAP21                SFRS=0;CAPCON4|=0x02
+#define set_CAPCON4_CAP20                SFRS=0;CAPCON4|=0x01
+
+#define clr_CAPCON4_CAP23                SFRS=0;CAPCON4&=0xF7
+#define clr_CAPCON4_CAP22                SFRS=0;CAPCON4&=0xFB
+#define clr_CAPCON4_CAP21                SFRS=0;CAPCON4&=0xFD
+#define clr_CAPCON4_CAP20                SFRS=0;CAPCON4&=0xFE
+
+/**** SPCR  F3H  PAGE 0 ****/
+#define set_SPCR_SSOE                    SFRS=0;SPCR|=0x80
+#define set_SPCR_SPIEN                   SFRS=0;SPCR|=0x40
+#define set_SPCR_LSBFE                   SFRS=0;SPCR|=0x20
+#define set_SPCR_MSTR                    SFRS=0;SPCR|=0x10
+#define set_SPCR_CPOL                    SFRS=0;SPCR|=0x08
+#define set_SPCR_CPHA                    SFRS=0;SPCR|=0x04
+#define set_SPCR_SPR1                    SFRS=0;SPCR|=0x02
+#define set_SPCR_SPR0                    SFRS=0;SPCR|=0x01
+
+#define clr_SPCR_SSOE                    SFRS=0;SPCR&=0x7F
+#define clr_SPCR_SPIEN                   SFRS=0;SPCR&=0xBF
+#define clr_SPCR_LSBFE                   SFRS=0;SPCR&=0xDF
+#define clr_SPCR_MSTR                    SFRS=0;SPCR&=0xEF
+#define clr_SPCR_CPOL                    SFRS=0;SPCR&=0xF7
+#define clr_SPCR_CPHA                    SFRS=0;SPCR&=0xFB
+#define clr_SPCR_SPR1                    SFRS=0;SPCR&=0xFD
+#define clr_SPCR_SPR0                    SFRS=0;SPCR&=0xFE
+
+/**** SPSR  F4H  PAGE 0 ****/
+#define set_SPSR_SPIF                    SFRS=0;SPSR|=0x80
+#define set_SPSR_WCOL                    SFRS=0;SPSR|=0x40
+#define set_SPSR_SPIOVF                  SFRS=0;SPSR|=0x20
+#define set_SPSR_MODF                    SFRS=0;SPSR|=0x10
+#define set_SPSR_DISMODF                 SFRS=0;SPSR|=0x08
+#define set_SPSR_TXBUF                   SFRS=0;SPSR|=0x04
+
+#define clr_SPSR_SPIF                    SFRS=0;SPSR&=0x7F
+#define clr_SPSR_WCOL                    SFRS=0;SPSR&=0xBF
+#define clr_SPSR_SPIOVF                  SFRS=0;SPSR&=0xDF
+#define clr_SPSR_MODF                    SFRS=0;SPSR&=0xEF
+#define clr_SPSR_DISMODF                 SFRS=0;SPSR&=0xF7
+#define clr_SPSR_TXBUF                   SFRS=0;SPSR&=0xFB
+
+/**** AINDIDS0  F6H  PAGE 0 ****/
+#define set_AINDIDS0_P11DIDS             SFRS=0;AINDIDS0|=0x80
+#define set_AINDIDS0_P03DIDS             SFRS=0;AINDIDS0|=0x40
+#define set_AINDIDS0_P04DIDS             SFRS=0;AINDIDS0|=0x20
+#define set_AINDIDS0_P05DIDS             SFRS=0;AINDIDS0|=0x10
+#define set_AINDIDS0_P06DIDS             SFRS=0;AINDIDS0|=0x08
+#define set_AINDIDS0_P07DIDS             SFRS=0;AINDIDS0|=0x04
+#define set_AINDIDS0_P30DIDS             SFRS=0;AINDIDS0|=0x02
+#define set_AINDIDS0_P17DIDS             SFRS=0;AINDIDS0|=0x01
+
+#define clr_AINDIDS0_P11DIDS             SFRS=0;AINDIDS0&=0x7F
+#define clr_AINDIDS0_P03DIDS             SFRS=0;AINDIDS0&=0xBF
+#define clr_AINDIDS0_P04DIDS             SFRS=0;AINDIDS0&=0xDF
+#define clr_AINDIDS0_P05DIDS             SFRS=0;AINDIDS0&=0xEF
+#define clr_AINDIDS0_P06DIDS             SFRS=0;AINDIDS0&=0xF7
+#define clr_AINDIDS0_P07DIDS             SFRS=0;AINDIDS0&=0xFB
+#define clr_AINDIDS0_P30DIDS             SFRS=0;AINDIDS0&=0xFD
+#define clr_AINDIDS0_P17DIDS             SFRS=0;AINDIDS0&=0xFE
+
+/**** EIPH  F7H  PAGE 0 ****/
+#define set_EIPH_PT2H                    SFRS=0;EIPH|=0x80
+#define set_EIPH_PSPIH                   SFRS=0;EIPH|=0x40
+#define set_EIPH_PFBH                    SFRS=0;EIPH|=0x20
+#define set_EIPH_PWDTH                   SFRS=0;EIPH|=0x10
+#define set_EIPH_PPWMH                   SFRS=0;EIPH|=0x08
+#define set_EIPH_PCAPH                   SFRS=0;EIPH|=0x04
+#define set_EIPH_PPIH                    SFRS=0;EIPH|=0x02
+#define set_EIPH_PI2CH                   SFRS=0;EIPH|=0x01
+
+#define clr_EIPH_PT2H                    SFRS=0;EIPH&=0x7F
+#define clr_EIPH_PSPIH                   SFRS=0;EIPH&=0xBF
+#define clr_EIPH_PFBH                    SFRS=0;EIPH&=0xDF
+#define clr_EIPH_PWDTH                   SFRS=0;EIPH&=0xEF
+#define clr_EIPH_PPWMH                   SFRS=0;EIPH&=0xF7
+#define clr_EIPH_PCAPH                   SFRS=0;EIPH&=0xFB
+#define clr_EIPH_PPIH                    SFRS=0;EIPH&=0xFD
+#define clr_EIPH_PI2CH                   SFRS=0;EIPH&=0xFE
+
+/**** PWM0DTEN  F9H  PAGE 0 TA protect register ****/
+#define set_PWM0DTEN_PWM0DTCNT_8         SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x10;EA=BIT_TMP
+#define set_PWM0DTEN_PDT45EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x04;EA=BIT_TMP
+#define set_PWM0DTEN_PDT23EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x02;EA=BIT_TMP
+#define set_PWM0DTEN_PDT01EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN|=0x01;EA=BIT_TMP
+
+#define clr_PWM0DTEN_PWM0DTCNT_8         SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN&=0xEF;EA=BIT_TMP
+#define clr_PWM0DTEN_PDT45EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN&=0xFB;EA=BIT_TMP
+#define clr_PWM0DTEN_PDT23EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN&=0xFD;EA=BIT_TMP
+#define clr_PWM0DTEN_PDT01EN             SFRS=0;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PWM0DTEN&=0xFE;EA=BIT_TMP
+
+/**** PWM0MEN  FBH  PAGE 0 ****/
+#define set_PWM0MEN_PMEN5                SFRS=0;PWM0MEN|=0x20
+#define set_PWM0MEN_PMEN4                SFRS=0;PWM0MEN|=0x10
+#define set_PWM0MEN_PMEN3                SFRS=0;PWM0MEN|=0x08
+#define set_PWM0MEN_PMEN2                SFRS=0;PWM0MEN|=0x04
+#define set_PWM0MEN_PMEN1                SFRS=0;PWM0MEN|=0x02
+#define set_PWM0MEN_PMEN0                SFRS=0;PWM0MEN|=0x01
+
+#define clr_PWM0MEN_PMEN5                SFRS=0;PWM0MEN&=0xDF
+#define clr_PWM0MEN_PMEN4                SFRS=0;PWM0MEN&=0xEF
+#define clr_PWM0MEN_PMEN3                SFRS=0;PWM0MEN&=0xF7
+#define clr_PWM0MEN_PMEN2                SFRS=0;PWM0MEN&=0xFB
+#define clr_PWM0MEN_PMEN1                SFRS=0;PWM0MEN&=0xFD
+#define clr_PWM0MEN_PMEN0                SFRS=0;PWM0MEN&=0xFE
+
+/**** PWM0MD  FCH  PAGE 0 ****/
+#define set_PWM0MD_PMD5                  SFRS=0;PWM0MD|=0x20
+#define set_PWM0MD_PMD4                  SFRS=0;PWM0MD|=0x10
+#define set_PWM0MD_PMD3                  SFRS=0;PWM0MD|=0x08
+#define set_PWM0MD_PMD2                  SFRS=0;PWM0MD|=0x04
+#define set_PWM0MD_PMD1                  SFRS=0;PWM0MD|=0x02
+#define set_PWM0MD_PMD0                  SFRS=0;PWM0MD|=0x01
+
+#define clr_PWM0MD_PMD5                  SFRS=0;PWM0MD&=0xDF
+#define clr_PWM0MD_PMD4                  SFRS=0;PWM0MD&=0xEF
+#define clr_PWM0MD_PMD3                  SFRS=0;PWM0MD&=0xF7
+#define clr_PWM0MD_PMD2                  SFRS=0;PWM0MD&=0xFB
+#define clr_PWM0MD_PMD1                  SFRS=0;PWM0MD&=0xFD
+#define clr_PWM0MD_PMD0                  SFRS=0;PWM0MD&=0xFE
+
+/**** EIPH1  FFH  PAGE 0 ****/
+#define set_EIPH1_PPWM3H                 SFRS=0;EIPH1|=0x20
+#define set_EIPH1_PPWM2H                 SFRS=0;EIPH1|=0x10
+#define set_EIPH1_PPWM1H                 SFRS=0;EIPH1|=0x08
+#define set_EIPH1_PWKTH                  SFRS=0;EIPH1|=0x04
+#define set_EIPH1_PT3H                   SFRS=0;EIPH1|=0x02
+#define set_EIPH1_PSH_1                  SFRS=0;EIPH1|=0x01
+
+#define clr_EIPH1_PPWM3H                 SFRS=0;EIPH1&=0xDF
+#define clr_EIPH1_PPWM2H                 SFRS=0;EIPH1&=0xEF
+#define clr_EIPH1_PPWM1H                 SFRS=0;EIPH1&=0xF7
+#define clr_EIPH1_PWKTH                  SFRS=0;EIPH1&=0xFB
+#define clr_EIPH1_PT3H                   SFRS=0;EIPH1&=0xFD
+#define clr_EIPH1_PSH_1                  SFRS=0;EIPH1&=0xFE
+
+/********SFR PAGE 1*************/
+/**** P3S  ACH  PAGE 1 ****/
+#define set_P3S_7                        SFRS=1;P3S|=0x80
+#define set_P3S_6                        SFRS=1;P3S|=0x40
+#define set_P3S_5                        SFRS=1;P3S|=0x20
+#define set_P3S_4                        SFRS=1;P3S|=0x10
+#define set_P3S_3                        SFRS=1;P3S|=0x08
+#define set_P3S_2                        SFRS=1;P3S|=0x04
+#define set_P3S_1                        SFRS=1;P3S|=0x02
+#define set_P3S_0                        SFRS=1;P3S|=0x01
+
+#define clr_P3S_7                        SFRS=1;P3S&=0x7F
+#define clr_P3S_6                        SFRS=1;P3S&=0xBF
+#define clr_P3S_5                        SFRS=1;P3S&=0xDF
+#define clr_P3S_4                        SFRS=1;P3S&=0xEF
+#define clr_P3S_3                        SFRS=1;P3S&=0xF7
+#define clr_P3S_2                        SFRS=1;P3S&=0xFB
+#define clr_P3S_1                        SFRS=1;P3S&=0xFD
+#define clr_P3S_0                        SFRS=1;P3S&=0xFE
+
+/**** P3SR  ADH  PAGE 1 ****/
+#define set_P3SR_7                       SFRS=1;P3SR|=0x80
+#define set_P3SR_6                       SFRS=1;P3SR|=0x40
+#define set_P3SR_5                       SFRS=1;P3SR|=0x20
+#define set_P3SR_4                       SFRS=1;P3SR|=0x10
+#define set_P3SR_3                       SFRS=1;P3SR|=0x08
+#define set_P3SR_2                       SFRS=1;P3SR|=0x04
+#define set_P3SR_1                       SFRS=1;P3SR|=0x02
+#define set_P3SR_0                       SFRS=1;P3SR|=0x01
+
+#define clr_P3SR_7                       SFRS=1;P3SR&=0x7F
+#define clr_P3SR_6                       SFRS=1;P3SR&=0xBF
+#define clr_P3SR_5                       SFRS=1;P3SR&=0xDF
+#define clr_P3SR_4                       SFRS=1;P3SR&=0xEF
+#define clr_P3SR_3                       SFRS=1;P3SR&=0xF7
+#define clr_P3SR_2                       SFRS=1;P3SR&=0xFB
+#define clr_P3SR_1                       SFRS=1;P3SR&=0xFD
+#define clr_P3SR_0                       SFRS=1;P3SR&=0xFE
+
+/**** PWM0INTC  AFH  PAGE 1 ****/
+#define set_PWM0INTC_INTTYP1             SFRS=1;PWM0INTC|=0x20
+#define set_PWM0INTC_INTTYP0             SFRS=1;PWM0INTC|=0x10
+#define set_PWM0INTC_INTSEL2             SFRS=1;PWM0INTC|=0x04
+#define set_PWM0INTC_INTSEL1             SFRS=1;PWM0INTC|=0x02
+#define set_PWM0INTC_INTSEL0             SFRS=1;PWM0INTC|=0x01
+
+#define clr_PWM0INTC_INTTYP1             SFRS=1;PWM0INTC&=0xDF
+#define clr_PWM0INTC_INTTYP0             SFRS=1;PWM0INTC&=0xEF
+#define clr_PWM0INTC_INTSEL2             SFRS=1;PWM0INTC&=0xFB
+#define clr_PWM0INTC_INTSEL1             SFRS=1;PWM0INTC&=0xFD
+#define clr_PWM0INTC_INTSEL0             SFRS=1;PWM0INTC&=0xFE
+
+/**** P0S  B1H  PAGE 1 ****/
+#define set_P0S_7                        SFRS=1;P0S|=0x80
+#define set_P0S_6                        SFRS=1;P0S|=0x40
+#define set_P0S_5                        SFRS=1;P0S|=0x20
+#define set_P0S_4                        SFRS=1;P0S|=0x10
+#define set_P0S_3                        SFRS=1;P0S|=0x08
+#define set_P0S_2                        SFRS=1;P0S|=0x04
+#define set_P0S_1                        SFRS=1;P0S|=0x02
+#define set_P0S_0                        SFRS=1;P0S|=0x01
+
+#define clr_P0S_7                        SFRS=1;P0S&=0x7F
+#define clr_P0S_6                        SFRS=1;P0S&=0xBF
+#define clr_P0S_5                        SFRS=1;P0S&=0xDF
+#define clr_P0S_4                        SFRS=1;P0S&=0xEF
+#define clr_P0S_3                        SFRS=1;P0S&=0xF7
+#define clr_P0S_2                        SFRS=1;P0S&=0xFB
+#define clr_P0S_1                        SFRS=1;P0S&=0xFD
+#define clr_P0S_0                        SFRS=1;P0S&=0xFE
+
+/**** P0SR  B2H  PAGE 1 ****/
+#define set_P0SR_7                       SFRS=1;P0SR|=0x80
+#define set_P0SR_6                       SFRS=1;P0SR|=0x40
+#define set_P0SR_5                       SFRS=1;P0SR|=0x20
+#define set_P0SR_4                       SFRS=1;P0SR|=0x10
+#define set_P0SR_3                       SFRS=1;P0SR|=0x08
+#define set_P0SR_2                       SFRS=1;P0SR|=0x04
+#define set_P0SR_1                       SFRS=1;P0SR|=0x02
+#define set_P0SR_0                       SFRS=1;P0SR|=0x01
+
+#define clr_P0SR_7                       SFRS=1;P0SR&=0x7F
+#define clr_P0SR_6                       SFRS=1;P0SR&=0xBF
+#define clr_P0SR_5                       SFRS=1;P0SR&=0xDF
+#define clr_P0SR_4                       SFRS=1;P0SR&=0xEF
+#define clr_P0SR_3                       SFRS=1;P0SR&=0xF7
+#define clr_P0SR_2                       SFRS=1;P0SR&=0xFB
+#define clr_P0SR_1                       SFRS=1;P0SR&=0xFD
+#define clr_P0SR_0                       SFRS=1;P0SR&=0xFE
+
+/**** P1S  B3H  PAGE 1 ****/
+#define set_P1S_7                        SFRS=1;P1S|=0x80
+#define set_P1S_6                        SFRS=1;P1S|=0x40
+#define set_P1S_5                        SFRS=1;P1S|=0x20
+#define set_P1S_4                        SFRS=1;P1S|=0x10
+#define set_P1S_3                        SFRS=1;P1S|=0x08
+#define set_P1S_2                        SFRS=1;P1S|=0x04
+#define set_P1S_1                        SFRS=1;P1S|=0x02
+#define set_P1S_0                        SFRS=1;P1S|=0x01
+
+#define clr_P1S_7                        SFRS=1;P1S&=0x7F
+#define clr_P1S_6                        SFRS=1;P1S&=0xBF
+#define clr_P1S_5                        SFRS=1;P1S&=0xDF
+#define clr_P1S_4                        SFRS=1;P1S&=0xEF
+#define clr_P1S_3                        SFRS=1;P1S&=0xF7
+#define clr_P1S_2                        SFRS=1;P1S&=0xFB
+#define clr_P1S_1                        SFRS=1;P1S&=0xFD
+#define clr_P1S_0                        SFRS=1;P1S&=0xFE
+
+/**** P1SR  B4H  PAGE 1 ****/
+#define set_P1SR_7                       SFRS=1;P1SR|=0x80
+#define set_P1SR_6                       SFRS=1;P1SR|=0x40
+#define set_P1SR_5                       SFRS=1;P1SR|=0x20
+#define set_P1SR_4                       SFRS=1;P1SR|=0x10
+#define set_P1SR_3                       SFRS=1;P1SR|=0x08
+#define set_P1SR_2                       SFRS=1;P1SR|=0x04
+#define set_P1SR_1                       SFRS=1;P1SR|=0x02
+#define set_P1SR_0                       SFRS=1;P1SR|=0x01
+
+#define clr_P1SR_7                       SFRS=1;P1SR&=0x7F
+#define clr_P1SR_6                       SFRS=1;P1SR&=0xBF
+#define clr_P1SR_5                       SFRS=1;P1SR&=0xDF
+#define clr_P1SR_4                       SFRS=1;P1SR&=0xEF
+#define clr_P1SR_3                       SFRS=1;P1SR&=0xF7
+#define clr_P1SR_2                       SFRS=1;P1SR&=0xFB
+#define clr_P1SR_1                       SFRS=1;P1SR&=0xFD
+#define clr_P1SR_0                       SFRS=1;P1SR&=0xFE
+
+/**** PIOCON1  C6H  PAGE1 ****/ 
+#define set_PIOCON1_PIO17                SFRS=1;PIOCON1|=0x80   
+#define set_PIOCON1_PIO15                SFRS=1;PIOCON1|=0x20
+#define set_PIOCON1_PIO04                SFRS=1;PIOCON1|=0x08
+#define set_PIOCON1_PIO05                SFRS=1;PIOCON1|=0x04
+#define set_PIOCON1_PIO14                SFRS=1;PIOCON1|=0x02
+                                         
+#define clr_PIOCON1_PIO17                SFRS=1;PIOCON1&=0x7F
+#define clr_PIOCON1_PIO15                SFRS=1;PIOCON1&=0xDF
+#define clr_PIOCON1_PIO04                SFRS=1;PIOCON1&=0xF7
+#define clr_PIOCON1_PIO05                SFRS=1;PIOCON1&=0xFB
+#define clr_PIOCON1_PIO14                SFRS=1;PIOCON1&=0xFD
+
+/**** SPCR2  F3H  PAGE 1 ****/
+#define set_SPCR2_SPIS1                  SFRS=1;SPCR2|=0x02
+#define set_SPCR2_SPIS0                  SFRS=1;SPCR2|=0x01
+
+
+#define clr_SPCR2_SPIS1                  SFRS=1;SPCR2&=0xFD
+#define clr_SPCR2_SPIS0                  SFRS=1;SPCR2&=0xFE
+
+/**** EIP1  FEH  PAGE 1 ****/
+#define set_EIP1_PPWM3                   SFRS=1;EIP1|=0x20
+#define set_EIP1_PPWM2                   SFRS=1;EIP1|=0x10
+#define set_EIP1_PPWM1                   SFRS=1;EIP1|=0x08
+#define set_EIP1_PWKT                    SFRS=1;EIP1|=0x04
+#define set_EIP1_PT3                     SFRS=1;EIP1|=0x02
+#define set_EIP1_PS_1                    SFRS=1;EIP1|=0x01
+
+#define clr_EIP1_PPWM3                   SFRS=1;EIP1&=0xDF
+#define clr_EIP1_PPWM2                   SFRS=1;EIP1&=0xEF
+#define clr_EIP1_PPWM1                   SFRS=1;EIP1&=0xF7
+#define clr_EIP1_PWKT                    SFRS=1;EIP1&=0xFB
+#define clr_EIP1_PT3                     SFRS=1;EIP1&=0xFD
+#define clr_EIP1_PS_1                    SFRS=1;EIP1&=0xFE
+
+/********SFR PAGE 2*************/
+/**** ADCBAH  85H  PAGE 2 ****/
+#define set_ADCBAH_ADCBA3                SFRS=2;ADCBAH|=0x08
+#define set_ADCBAH_ADCBA2                SFRS=2;ADCBAH|=0x04
+#define set_ADCBAH_ADCBA1                SFRS=2;ADCBAH|=0x02
+#define set_ADCBAH_ADCBA0                SFRS=2;ADCBAH|=0x01
+
+#define clr_ADCBAH_ADCBA3                SFRS=2;ADCBAH&=0xF7
+#define clr_ADCBAH_ADCBA2                SFRS=2;ADCBAH&=0xFB
+#define clr_ADCBAH_ADCBA1                SFRS=2;ADCBAH&=0xFD
+#define clr_ADCBAH_ADCBA0                SFRS=2;ADCBAH&=0xFE
+
+/**** ADCCON3  86H  PAGE 2 ****/
+#define set_ADCCON3_HIE                  SFRS=2;ADCCON3|=0x20
+#define set_ADCCON3_CONT                 SFRS=2;ADCCON3|=0x10
+#define set_ADCCON3_ADCAQT1_2            SFRS=2;ADCCON3|=0x08
+#define set_ADCCON3_ADCAQT1_1            SFRS=2;ADCCON3|=0x04
+#define set_ADCCON3_ADCAQT1_0            SFRS=2;ADCCON3|=0x02
+#define set_ADCCON3_SLOW                 SFRS=2;ADCCON3|=0x01
+
+#define clr_ADCCON3_HIE                  SFRS=2;ADCCON3&=0xDF
+#define clr_ADCCON3_CONT                 SFRS=2;ADCCON3&=0xEF
+#define clr_ADCCON3_ADCAQT1_2            SFRS=2;ADCCON3&=0xF7
+#define clr_ADCCON3_ADCAQT1_1            SFRS=2;ADCCON3&=0xFB
+#define clr_ADCCON3_ADCAQT1_0            SFRS=2;ADCCON3&=0xFD
+#define clr_ADCCON3_SLOW                 SFRS=2;ADCCON3&=0xFE
+
+/**** P2M1  89H  PAGE 2 ****/
+#define set_P2M1_7                       SFRS=2;P2M1|=0x80
+#define set_P2M1_6                       SFRS=2;P2M1|=0x40
+#define set_P2M1_5                       SFRS=2;P2M1|=0x20
+#define set_P2M1_4                       SFRS=2;P2M1|=0x10
+#define set_P2M1_3                       SFRS=2;P2M1|=0x08
+#define set_P2M1_2                       SFRS=2;P2M1|=0x04
+#define set_P2M1_1                       SFRS=2;P2M1|=0x02
+#define set_P2M1_0                       SFRS=2;P2M1|=0x01
+
+#define clr_P2M1_7                       SFRS=2;P2M1&=0x7F
+#define clr_P2M1_6                       SFRS=2;P2M1&=0xBF
+#define clr_P2M1_5                       SFRS=2;P2M1&=0xDF
+#define clr_P2M1_4                       SFRS=2;P2M1&=0xEF
+#define clr_P2M1_3                       SFRS=2;P2M1&=0xF7
+#define clr_P2M1_2                       SFRS=2;P2M1&=0xFB
+#define clr_P2M1_1                       SFRS=2;P2M1&=0xFD
+#define clr_P2M1_0                       SFRS=2;P2M1&=0xFE
+
+/**** P2M2  8AH  PAGE 2 ****/
+#define set_P2M2_7                       SFRS=2;P2M2|=0x80
+#define set_P2M2_6                       SFRS=2;P2M2|=0x40
+#define set_P2M2_5                       SFRS=2;P2M2|=0x20
+#define set_P2M2_4                       SFRS=2;P2M2|=0x10
+#define set_P2M2_3                       SFRS=2;P2M2|=0x08
+#define set_P2M2_2                       SFRS=2;P2M2|=0x04
+#define set_P2M2_1                       SFRS=2;P2M2|=0x02
+#define set_P2M2_0                       SFRS=2;P2M2|=0x01
+
+#define clr_P2M2_7                       SFRS=2;P2M2&=0x7F
+#define clr_P2M2_6                       SFRS=2;P2M2&=0xBF
+#define clr_P2M2_5                       SFRS=2;P2M2&=0xDF
+#define clr_P2M2_4                       SFRS=2;P2M2&=0xEF
+#define clr_P2M2_3                       SFRS=2;P2M2&=0xF7
+#define clr_P2M2_2                       SFRS=2;P2M2&=0xFB
+#define clr_P2M2_1                       SFRS=2;P2M2&=0xFD
+#define clr_P2M2_0                       SFRS=2;P2M2&=0xFE
+
+/**** P2SR  8BH  PAGE 2 ****/
+#define set_P2SR_7                       SFRS=2;P2SR|=0x80
+#define set_P2SR_6                       SFRS=2;P2SR|=0x40
+#define set_P2SR_5                       SFRS=2;P2SR|=0x20
+#define set_P2SR_4                       SFRS=2;P2SR|=0x10
+#define set_P2SR_3                       SFRS=2;P2SR|=0x08
+#define set_P2SR_2                       SFRS=2;P2SR|=0x04
+#define set_P2SR_1                       SFRS=2;P2SR|=0x02
+#define set_P2SR_0                       SFRS=2;P2SR|=0x01
+
+#define clr_P2SR_7                       SFRS=2;P2SR&=0x7F
+#define clr_P2SR_6                       SFRS=2;P2SR&=0xBF
+#define clr_P2SR_5                       SFRS=2;P2SR&=0xDF
+#define clr_P2SR_4                       SFRS=2;P2SR&=0xEF
+#define clr_P2SR_3                       SFRS=2;P2SR&=0xF7
+#define clr_P2SR_2                       SFRS=2;P2SR&=0xFB
+#define clr_P2SR_1                       SFRS=2;P2SR&=0xFD
+#define clr_P2SR_0                       SFRS=2;P2SR&=0xFE
+
+/**** P2S  8CH  PAGE 2 ****/
+#define set_P2S_7                        SFRS=2;P2S|=0x80
+#define set_P2S_6                        SFRS=2;P2S|=0x40
+#define set_P2S_5                        SFRS=2;P2S|=0x20
+#define set_P2S_4                        SFRS=2;P2S|=0x10
+#define set_P2S_3                        SFRS=2;P2S|=0x08
+#define set_P2S_2                        SFRS=2;P2S|=0x04
+#define set_P2S_1                        SFRS=2;P2S|=0x02
+#define set_P2S_0                        SFRS=2;P2S|=0x01
+
+#define clr_P2S_7                        SFRS=2;P2S&=0x7F
+#define clr_P2S_6                        SFRS=2;P2S&=0xBF
+#define clr_P2S_5                        SFRS=2;P2S&=0xDF
+#define clr_P2S_4                        SFRS=2;P2S&=0xEF
+#define clr_P2S_3                        SFRS=2;P2S&=0xF7
+#define clr_P2S_2                        SFRS=2;P2S&=0xFB
+#define clr_P2S_1                        SFRS=2;P2S&=0xFD
+#define clr_P2S_0                        SFRS=2;P2S&=0xFE
+
+/**** ADCSR  8FH  PAGE 2 ****/
+#define set_ADCSR_CMPHIT                 SFRS=2;ADCSR|=0x04
+#define set_ADCSR_HDONE                  SFRS=2;ADCSR|=0x02
+#define set_ADCSR_FDONE                  SFRS=2;ADCSR|=0x01
+
+#define clr_ADCSR_CMPHIT                 SFRS=2;ADCSR&=0xFB
+#define clr_ADCSR_HDONE                  SFRS=2;ADCSR&=0xFD
+#define clr_ADCSR_FDONE                  SFRS=2;ADCSR&=0xFE
+
+/**** P0UP  92H  PAGE 2 ****/
+#define set_P0UP_7                       SFRS=2;P0UP|=0x80
+#define set_P0UP_6                       SFRS=2;P0UP|=0x40
+#define set_P0UP_5                       SFRS=2;P0UP|=0x20
+#define set_P0UP_4                       SFRS=2;P0UP|=0x10
+#define set_P0UP_3                       SFRS=2;P0UP|=0x08
+#define set_P0UP_2                       SFRS=2;P0UP|=0x04
+#define set_P0UP_1                       SFRS=2;P0UP|=0x02
+#define set_P0UP_0                       SFRS=2;P0UP|=0x01
+
+#define clr_P0UP_7                       SFRS=2;P0UP&=0x7F
+#define clr_P0UP_6                       SFRS=2;P0UP&=0xBF
+#define clr_P0UP_5                       SFRS=2;P0UP&=0xDF
+#define clr_P0UP_4                       SFRS=2;P0UP&=0xEF
+#define clr_P0UP_3                       SFRS=2;P0UP&=0xF7
+#define clr_P0UP_2                       SFRS=2;P0UP&=0xFB
+#define clr_P0UP_1                       SFRS=2;P0UP&=0xFD
+#define clr_P0UP_0                       SFRS=2;P0UP&=0xFE
+
+/**** P1UP  93H  PAGE 2 ****/
+#define set_P1UP_7                       SFRS=2;P1UP|=0x80
+#define set_P1UP_6                       SFRS=2;P1UP|=0x40
+#define set_P1UP_5                       SFRS=2;P1UP|=0x20
+#define set_P1UP_4                       SFRS=2;P1UP|=0x10
+#define set_P1UP_3                       SFRS=2;P1UP|=0x08
+#define set_P1UP_2                       SFRS=2;P1UP|=0x04
+#define set_P1UP_1                       SFRS=2;P1UP|=0x02
+#define set_P1UP_0                       SFRS=2;P1UP|=0x01
+
+#define clr_P1UP_7                       SFRS=2;P1UP&=0x7F
+#define clr_P1UP_6                       SFRS=2;P1UP&=0xBF
+#define clr_P1UP_5                       SFRS=2;P1UP&=0xDF
+#define clr_P1UP_4                       SFRS=2;P1UP&=0xEF
+#define clr_P1UP_3                       SFRS=2;P1UP&=0xF7
+#define clr_P1UP_2                       SFRS=2;P1UP&=0xFB
+#define clr_P1UP_1                       SFRS=2;P1UP&=0xFD
+#define clr_P1UP_0                       SFRS=2;P1UP&=0xFE
+
+/**** P2UP  94H  PAGE 2 ****/
+#define set_P2UP_5                       SFRS=2;P2UP|=0x20
+#define set_P2UP_4                       SFRS=2;P2UP|=0x10
+#define set_P2UP_3                       SFRS=2;P2UP|=0x08
+#define set_P2UP_2                       SFRS=2;P2UP|=0x04
+#define set_P2UP_1                       SFRS=2;P2UP|=0x02
+#define set_P2UP_0                       SFRS=2;P2UP|=0x01
+
+#define clr_P2UP_5                       SFRS=2;P2UP&=0xDF
+#define clr_P2UP_4                       SFRS=2;P2UP&=0xEF
+#define clr_P2UP_3                       SFRS=2;P2UP&=0xF7
+#define clr_P2UP_2                       SFRS=2;P2UP&=0xFB
+#define clr_P2UP_1                       SFRS=2;P2UP&=0xFD
+#define clr_P2UP_0                       SFRS=2;P2UP&=0xFE
+
+/**** P3UP  95H  PAGE 2 ****/
+#define set_P3UP_7                       SFRS=2;P3UP|=0x80
+#define set_P3UP_6                       SFRS=2;P3UP|=0x40
+#define set_P3UP_5                       SFRS=2;P3UP|=0x20
+#define set_P3UP_4                       SFRS=2;P3UP|=0x10
+#define set_P3UP_3                       SFRS=2;P3UP|=0x08
+#define set_P3UP_2                       SFRS=2;P3UP|=0x04
+#define set_P3UP_1                       SFRS=2;P3UP|=0x02
+#define set_P3UP_0                       SFRS=2;P3UP|=0x01
+
+#define clr_P3UP_7                       SFRS=2;P3UP&=0x7F
+#define clr_P3UP_6                       SFRS=2;P3UP&=0xBF
+#define clr_P3UP_5                       SFRS=2;P3UP&=0xDF
+#define clr_P3UP_4                       SFRS=2;P3UP&=0xEF
+#define clr_P3UP_3                       SFRS=2;P3UP&=0xF7
+#define clr_P3UP_2                       SFRS=2;P3UP&=0xFB
+#define clr_P3UP_1                       SFRS=2;P3UP&=0xFD
+#define clr_P3UP_0                       SFRS=2;P3UP&=0xFE
+
+/**** AINDIDS1  99H  PAGE 2 ****/
+#define set_AINDIDS1_P25DIDS             SFRS=2;AINDIDS1|=0x80
+#define set_AINDIDS1_P14DIDS             SFRS=2;AINDIDS1|=0x40
+#define set_AINDIDS1_P13DIDS             SFRS=2;AINDIDS1|=0x20
+#define set_AINDIDS1_P24DIDS             SFRS=2;AINDIDS1|=0x10
+#define set_AINDIDS1_P23DIDS             SFRS=2;AINDIDS1|=0x08
+#define set_AINDIDS1_P22DIDS             SFRS=2;AINDIDS1|=0x04
+#define set_AINDIDS1_P21DIDS             SFRS=2;AINDIDS1|=0x02
+
+#define clr_AINDIDS1_P25DIDS             SFRS=2;AINDIDS1&=0x7F
+#define clr_AINDIDS1_P14DIDS             SFRS=2;AINDIDS1&=0xBF
+#define clr_AINDIDS1_P13DIDS             SFRS=2;AINDIDS1&=0xDF
+#define clr_AINDIDS1_P24DIDS             SFRS=2;AINDIDS1&=0xEF
+#define clr_AINDIDS1_P23DIDS             SFRS=2;AINDIDS1&=0xF7
+#define clr_AINDIDS1_P22DIDS             SFRS=2;AINDIDS1&=0xFB
+#define clr_AINDIDS1_P21DIDS             SFRS=2;AINDIDS1&=0xFD
+
+/**** P0DW  9AH  PAGE 2 ****/
+#define set_P0DW_7                       SFRS=2;P0DW|=0x80
+#define set_P0DW_6                       SFRS=2;P0DW|=0x40
+#define set_P0DW_5                       SFRS=2;P0DW|=0x20
+#define set_P0DW_4                       SFRS=2;P0DW|=0x10
+#define set_P0DW_3                       SFRS=2;P0DW|=0x08
+#define set_P0DW_2                       SFRS=2;P0DW|=0x04
+#define set_P0DW_1                       SFRS=2;P0DW|=0x02
+#define set_P0DW_0                       SFRS=2;P0DW|=0x01
+
+#define clr_P0DW_7                       SFRS=2;P0DW&=0x7F
+#define clr_P0DW_6                       SFRS=2;P0DW&=0xBF
+#define clr_P0DW_5                       SFRS=2;P0DW&=0xDF
+#define clr_P0DW_4                       SFRS=2;P0DW&=0xEF
+#define clr_P0DW_3                       SFRS=2;P0DW&=0xF7
+#define clr_P0DW_2                       SFRS=2;P0DW&=0xFB
+#define clr_P0DW_1                       SFRS=2;P0DW&=0xFD
+#define clr_P0DW_0                       SFRS=2;P0DW&=0xFE
+
+/**** P1DW  9BH  PAGE 2 ****/
+#define set_P1DW_7                       SFRS=2;P1DW|=0x80
+#define set_P1DW_6                       SFRS=2;P1DW|=0x40
+#define set_P1DW_5                       SFRS=2;P1DW|=0x20
+#define set_P1DW_4                       SFRS=2;P1DW|=0x10
+#define set_P1DW_3                       SFRS=2;P1DW|=0x08
+#define set_P1DW_2                       SFRS=2;P1DW|=0x04
+#define set_P1DW_1                       SFRS=2;P1DW|=0x02
+#define set_P1DW_0                       SFRS=2;P1DW|=0x01
+
+#define clr_P1DW_7                       SFRS=2;P1DW&=0x7F
+#define clr_P1DW_6                       SFRS=2;P1DW&=0xBF
+#define clr_P1DW_5                       SFRS=2;P1DW&=0xDF
+#define clr_P1DW_4                       SFRS=2;P1DW&=0xEF
+#define clr_P1DW_3                       SFRS=2;P1DW&=0xF7
+#define clr_P1DW_2                       SFRS=2;P1DW&=0xFB
+#define clr_P1DW_1                       SFRS=2;P1DW&=0xFD
+#define clr_P1DW_0                       SFRS=2;P1DW&=0xFE
+
+/**** P2DW  9CH  PAGE 2 ****/
+#define set_P2DW_5                       SFRS=2;P2DW|=0x20
+#define set_P2DW_4                       SFRS=2;P2DW|=0x10
+#define set_P2DW_3                       SFRS=2;P2DW|=0x08
+#define set_P2DW_2                       SFRS=2;P2DW|=0x04
+#define set_P2DW_1                       SFRS=2;P2DW|=0x02
+#define set_P2DW_0                       SFRS=2;P2DW|=0x01
+
+#define clr_P2DW_5                       SFRS=2;P2DW&=0xDF
+#define clr_P2DW_4                       SFRS=2;P2DW&=0xEF
+#define clr_P2DW_3                       SFRS=2;P2DW&=0xF7
+#define clr_P2DW_2                       SFRS=2;P2DW&=0xFB
+#define clr_P2DW_1                       SFRS=2;P2DW&=0xFD
+#define clr_P2DW_0                       SFRS=2;P2DW&=0xFE
+
+/**** P3DW  9DH  PAGE 2 ****/
+#define set_P3DW_7                       SFRS=2;P3DW|=0x80
+#define set_P3DW_6                       SFRS=2;P3DW|=0x40
+#define set_P3DW_5                       SFRS=2;P3DW|=0x20
+#define set_P3DW_4                       SFRS=2;P3DW|=0x10
+#define set_P3DW_3                       SFRS=2;P3DW|=0x08
+#define set_P3DW_2                       SFRS=2;P3DW|=0x04
+#define set_P3DW_1                       SFRS=2;P3DW|=0x02
+#define set_P3DW_0                       SFRS=2;P3DW|=0x01
+
+#define clr_P3DW_7                       SFRS=2;P3DW&=0x7F
+#define clr_P3DW_6                       SFRS=2;P3DW&=0xBF
+#define clr_P3DW_5                       SFRS=2;P3DW&=0xDF
+#define clr_P3DW_4                       SFRS=2;P3DW&=0xEF
+#define clr_P3DW_3                       SFRS=2;P3DW&=0xF7
+#define clr_P3DW_2                       SFRS=2;P3DW&=0xFB
+#define clr_P3DW_1                       SFRS=2;P3DW&=0xFD
+#define clr_P3DW_0                       SFRS=2;P3DW&=0xFE
+
+/**** AUXR2  A1H  PAGE 2 ****/
+#define set_AUXR2_UART2TXP1              SFRS=2;AUXR2|=0x80
+#define set_AUXR2_UART2TXP0              SFRS=2;AUXR2|=0x40
+#define set_AUXR2_UART2RXP1              SFRS=2;AUXR2|=0x20
+#define set_AUXR2_UART2RXP0              SFRS=2;AUXR2|=0x10
+#define set_AUXR2_UART1TXP1              SFRS=2;AUXR2|=0x08
+#define set_AUXR2_UART1TXP0              SFRS=2;AUXR2|=0x04
+#define set_AUXR2_UART1RXP1              SFRS=2;AUXR2|=0x02
+#define set_AUXR2_UART1RXP0              SFRS=2;AUXR2|=0x01
+
+#define clr_AUXR2_UART2TXP1              SFRS=2;AUXR2&=0x7F
+#define clr_AUXR2_UART2TXP0              SFRS=2;AUXR2&=0xBF
+#define clr_AUXR2_UART2RXP1              SFRS=2;AUXR2&=0xDF
+#define clr_AUXR2_UART2RXP0              SFRS=2;AUXR2&=0xEF
+#define clr_AUXR2_UART1TXP1              SFRS=2;AUXR2&=0xF7
+#define clr_AUXR2_UART1TXP0              SFRS=2;AUXR2&=0xFB
+#define clr_AUXR2_UART1RXP1              SFRS=2;AUXR2&=0xFD
+#define clr_AUXR2_UART1RXP0              SFRS=2;AUXR2&=0xFE
+
+/**** AUXR3  A2H  PAGE 2 ****/
+#define set_AUXR3_UART4TXP1              SFRS=2;AUXR3|=0x80
+#define set_AUXR3_UART4TXP0              SFRS=2;AUXR3|=0x40
+#define set_AUXR3_UART4RXP1              SFRS=2;AUXR3|=0x20
+#define set_AUXR3_UART4RXP0              SFRS=2;AUXR3|=0x10
+#define set_AUXR3_UART3TXP1              SFRS=2;AUXR3|=0x08
+#define set_AUXR3_UART3TXP0              SFRS=2;AUXR3|=0x04
+#define set_AUXR3_UART3RXP1              SFRS=2;AUXR3|=0x02
+#define set_AUXR3_UART3RXP0              SFRS=2;AUXR3|=0x01
+
+#define clr_AUXR3_UART4TXP1              SFRS=2;AUXR3&=0x7F
+#define clr_AUXR3_UART4TXP0              SFRS=2;AUXR3&=0xBF
+#define clr_AUXR3_UART4RXP1              SFRS=2;AUXR3&=0xDF
+#define clr_AUXR3_UART4RXP0              SFRS=2;AUXR3&=0xEF
+#define clr_AUXR3_UART3TXP1              SFRS=2;AUXR3&=0xF7
+#define clr_AUXR3_UART3TXP0              SFRS=2;AUXR3&=0xFB
+#define clr_AUXR3_UART3RXP1              SFRS=2;AUXR3&=0xFD
+#define clr_AUXR3_UART3RXP0              SFRS=2;AUXR3&=0xFE
+
+/**** AUXR4  A3H  PAGE 2 ****/
+#define set_AUXR4_PWM2C1P1               SFRS=2;AUXR4|=0x80
+#define set_AUXR4_PWM2C1P0               SFRS=2;AUXR4|=0x40
+#define set_AUXR4_PWM2C0P1               SFRS=2;AUXR4|=0x20
+#define set_AUXR4_PWM2C0P0               SFRS=2;AUXR4|=0x10
+#define set_AUXR4_PWM1C1P1               SFRS=2;AUXR4|=0x08
+#define set_AUXR4_PWM1C1P0               SFRS=2;AUXR4|=0x04
+#define set_AUXR4_PWM1C0P1               SFRS=2;AUXR4|=0x02
+#define set_AUXR4_PWM1C0P0               SFRS=2;AUXR4|=0x01
+
+#define clr_AUXR4_PWM2C1P1               SFRS=2;AUXR4&=0x7F
+#define clr_AUXR4_PWM2C1P0               SFRS=2;AUXR4&=0xBF
+#define clr_AUXR4_PWM2C0P1               SFRS=2;AUXR4&=0xDF
+#define clr_AUXR4_PWM2C0P0               SFRS=2;AUXR4&=0xEF
+#define clr_AUXR4_PWM1C1P1               SFRS=2;AUXR4&=0xF7
+#define clr_AUXR4_PWM1C1P0               SFRS=2;AUXR4&=0xFB
+#define clr_AUXR4_PWM1C0P1               SFRS=2;AUXR4&=0xFD
+#define clr_AUXR4_PWM1C0P0               SFRS=2;AUXR4&=0xFE
+
+/**** AUXR5  A4H  PAGE 2 ****/
+#define set_AUXR5_CLOP                   SFRS=2;AUXR5|=0x80
+#define set_AUXR5_T0P                    SFRS=2;AUXR5|=0x40
+#define set_AUXR5_PWM3C1P1               SFRS=2;AUXR5|=0x08
+#define set_AUXR5_PWM3C1P0               SFRS=2;AUXR5|=0x04
+#define set_AUXR5_PWM3C0P1               SFRS=2;AUXR5|=0x02
+#define set_AUXR5_PWM3C0P0               SFRS=2;AUXR5|=0x01
+
+#define clr_AUXR5_CLOP                   SFRS=2;AUXR5&=0x7F
+#define clr_AUXR5_T0P                    SFRS=2;AUXR5&=0xBF
+#define clr_AUXR5_PWM3C1P1               SFRS=2;AUXR5&=0xF7
+#define clr_AUXR5_PWM3C1P0               SFRS=2;AUXR5&=0xFB
+#define clr_AUXR5_PWM3C0P1               SFRS=2;AUXR5&=0xFD
+#define clr_AUXR5_PWM3C0P0               SFRS=2;AUXR5&=0xFE
+
+/**** AUXR6  A5H  PAGE 2 ****/
+#define set_AUXR6_UART4DG                SFRS=2;AUXR6|=0x10
+#define set_AUXR6_UART3DG                SFRS=2;AUXR6|=0x08
+#define set_AUXR6_UART2DG                SFRS=2;AUXR6|=0x04
+#define set_AUXR6_UART1DG                SFRS=2;AUXR6|=0x02
+#define set_AUXR6_UART0DG                SFRS=2;AUXR6|=0x01
+
+#define clr_AUXR6_UART4DG                SFRS=2;AUXR6&=0xEF
+#define clr_AUXR6_UART3DG                SFRS=2;AUXR6&=0xF7
+#define clr_AUXR6_UART2DG                SFRS=2;AUXR6&=0xFB
+#define clr_AUXR6_UART1DG                SFRS=2;AUXR6&=0xFD
+#define clr_AUXR6_UART0DG                SFRS=2;AUXR6&=0xFE
+
+/**** AUXR7  A6H  PAGE 2 ****/
+#define set_AUXR7_SPI0NSSP1              SFRS=2;AUXR7|=0x10
+#define set_AUXR7_SPI0NSSP0              SFRS=2;AUXR7|=0x08
+#define set_AUXR7_SPI0MOSIP              SFRS=2;AUXR7|=0x04
+#define set_AUXR7_SPI0MISOP              SFRS=2;AUXR7|=0x02
+#define set_AUXR7_SPI0CKP                SFRS=2;AUXR7|=0x01
+
+#define clr_AUXR7_SPI0NSSP1              SFRS=2;AUXR7&=0xEF
+#define clr_AUXR7_SPI0NSSP0              SFRS=2;AUXR7&=0xF7
+#define clr_AUXR7_SPI0MOSIP              SFRS=2;AUXR7&=0xFB
+#define clr_AUXR7_SPI0MISOP              SFRS=2;AUXR7&=0xFD
+#define clr_AUXR7_SPI0CKP                SFRS=2;AUXR7&=0xFE
+
+/**** AUXR8  A7H  PAGE 2 TA protect register ****/
+#define set_AUXR8_CLODIV3                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x80;EA=BIT_TMP
+#define set_AUXR8_CLODIV2                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x40;EA=BIT_TMP
+#define set_AUXR8_CLODIV1                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x20;EA=BIT_TMP
+#define set_AUXR8_CLODIV0                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x10;EA=BIT_TMP
+#define set_AUXR8_CKTESTOEN3             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x08;EA=BIT_TMP
+#define set_AUXR8_CKTESTOEN2             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x04;EA=BIT_TMP
+#define set_AUXR8_CKTESTOEN1             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x02;EA=BIT_TMP
+#define set_AUXR8_CKTESTOEN0             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8|=0x01;EA=BIT_TMP
+
+#define clr_AUXR8_CLODIV3                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0x7F;EA=BIT_TMP
+#define clr_AUXR8_CLODIV2                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xBF;EA=BIT_TMP
+#define clr_AUXR8_CLODIV1                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xDF;EA=BIT_TMP
+#define clr_AUXR8_CLODIV0                SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xEF;EA=BIT_TMP
+#define clr_AUXR8_CKTESTOEN3             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xF7;EA=BIT_TMP
+#define clr_AUXR8_CKTESTOEN2             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xFB;EA=BIT_TMP
+#define clr_AUXR8_CKTESTOEN1             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xFD;EA=BIT_TMP
+#define clr_AUXR8_CKTESTOEN0             SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;AUXR8&=0xFE;EA=BIT_TMP
+
+/**** PWM1MD  ADH  PAGE 2 ****/
+#define set_PWM1MD_PMD1                  SFRS=2;PWM1MD|=0x02
+#define set_PWM1MD_PMD0                  SFRS=2;PWM1MD|=0x01
+
+#define clr_PWM1MD_PMD1                  SFRS=2;PWM1MD&=0xFD
+#define clr_PWM1MD_PMD0                  SFRS=2;PWM1MD&=0xFE
+
+/**** PWM1MEN  AEH  PAGE 2 ****/
+#define set_PWM1MEN_PMEN1                SFRS=2;PWM1MEN|=0x02
+#define set_PWM1MEN_PMEN0                SFRS=2;PWM1MEN|=0x01
+
+#define clr_PWM1MEN_PMEN1                SFRS=2;PWM1MEN&=0xFD
+#define clr_PWM1MEN_PMEN0                SFRS=2;PWM1MEN&=0xFE
+
+/**** PWM1CON0  B4H  PAGE 2 ****/
+#define set_PWM1CON0_PWMRUN              SFRS=2;PWM1CON0|=0x80
+#define set_PWM1CON0_LOAD                SFRS=2;PWM1CON0|=0x40
+#define set_PWM1CON0_PWMF                SFRS=2;PWM1CON0|=0x20
+#define set_PWM1CON0_CLRPWM              SFRS=2;PWM1CON0|=0x10
+
+#define clr_PWM1CON0_PWMRUN              SFRS=2;PWM1CON0&=0x7F
+#define clr_PWM1CON0_LOAD                SFRS=2;PWM1CON0&=0xBF
+#define clr_PWM1CON0_PWMF                SFRS=2;PWM1CON0&=0xDF
+#define clr_PWM1CON0_CLRPWM              SFRS=2;PWM1CON0&=0xEF
+
+/**** PWM1CON1  B5H  PAGE 2 ****/
+#define set_PWM1CON1_PWMMOD1             SFRS=2;PWM1CON1|=0x80
+#define set_PWM1CON1_PWMMOD0             SFRS=2;PWM1CON1|=0x40
+#define set_PWM1CON1_PWMTYP              SFRS=2;PWM1CON1|=0x10
+#define set_PWM1CON1_PWMDIV2             SFRS=2;PWM1CON1|=0x04
+#define set_PWM1CON1_PWMDIV1             SFRS=2;PWM1CON1|=0x02
+#define set_PWM1CON1_PWMDIV0             SFRS=2;PWM1CON1|=0x01
+
+#define clr_PWM1CON1_PWMMOD1             SFRS=2;PWM1CON1&=0x7F
+#define clr_PWM1CON1_PWMMOD0             SFRS=2;PWM1CON1&=0xBF
+#define clr_PWM1CON1_PWMTYP              SFRS=2;PWM1CON1&=0xEF
+#define clr_PWM1CON1_PWMDIV2             SFRS=2;PWM1CON1&=0xFB
+#define clr_PWM1CON1_PWMDIV1             SFRS=2;PWM1CON1&=0xFD
+#define clr_PWM1CON1_PWMDIV0             SFRS=2;PWM1CON1&=0xFE
+
+/**** PWM1INTC  B6H  PAGE 2 ****/
+#define set_PWM1INTC_INTTYP1             SFRS=2;PWM1INTC|=0x20
+#define set_PWM1INTC_INTTYP0             SFRS=2;PWM1INTC|=0x10
+#define set_PWM1INTC_INTSEL2             SFRS=2;PWM1INTC|=0x04
+#define set_PWM1INTC_INTSEL1             SFRS=2;PWM1INTC|=0x02
+#define set_PWM1INTC_INTSEL0             SFRS=2;PWM1INTC|=0x01
+
+#define clr_PWM1INTC_INTTYP1             SFRS=2;PWM1INTC&=0xDF
+#define clr_PWM1INTC_INTTYP0             SFRS=2;PWM1INTC&=0xEF
+#define clr_PWM1INTC_INTSEL2             SFRS=2;PWM1INTC&=0xFB
+#define clr_PWM1INTC_INTSEL1             SFRS=2;PWM1INTC&=0xFD
+#define clr_PWM1INTC_INTSEL0             SFRS=2;PWM1INTC&=0xFE
+
+/**** PIOCON2  B7H  PAGE 2 ****/
+#define set_PIOCON2_PIO34                SFRS=2;PIOCON2|=0x80
+#define set_PIOCON2_PIO33                SFRS=2;PIOCON2|=0x40
+#define set_PIOCON2_PIO32                SFRS=2;PIOCON2|=0x20
+#define set_PIOCON2_PIO31                SFRS=2;PIOCON2|=0x10
+#define set_PIOCON2_PIO30                SFRS=2;PIOCON2|=0x08
+#define set_PIOCON2_PIO23                SFRS=2;PIOCON2|=0x04
+#define set_PIOCON2_PIO22                SFRS=2;PIOCON2|=0x02
+#define set_PIOCON2_PIO21                SFRS=2;PIOCON2|=0x01
+
+#define clr_PIOCON2_PIO34                SFRS=2;PIOCON2&=0x7F
+#define clr_PIOCON2_PIO33                SFRS=2;PIOCON2&=0xBF
+#define clr_PIOCON2_PIO32                SFRS=2;PIOCON2&=0xDF
+#define clr_PIOCON2_PIO31                SFRS=2;PIOCON2&=0xEF
+#define clr_PIOCON2_PIO30                SFRS=2;PIOCON2&=0xF7
+#define clr_PIOCON2_PIO23                SFRS=2;PIOCON2&=0xFB
+#define clr_PIOCON2_PIO22                SFRS=2;PIOCON2&=0xFD
+#define clr_PIOCON2_PIO21                SFRS=2;PIOCON2&=0xFE
+
+/**** PWM2MD  BEH  PAGE 2 ****/
+#define set_PWM2MD_PMD1                  SFRS=2;PWM2MD|=0x02
+#define set_PWM2MD_PMD0                  SFRS=2;PWM2MD|=0x01
+
+#define clr_PWM2MD_PMD1                  SFRS=2;PWM2MD&=0xFD
+#define clr_PWM2MD_PMD0                  SFRS=2;PWM2MD&=0xFE
+
+/**** PWM2MEN  BFH  PAGE 2 ****/
+#define set_PWM2MEN_PMEN1                SFRS=2;PWM2MEN|=0x02
+#define set_PWM2MEN_PMEN0                SFRS=2;PWM2MEN|=0x01
+
+#define clr_PWM2MEN_PMEN1                SFRS=2;PWM2MEN&=0xFD
+#define clr_PWM2MEN_PMEN0                SFRS=2;PWM2MEN&=0xFE
+
+/**** PWM2CON0  C4H  PAGE 2 ****/
+#define set_PWM2CON0_PWMRUN              SFRS=2;PWM2CON0|=0x80
+#define set_PWM2CON0_LOAD                SFRS=2;PWM2CON0|=0x40
+#define set_PWM2CON0_PWMF                SFRS=2;PWM2CON0|=0x20
+#define set_PWM2CON0_CLRPWM              SFRS=2;PWM2CON0|=0x10
+
+#define clr_PWM2CON0_PWMRUN              SFRS=2;PWM2CON0&=0x7F
+#define clr_PWM2CON0_LOAD                SFRS=2;PWM2CON0&=0xBF
+#define clr_PWM2CON0_PWMF                SFRS=2;PWM2CON0&=0xDF
+#define clr_PWM2CON0_CLRPWM              SFRS=2;PWM2CON0&=0xEF
+
+/**** PWM2CON1  C5H  PAGE 2 ****/
+#define set_PWM2CON1_PWMMOD1             SFRS=2;PWM2CON1|=0x80
+#define set_PWM2CON1_PWMMOD0             SFRS=2;PWM2CON1|=0x40
+#define set_PWM2CON1_PWMTYP              SFRS=2;PWM2CON1|=0x20
+#define set_PWM2CON1_PWMDIV2             SFRS=2;PWM2CON1|=0x04
+#define set_PWM2CON1_PWMDIV1             SFRS=2;PWM2CON1|=0x02
+#define set_PWM2CON1_PWMDIV0             SFRS=2;PWM2CON1|=0x01
+
+#define clr_PWM2CON1_PWMMOD1             SFRS=2;PWM2CON1&=0x7F
+#define clr_PWM2CON1_PWMMOD0             SFRS=2;PWM2CON1&=0xBF
+#define clr_PWM2CON1_PWMTYP              SFRS=2;PWM2CON1&=0xDF
+#define clr_PWM2CON1_PWMDIV2             SFRS=2;PWM2CON1&=0xFB
+#define clr_PWM2CON1_PWMDIV1             SFRS=2;PWM2CON1&=0xFD
+#define clr_PWM2CON1_PWMDIV0             SFRS=2;PWM2CON1&=0xFE
+
+/**** PWM2INTC  C6H  PAGE 2 ****/
+#define set_PWM2INTC_INTTYP1             SFRS=2;PWM2INTC|=0x20
+#define set_PWM2INTC_INTTYP0             SFRS=2;PWM2INTC|=0x10
+#define set_PWM2INTC_INTSEL2             SFRS=2;PWM2INTC|=0x04
+#define set_PWM2INTC_INTSEL1             SFRS=2;PWM2INTC|=0x02
+#define set_PWM2INTC_INTSEL0             SFRS=2;PWM2INTC|=0x01
+
+#define clr_PWM2INTC_INTTYP1             SFRS=2;PWM2INTC&=0xDF
+#define clr_PWM2INTC_INTTYP0             SFRS=2;PWM2INTC&=0xEF
+#define clr_PWM2INTC_INTSEL2             SFRS=2;PWM2INTC&=0xFB
+#define clr_PWM2INTC_INTSEL1             SFRS=2;PWM2INTC&=0xFD
+#define clr_PWM2INTC_INTSEL0             SFRS=2;PWM2INTC&=0xFE
+
+/**** PWM3MD  CCH  PAGE 2 ****/
+#define set_PWM3MD_PMD1                  SFRS=2;PWM3MD|=0x02
+#define set_PWM3MD_PMD0                  SFRS=2;PWM3MD|=0x01
+
+#define clr_PWM3MD_PMD1                  SFRS=2;PWM3MD&=0xFD
+#define clr_PWM3MD_PMD0                  SFRS=2;PWM3MD&=0xFE
+
+/**** PWM3MEN  CDH  PAGE 2 ****/
+#define set_PWM3MEN_PMEN1                SFRS=2;PWM3MEN|=0x02
+#define set_PWM3MEN_PMEN0                SFRS=2;PWM3MEN|=0x01
+
+#define clr_PWM3MEN_PMEN1                SFRS=2;PWM3MEN&=0xFD
+#define clr_PWM3MEN_PMEN0                SFRS=2;PWM3MEN&=0xFE
+
+/**** EIP2  CEH  PAGE 2 ****/
+#define set_EIP2_PSC2                    SFRS=2;EIP2|=0x04
+#define set_EIP2_PSC1                    SFRS=2;EIP2|=0x02
+#define set_EIP2_PSC0                    SFRS=2;EIP2|=0x01
+
+#define clr_EIP2_PSC2                    SFRS=2;EIP2&=0xFB
+#define clr_EIP2_PSC1                    SFRS=2;EIP2&=0xFD
+#define clr_EIP2_PSC0                    SFRS=2;EIP2&=0xFE
+
+/**** EIPH2  CFH  PAGE 2 ****/
+#define set_EIPH2_PSC2H                    SFRS=2;EIPH2|=0x04
+#define set_EIPH2_PSC1H                    SFRS=2;EIPH2|=0x02
+#define set_EIPH2_PSC0H                    SFRS=2;EIPH2|=0x01
+
+#define clr_EIPH2_PSC2H                    SFRS=2;EIPH2&=0xFB
+#define clr_EIPH2_PSC1H                    SFRS=2;EIPH2&=0xFD
+#define clr_EIPH2_PSC0H                    SFRS=2;EIPH2&=0xFE
+
+/**** PWM3CON0  D4H  PAGE 2 ****/
+#define set_PWM3CON0_PWMRUN              SFRS=2;PWM3CON0|=0x80
+#define set_PWM3CON0_LOAD                SFRS=2;PWM3CON0|=0x40
+#define set_PWM3CON0_PWMF                SFRS=2;PWM3CON0|=0x20
+#define set_PWM3CON0_CLRPWM              SFRS=2;PWM3CON0|=0x10
+
+#define clr_PWM3CON0_PWMRUN              SFRS=2;PWM3CON0&=0x7F
+#define clr_PWM3CON0_LOAD                SFRS=2;PWM3CON0&=0xBF
+#define clr_PWM3CON0_PWMF                SFRS=2;PWM3CON0&=0xDF
+#define clr_PWM3CON0_CLRPWM              SFRS=2;PWM3CON0&=0xEF
+
+/**** PWM3CON1  D5H  PAGE 2 ****/
+#define set_PWM3CON1_PWMMOD1             SFRS=2;PWM3CON1|=0x80
+#define set_PWM3CON1_PWMMOD0             SFRS=2;PWM3CON1|=0x40
+#define set_PWM3CON1_PWMTYP              SFRS=2;PWM3CON1|=0x20
+#define set_PWM3CON1_PWMDIV2             SFRS=2;PWM3CON1|=0x04
+#define set_PWM3CON1_PWMDIV1             SFRS=2;PWM3CON1|=0x02
+#define set_PWM3CON1_PWMDIV0             SFRS=2;PWM3CON1|=0x01
+
+#define clr_PWM3CON1_PWMMOD1             SFRS=2;PWM3CON1&=0x7F
+#define clr_PWM3CON1_PWMMOD0             SFRS=2;PWM3CON1&=0xBF
+#define clr_PWM3CON1_PWMTYP              SFRS=2;PWM3CON1&=0xDF
+#define clr_PWM3CON1_PWMDIV2             SFRS=2;PWM3CON1&=0xFB
+#define clr_PWM3CON1_PWMDIV1             SFRS=2;PWM3CON1&=0xFD
+#define clr_PWM3CON1_PWMDIV0             SFRS=2;PWM3CON1&=0xFE
+
+/**** PWM3INTC  D6H  PAGE 2 ****/
+#define set_PWM3INTC_INTTYP1             SFRS=2;PWM3INTC|=0x20
+#define set_PWM3INTC_INTTYP0             SFRS=2;PWM3INTC|=0x10
+#define set_PWM3INTC_INTSEL2             SFRS=2;PWM3INTC|=0x04
+#define set_PWM3INTC_INTSEL1             SFRS=2;PWM3INTC|=0x02
+#define set_PWM3INTC_INTSEL0             SFRS=2;PWM3INTC|=0x01
+
+#define clr_PWM3INTC_INTTYP1             SFRS=2;PWM3INTC&=0xDF
+#define clr_PWM3INTC_INTTYP0             SFRS=2;PWM3INTC&=0xEF
+#define clr_PWM3INTC_INTSEL2             SFRS=2;PWM3INTC&=0xFB
+#define clr_PWM3INTC_INTSEL1             SFRS=2;PWM3INTC&=0xFD
+#define clr_PWM3INTC_INTSEL0             SFRS=2;PWM3INTC&=0xFE
+
+/**** XTLCON  D7H  PAGE 2 TA protect register ****/
+#define set_XTLCON_HXSG2                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON|=0x40;EA=BIT_TMP
+#define set_XTLCON_HXSG1                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON|=0x20;EA=BIT_TMP
+#define set_XTLCON_HXSG0                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON|=0x10;EA=BIT_TMP
+
+#define clr_XTLCON_HXSG2                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON&=0xBF;EA=BIT_TMP
+#define clr_XTLCON_HXSG1                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON&=0xDF;EA=BIT_TMP
+#define clr_XTLCON_HXSG0                 SFRS=2;BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;XTLCON&=0xEF;EA=BIT_TMP
+
+/**** SC0ETURD1  DCH  PAGE 2 ****/
+#define set_SC0ETURD1_SCDIV2             SFRS=2;SC0ETURD1|=0x40
+#define set_SC0ETURD1_SCDIV1             SFRS=2;SC0ETURD1|=0x20
+#define set_SC0ETURD1_SCDIV0             SFRS=2;SC0ETURD1|=0x10
+#define set_SC0ETURD1_ETURDIV11          SFRS=2;SC0ETURD1|=0x08
+#define set_SC0ETURD1_ETURDIV10          SFRS=2;SC0ETURD1|=0x04
+#define set_SC0ETURD1_ETURDIV9           SFRS=2;SC0ETURD1|=0x02
+#define set_SC0ETURD1_ETURDIV8           SFRS=2;SC0ETURD1|=0x01
+
+#define clr_SC0ETURD1_SCDIV2             SFRS=2;SC0ETURD1&=0xBF
+#define clr_SC0ETURD1_SCDIV1             SFRS=2;SC0ETURD1&=0xDF
+#define clr_SC0ETURD1_SCDIV0             SFRS=2;SC0ETURD1&=0xEF
+#define clr_SC0ETURD1_ETURDIV11          SFRS=2;SC0ETURD1&=0xF7
+#define clr_SC0ETURD1_ETURDIV10          SFRS=2;SC0ETURD1&=0xFB
+#define clr_SC0ETURD1_ETURDIV9           SFRS=2;SC0ETURD1&=0xFD
+#define clr_SC0ETURD1_ETURDIV8           SFRS=2;SC0ETURD1&=0xFE
+
+/**** SC0IE  DDH  PAGE 2 ****/
+#define set_SC0IE_ACERRIEN               SFRS=2;SC0IE|=0x10
+#define set_SC0IE_BGTIEN                 SFRS=2;SC0IE|=0x08
+#define set_SC0IE_TERRIEN                SFRS=2;SC0IE|=0x04
+#define set_SC0IE_TBEIEN                 SFRS=2;SC0IE|=0x02
+#define set_SC0IE_RDAIEN                 SFRS=2;SC0IE|=0x01
+
+#define clr_SC0IE_ACERRIEN               SFRS=2;SC0IE&=0xEF
+#define clr_SC0IE_BGTIEN                 SFRS=2;SC0IE&=0xF7
+#define clr_SC0IE_TERRIEN                SFRS=2;SC0IE&=0xFB
+#define clr_SC0IE_TBEIEN                 SFRS=2;SC0IE&=0xFD
+#define clr_SC0IE_RDAIEN                 SFRS=2;SC0IE&=0xFE
+
+/**** SC0IS  DEH  PAGE 2 ****/
+#define set_SC0IS_ACERRIF                SFRS=2;SC0IS|=0x10
+#define set_SC0IS_BGTIF                  SFRS=2;SC0IS|=0x08
+#define set_SC0IS_TERRIF                 SFRS=2;SC0IS|=0x04
+#define set_SC0IS_TBEIF                  SFRS=2;SC0IS|=0x02
+#define set_SC0IS_RDAIF                  SFRS=2;SC0IS|=0x01
+
+#define clr_SC0IS_ACERRIF                SFRS=2;SC0IS&=0xEF
+#define clr_SC0IS_BGTIF                  SFRS=2;SC0IS&=0xF7
+#define clr_SC0IS_TERRIF                 SFRS=2;SC0IS&=0xFB
+#define clr_SC0IS_TBEIF                  SFRS=2;SC0IS&=0xFD
+#define clr_SC0IS_RDAIF                  SFRS=2;SC0IS&=0xFE
+
+/**** SC0TSR  DFH  PAGE 2 ****/
+#define set_SC0TSR_ACT                   SFRS=2;SC0TSR|=0x80
+#define set_SC0TSR_BEF                   SFRS=2;SC0TSR|=0x40
+#define set_SC0TSR_FEF                   SFRS=2;SC0TSR|=0x20
+#define set_SC0TSR_PEF                   SFRS=2;SC0TSR|=0x10
+#define set_SC0TSR_TXEMPTY               SFRS=2;SC0TSR|=0x08
+#define set_SC0TSR_TXOV                  SFRS=2;SC0TSR|=0x04
+#define set_SC0TSR_RXEMPTY               SFRS=2;SC0TSR|=0x02
+#define set_SC0TSR_RXOV                  SFRS=2;SC0TSR|=0x01
+
+#define clr_SC0TSR_ACT                   SFRS=2;SC0TSR&=0x7F
+#define clr_SC0TSR_BEF                   SFRS=2;SC0TSR&=0xBF
+#define clr_SC0TSR_FEF                   SFRS=2;SC0TSR&=0xDF
+#define clr_SC0TSR_PEF                   SFRS=2;SC0TSR&=0xEF
+#define clr_SC0TSR_TXEMPTY               SFRS=2;SC0TSR&=0xF7
+#define clr_SC0TSR_TXOV                  SFRS=2;SC0TSR&=0xFB
+#define clr_SC0TSR_RXEMPTY               SFRS=2;SC0TSR&=0xFD
+#define clr_SC0TSR_RXOV                  SFRS=2;SC0TSR&=0xFE
+
+/**** SC1ETURD1  E4H  PAGE 2 ****/
+#define set_SC1ETURD1_SCDIV2             SFRS=2;SC1ETURD1|=0x40
+#define set_SC1ETURD1_SCDIV1             SFRS=2;SC1ETURD1|=0x20
+#define set_SC1ETURD1_SCDIV0             SFRS=2;SC1ETURD1|=0x10
+#define set_SC1ETURD1_ETURDIV11          SFRS=2;SC1ETURD1|=0x08
+#define set_SC1ETURD1_ETURDIV10          SFRS=2;SC1ETURD1|=0x04
+#define set_SC1ETURD1_ETURDIV9           SFRS=2;SC1ETURD1|=0x02
+#define set_SC1ETURD1_ETURDIV8           SFRS=2;SC1ETURD1|=0x01
+
+#define clr_SC1ETURD1_SCDIV2             SFRS=2;SC1ETURD1&=0xBF
+#define clr_SC1ETURD1_SCDIV1             SFRS=2;SC1ETURD1&=0xDF
+#define clr_SC1ETURD1_SCDIV0             SFRS=2;SC1ETURD1&=0xEF
+#define clr_SC1ETURD1_ETURDIV11          SFRS=2;SC1ETURD1&=0xF7
+#define clr_SC1ETURD1_ETURDIV10          SFRS=2;SC1ETURD1&=0xFB
+#define clr_SC1ETURD1_ETURDIV9           SFRS=2;SC1ETURD1&=0xFD
+#define clr_SC1ETURD1_ETURDIV8           SFRS=2;SC1ETURD1&=0xFE
+
+/**** SC1IE  E5H  PAGE 2 ****/
+#define set_SC1IE_ACERRIEN               SFRS=2;SC1IE|=0x10
+#define set_SC1IE_BGTIEN                 SFRS=2;SC1IE|=0x08
+#define set_SC1IE_TERRIEN                SFRS=2;SC1IE|=0x04
+#define set_SC1IE_TBEIEN                 SFRS=2;SC1IE|=0x02
+#define set_SC1IE_RDAIEN                 SFRS=2;SC1IE|=0x01
+
+#define clr_SC1IE_ACERRIEN               SFRS=2;SC1IE&=0xEF
+#define clr_SC1IE_BGTIEN                 SFRS=2;SC1IE&=0xF7
+#define clr_SC1IE_TERRIEN                SFRS=2;SC1IE&=0xFB
+#define clr_SC1IE_TBEIEN                 SFRS=2;SC1IE&=0xFD
+#define clr_SC1IE_RDAIEN                 SFRS=2;SC1IE&=0xFE
+
+/**** SC1IS  E6H  PAGE 2 ****/
+#define set_SC1IS_ACERRIF                SFRS=2;SC1IS|=0x10
+#define set_SC1IS_BGTIF                  SFRS=2;SC1IS|=0x08
+#define set_SC1IS_TERRIF                 SFRS=2;SC1IS|=0x04
+#define set_SC1IS_TBEIF                  SFRS=2;SC1IS|=0x02
+#define set_SC1IS_RDAIF                  SFRS=2;SC1IS|=0x01
+
+#define clr_SC1IS_ACERRIF                SFRS=2;SC1IS&=0xEF
+#define clr_SC1IS_BGTIF                  SFRS=2;SC1IS&=0xF7
+#define clr_SC1IS_TERRIF                 SFRS=2;SC1IS&=0xFB
+#define clr_SC1IS_TBEIF                  SFRS=2;SC1IS&=0xFD
+#define clr_SC1IS_RDAIF                  SFRS=2;SC1IS&=0xFE
+
+/**** SC1TSR  E7H  PAGE 2 ****/
+#define set_SC1TSR_ACT                   SFRS=2;SC1TSR|=0x80
+#define set_SC1TSR_BEF                   SFRS=2;SC1TSR|=0x40
+#define set_SC1TSR_FEF                   SFRS=2;SC1TSR|=0x20
+#define set_SC1TSR_PEF                   SFRS=2;SC1TSR|=0x10
+#define set_SC1TSR_TXEMPTY               SFRS=2;SC1TSR|=0x08
+#define set_SC1TSR_TXOV                  SFRS=2;SC1TSR|=0x04
+#define set_SC1TSR_RXEMPTY               SFRS=2;SC1TSR|=0x02
+#define set_SC1TSR_RXOV                  SFRS=2;SC1TSR|=0x01
+
+#define clr_SC1TSR_ACT                   SFRS=2;SC1TSR&=0x7F
+#define clr_SC1TSR_BEF                   SFRS=2;SC1TSR&=0xBF
+#define clr_SC1TSR_FEF                   SFRS=2;SC1TSR&=0xDF
+#define clr_SC1TSR_PEF                   SFRS=2;SC1TSR&=0xEF
+#define clr_SC1TSR_TXEMPTY               SFRS=2;SC1TSR&=0xF7
+#define clr_SC1TSR_TXOV                  SFRS=2;SC1TSR&=0xFB
+#define clr_SC1TSR_RXEMPTY               SFRS=2;SC1TSR&=0xFD
+#define clr_SC1TSR_RXOV                  SFRS=2;SC1TSR&=0xFE
+
+/**** SC2ETURD1  ECH  PAGE 2 ****/
+#define set_SC2ETURD1_SCDIV2             SFRS=2;SC2ETURD1|=0x40
+#define set_SC2ETURD1_SCDIV1             SFRS=2;SC2ETURD1|=0x20
+#define set_SC2ETURD1_SCDIV0             SFRS=2;SC2ETURD1|=0x10
+#define set_SC2ETURD1_ETURDIV11          SFRS=2;SC2ETURD1|=0x08
+#define set_SC2ETURD1_ETURDIV10          SFRS=2;SC2ETURD1|=0x04
+#define set_SC2ETURD1_ETURDIV9           SFRS=2;SC2ETURD1|=0x02
+#define set_SC2ETURD1_ETURDIV8           SFRS=2;SC2ETURD1|=0x01
+
+#define clr_SC2ETURD1_SCDIV2             SFRS=2;SC2ETURD1&=0xBF
+#define clr_SC2ETURD1_SCDIV1             SFRS=2;SC2ETURD1&=0xDF
+#define clr_SC2ETURD1_SCDIV0             SFRS=2;SC2ETURD1&=0xEF
+#define clr_SC2ETURD1_ETURDIV11          SFRS=2;SC2ETURD1&=0xF7
+#define clr_SC2ETURD1_ETURDIV10          SFRS=2;SC2ETURD1&=0xFB
+#define clr_SC2ETURD1_ETURDIV9           SFRS=2;SC2ETURD1&=0xFD
+#define clr_SC2ETURD1_ETURDIV8           SFRS=2;SC2ETURD1&=0xFE
+
+/**** SC2IE  EDH  PAGE 2 ****/
+#define set_SC2IE_ACERRIEN               SFRS=2;SC2IE|=0x10
+#define set_SC2IE_BGTIEN                 SFRS=2;SC2IE|=0x08
+#define set_SC2IE_TERRIEN                SFRS=2;SC2IE|=0x04
+#define set_SC2IE_TBEIEN                 SFRS=2;SC2IE|=0x02
+#define set_SC2IE_RDAIEN                 SFRS=2;SC2IE|=0x01
+
+#define clr_SC2IE_ACERRIEN               SFRS=2;SC2IE&=0xEF
+#define clr_SC2IE_BGTIEN                 SFRS=2;SC2IE&=0xF7
+#define clr_SC2IE_TERRIEN                SFRS=2;SC2IE&=0xFB
+#define clr_SC2IE_TBEIEN                 SFRS=2;SC2IE&=0xFD
+#define clr_SC2IE_RDAIEN                 SFRS=2;SC2IE&=0xFE
+
+/**** SC2IS  EEH  PAGE 2 ****/
+#define set_SC2IS_ACERRIF                SFRS=2;SC2IS|=0x10
+#define set_SC2IS_BGTIF                  SFRS=2;SC2IS|=0x08
+#define set_SC2IS_TERRIF                 SFRS=2;SC2IS|=0x04
+#define set_SC2IS_TBEIF                  SFRS=2;SC2IS|=0x02
+#define set_SC2IS_RDAIF                  SFRS=2;SC2IS|=0x01
+
+#define clr_SC2IS_ACERRIF                SFRS=2;SC2IS&=0xEF
+#define clr_SC2IS_BGTIF                  SFRS=2;SC2IS&=0xF7
+#define clr_SC2IS_TERRIF                 SFRS=2;SC2IS&=0xFB
+#define clr_SC2IS_TBEIF                  SFRS=2;SC2IS&=0xFD
+#define clr_SC2IS_RDAIF                  SFRS=2;SC2IS&=0xFE
+
+/**** SC2TSR  EFH  PAGE 2 ****/
+#define set_SC2TSR_ACT                   SFRS=2;SC2TSR|=0x80
+#define set_SC2TSR_BEF                   SFRS=2;SC2TSR|=0x40
+#define set_SC2TSR_FEF                   SFRS=2;SC2TSR|=0x20
+#define set_SC2TSR_PEF                   SFRS=2;SC2TSR|=0x10
+#define set_SC2TSR_TXEMPTY               SFRS=2;SC2TSR|=0x08
+#define set_SC2TSR_TXOV                  SFRS=2;SC2TSR|=0x04
+#define set_SC2TSR_RXEMPTY               SFRS=2;SC2TSR|=0x02
+#define set_SC2TSR_RXOV                  SFRS=2;SC2TSR|=0x01
+
+#define clr_SC2TSR_ACT                   SFRS=2;SC2TSR&=0x7F
+#define clr_SC2TSR_BEF                   SFRS=2;SC2TSR&=0xBF
+#define clr_SC2TSR_FEF                   SFRS=2;SC2TSR&=0xDF
+#define clr_SC2TSR_PEF                   SFRS=2;SC2TSR&=0xEF
+#define clr_SC2TSR_TXEMPTY               SFRS=2;SC2TSR&=0xF7
+#define clr_SC2TSR_TXOV                  SFRS=2;SC2TSR&=0xFB
+#define clr_SC2TSR_RXEMPTY               SFRS=2;SC2TSR&=0xFD
+#define clr_SC2TSR_RXOV                  SFRS=2;SC2TSR&=0xFE
+
+/**** SC0CR0  F1H  PAGE 2 ****/
+#define set_SC0CR0_NSB                   SFRS=2;SC0CR0|=0x80
+#define set_SC0CR0_T                     SFRS=2;SC0CR0|=0x40
+#define set_SC0CR0_RXBGTEN               SFRS=2;SC0CR0|=0x20
+#define set_SC0CR0_CONSEL                SFRS=2;SC0CR0|=0x10
+#define set_SC0CR0_AUTOCEN               SFRS=2;SC0CR0|=0x08
+#define set_SC0CR0_TXOFF                 SFRS=2;SC0CR0|=0x04
+#define set_SC0CR0_RXOFF                 SFRS=2;SC0CR0|=0x02
+#define set_SC0CR0_SCEN                  SFRS=2;SC0CR0|=0x01
+
+#define clr_SC0CR0_NSB                   SFRS=2;SC0CR0&=0x7F
+#define clr_SC0CR0_T                     SFRS=2;SC0CR0&=0xBF
+#define clr_SC0CR0_RXBGTEN               SFRS=2;SC0CR0&=0xDF
+#define clr_SC0CR0_CONSEL                SFRS=2;SC0CR0&=0xEF
+#define clr_SC0CR0_AUTOCEN               SFRS=2;SC0CR0&=0xF7
+#define clr_SC0CR0_TXOFF                 SFRS=2;SC0CR0&=0xFB
+#define clr_SC0CR0_RXOFF                 SFRS=2;SC0CR0&=0xFD
+#define clr_SC0CR0_SCEN                  SFRS=2;SC0CR0&=0xFE
+
+/**** SC0CR1  F2H  PAGE 2 ****/
+#define set_SC0CR1_OPE                   SFRS=2;SC0CR1|=0x80
+#define set_SC0CR1_PBOFF                 SFRS=2;SC0CR1|=0x40
+#define set_SC0CR1_WLS1                  SFRS=2;SC0CR1|=0x20
+#define set_SC0CR1_WLS0                  SFRS=2;SC0CR1|=0x10
+#define set_SC0CR1_TXDMAEN               SFRS=2;SC0CR1|=0x08
+#define set_SC0CR1_RXDMAEN               SFRS=2;SC0CR1|=0x04
+#define set_SC0CR1_CLKKEEP               SFRS=2;SC0CR1|=0x02
+#define set_SC0CR1_UARTEN                SFRS=2;SC0CR1|=0x01
+
+#define clr_SC0CR1_OPE                   SFRS=2;SC0CR1&=0x7F
+#define clr_SC0CR1_PBOFF                 SFRS=2;SC0CR1&=0xBF
+#define clr_SC0CR1_WLS1                  SFRS=2;SC0CR1&=0xDF
+#define clr_SC0CR1_WLS0                  SFRS=2;SC0CR1&=0xEF
+#define clr_SC0CR1_TXDMAEN               SFRS=2;SC0CR1&=0xF7
+#define clr_SC0CR1_RXDMAEN               SFRS=2;SC0CR1&=0xFB
+#define clr_SC0CR1_CLKKEEP               SFRS=2;SC0CR1&=0xFD
+#define clr_SC0CR1_UARTEN                SFRS=2;SC0CR1&=0xFE
+
+/**** SC1CR0  F3H  PAGE 2 ****/
+#define set_SC1CR0_NSB                   SFRS=2;SC1CR0|=0x80
+#define set_SC1CR0_T                     SFRS=2;SC1CR0|=0x40
+#define set_SC1CR0_RXBGTEN               SFRS=2;SC1CR0|=0x20
+#define set_SC1CR0_CONSEL                SFRS=2;SC1CR0|=0x10
+#define set_SC1CR0_AUTOCEN               SFRS=2;SC1CR0|=0x08
+#define set_SC1CR0_TXOFF                 SFRS=2;SC1CR0|=0x04
+#define set_SC1CR0_RXOFF                 SFRS=2;SC1CR0|=0x02
+#define set_SC1CR0_SCEN                  SFRS=2;SC1CR0|=0x01
+
+#define clr_SC1CR0_NSB                   SFRS=2;SC1CR0&=0x7F
+#define clr_SC1CR0_T                     SFRS=2;SC1CR0&=0xBF
+#define clr_SC1CR0_RXBGTEN               SFRS=2;SC1CR0&=0xDF
+#define clr_SC1CR0_CONSEL                SFRS=2;SC1CR0&=0xEF
+#define clr_SC1CR0_AUTOCEN               SFRS=2;SC1CR0&=0xF7
+#define clr_SC1CR0_TXOFF                 SFRS=2;SC1CR0&=0xFB
+#define clr_SC1CR0_RXOFF                 SFRS=2;SC1CR0&=0xFD
+#define clr_SC1CR0_SCEN                  SFRS=2;SC1CR0&=0xFE
+
+/**** SC1CR1  F4H  PAGE 2 ****/
+#define set_SC1CR1_OPE                   SFRS=2;SC1CR1|=0x80
+#define set_SC1CR1_PBOFF                 SFRS=2;SC1CR1|=0x40
+#define set_SC1CR1_WLS1                  SFRS=2;SC1CR1|=0x20
+#define set_SC1CR1_WLS0                  SFRS=2;SC1CR1|=0x10
+#define set_SC1CR1_TXDMAEN               SFRS=2;SC1CR1|=0x08
+#define set_SC1CR1_RXDMAEN               SFRS=2;SC1CR1|=0x04
+#define set_SC1CR1_CLKKEEP               SFRS=2;SC1CR1|=0x02
+#define set_SC1CR1_UARTEN                SFRS=2;SC1CR1|=0x01
+
+#define clr_SC1CR1_OPE                   SFRS=2;SC1CR1&=0x7F
+#define clr_SC1CR1_PBOFF                 SFRS=2;SC1CR1&=0xBF
+#define clr_SC1CR1_WLS1                  SFRS=2;SC1CR1&=0xDF
+#define clr_SC1CR1_WLS0                  SFRS=2;SC1CR1&=0xEF
+#define clr_SC1CR1_TXDMAEN               SFRS=2;SC1CR1&=0xF7
+#define clr_SC1CR1_RXDMAEN               SFRS=2;SC1CR1&=0xFB
+#define clr_SC1CR1_CLKKEEP               SFRS=2;SC1CR1&=0xFD
+#define clr_SC1CR1_UARTEN                SFRS=2;SC1CR1&=0xFE
+
+/**** SC2CR0  F5H  PAGE 2 ****/
+#define set_SC2CR0_NSB                   SFRS=2;SC2CR0|=0x80
+#define set_SC2CR0_T                     SFRS=2;SC2CR0|=0x40
+#define set_SC2CR0_RXBGTEN               SFRS=2;SC2CR0|=0x20
+#define set_SC2CR0_CONSEL                SFRS=2;SC2CR0|=0x10
+#define set_SC2CR0_AUTOCEN               SFRS=2;SC2CR0|=0x08
+#define set_SC2CR0_TXOFF                 SFRS=2;SC2CR0|=0x04
+#define set_SC2CR0_RXOFF                 SFRS=2;SC2CR0|=0x02
+#define set_SC2CR0_SCEN                  SFRS=2;SC2CR0|=0x01
+
+#define clr_SC2CR0_NSB                   SFRS=2;SC2CR0&=0x7F
+#define clr_SC2CR0_T                     SFRS=2;SC2CR0&=0xBF
+#define clr_SC2CR0_RXBGTEN               SFRS=2;SC2CR0&=0xDF
+#define clr_SC2CR0_CONSEL                SFRS=2;SC2CR0&=0xEF
+#define clr_SC2CR0_AUTOCEN               SFRS=2;SC2CR0&=0xF7
+#define clr_SC2CR0_TXOFF                 SFRS=2;SC2CR0&=0xFB
+#define clr_SC2CR0_RXOFF                 SFRS=2;SC2CR0&=0xFD
+#define clr_SC2CR0_SCEN                  SFRS=2;SC2CR0&=0xFE
+
+/**** SC2CR1  F6H  PAGE 2 ****/
+#define set_SC2CR1_OPE                   SFRS=2;SC2CR1|=0x80
+#define set_SC2CR1_PBOFF                 SFRS=2;SC2CR1|=0x40
+#define set_SC2CR1_WLS1                  SFRS=2;SC2CR1|=0x20
+#define set_SC2CR1_WLS0                  SFRS=2;SC2CR1|=0x10
+#define set_SC2CR1_TXDMAEN               SFRS=2;SC2CR1|=0x08
+#define set_SC2CR1_RXDMAEN               SFRS=2;SC2CR1|=0x04
+#define set_SC2CR1_CLKKEEP               SFRS=2;SC2CR1|=0x02
+#define set_SC2CR1_UARTEN                SFRS=2;SC2CR1|=0x01
+
+#define clr_SC2CR1_OPE                   SFRS=2;SC2CR1&=0x7F
+#define clr_SC2CR1_PBOFF                 SFRS=2;SC2CR1&=0xBF
+#define clr_SC2CR1_WLS1                  SFRS=2;SC2CR1&=0xDF
+#define clr_SC2CR1_WLS0                  SFRS=2;SC2CR1&=0xEF
+#define clr_SC2CR1_TXDMAEN               SFRS=2;SC2CR1&=0xF7
+#define clr_SC2CR1_RXDMAEN               SFRS=2;SC2CR1&=0xFB
+#define clr_SC2CR1_CLKKEEP               SFRS=2;SC2CR1&=0xFD
+#define clr_SC2CR1_UARTEN                SFRS=2;SC2CR1&=0xFE
+
+/**** PIPS7  F7H  PAGE 2 ****/
+#define set_PIPS7_PSEL2                  SFRS=2;PIPS7|=0x40
+#define set_PIPS7_PSEL1                  SFRS=2;PIPS7|=0x20
+#define set_PIPS7_PSEL0                  SFRS=2;PIPS7|=0x10
+#define set_PIPS7_BSEL2                  SFRS=2;PIPS7|=0x04
+#define set_PIPS7_BSEL1                  SFRS=2;PIPS7|=0x02
+#define set_PIPS7_BSEL0                  SFRS=2;PIPS7|=0x01
+
+#define clr_PIPS7_PSEL2                  SFRS=2;PIPS7&=0xBF
+#define clr_PIPS7_PSEL1                  SFRS=2;PIPS7&=0xDF
+#define clr_PIPS7_PSEL0                  SFRS=2;PIPS7&=0xEF
+#define clr_PIPS7_BSEL2                  SFRS=2;PIPS7&=0xFB
+#define clr_PIPS7_BSEL1                  SFRS=2;PIPS7&=0xFD
+#define clr_PIPS7_BSEL0                  SFRS=2;PIPS7&=0xFE
+
+/**** PIPS0  F9H  PAGE 2 ****/
+#define set_PIPS0_PSEL2                  SFRS=2;PIPS0|=0x40
+#define set_PIPS0_PSEL1                  SFRS=2;PIPS0|=0x20
+#define set_PIPS0_PSEL0                  SFRS=2;PIPS0|=0x10
+#define set_PIPS0_BSEL2                  SFRS=2;PIPS0|=0x04
+#define set_PIPS0_BSEL1                  SFRS=2;PIPS0|=0x02
+#define set_PIPS0_BSEL0                  SFRS=2;PIPS0|=0x01
+
+#define clr_PIPS0_PSEL2                  SFRS=2;PIPS0&=0xBF
+#define clr_PIPS0_PSEL1                  SFRS=2;PIPS0&=0xDF
+#define clr_PIPS0_PSEL0                  SFRS=2;PIPS0&=0xEF
+#define clr_PIPS0_BSEL2                  SFRS=2;PIPS0&=0xFB
+#define clr_PIPS0_BSEL1                  SFRS=2;PIPS0&=0xFD
+#define clr_PIPS0_BSEL0                  SFRS=2;PIPS0&=0xFE
+
+/**** PIPS1  FAH  PAGE 2 ****/
+#define set_PIPS1_PSEL2                  SFRS=2;PIPS1|=0x40
+#define set_PIPS1_PSEL1                  SFRS=2;PIPS1|=0x20
+#define set_PIPS1_PSEL0                  SFRS=2;PIPS1|=0x10
+#define set_PIPS1_BSEL2                  SFRS=2;PIPS1|=0x04
+#define set_PIPS1_BSEL1                  SFRS=2;PIPS1|=0x02
+#define set_PIPS1_BSEL0                  SFRS=2;PIPS1|=0x01
+
+#define clr_PIPS1_PSEL2                  SFRS=2;PIPS1&=0xBF
+#define clr_PIPS1_PSEL1                  SFRS=2;PIPS1&=0xDF
+#define clr_PIPS1_PSEL0                  SFRS=2;PIPS1&=0xEF
+#define clr_PIPS1_BSEL2                  SFRS=2;PIPS1&=0xFB
+#define clr_PIPS1_BSEL1                  SFRS=2;PIPS1&=0xFD
+#define clr_PIPS1_BSEL0                  SFRS=2;PIPS1&=0xFE
+
+/**** PIPS2  FBH  PAGE 2 ****/
+#define set_PIPS2_PSEL2                  SFRS=2;PIPS2|=0x40
+#define set_PIPS2_PSEL1                  SFRS=2;PIPS2|=0x20
+#define set_PIPS2_PSEL0                  SFRS=2;PIPS2|=0x10
+#define set_PIPS2_BSEL2                  SFRS=2;PIPS2|=0x04
+#define set_PIPS2_BSEL1                  SFRS=2;PIPS2|=0x02
+#define set_PIPS2_BSEL0                  SFRS=2;PIPS2|=0x01
+
+#define clr_PIPS2_PSEL2                  SFRS=2;PIPS2&=0xBF
+#define clr_PIPS2_PSEL1                  SFRS=2;PIPS2&=0xDF
+#define clr_PIPS2_PSEL0                  SFRS=2;PIPS2&=0xEF
+#define clr_PIPS2_BSEL2                  SFRS=2;PIPS2&=0xFB
+#define clr_PIPS2_BSEL1                  SFRS=2;PIPS2&=0xFD
+#define clr_PIPS2_BSEL0                  SFRS=2;PIPS2&=0xFE
+
+/**** PIPS3  FCH  PAGE 2 ****/
+#define set_PIPS3_PSEL2                  SFRS=2;PIPS3|=0x40
+#define set_PIPS3_PSEL1                  SFRS=2;PIPS3|=0x20
+#define set_PIPS3_PSEL0                  SFRS=2;PIPS3|=0x10
+#define set_PIPS3_BSEL2                  SFRS=2;PIPS3|=0x04
+#define set_PIPS3_BSEL1                  SFRS=2;PIPS3|=0x02
+#define set_PIPS3_BSEL0                  SFRS=2;PIPS3|=0x01
+
+#define clr_PIPS3_PSEL2                  SFRS=2;PIPS3&=0xBF
+#define clr_PIPS3_PSEL1                  SFRS=2;PIPS3&=0xDF
+#define clr_PIPS3_PSEL0                  SFRS=2;PIPS3&=0xEF
+#define clr_PIPS3_BSEL2                  SFRS=2;PIPS3&=0xFB
+#define clr_PIPS3_BSEL1                  SFRS=2;PIPS3&=0xFD
+#define clr_PIPS3_BSEL0                  SFRS=2;PIPS3&=0xFE
+
+/**** PIPS4  FDH  PAGE 2 ****/
+#define set_PIPS4_PSEL2                  SFRS=2;PIPS4|=0x40
+#define set_PIPS4_PSEL1                  SFRS=2;PIPS4|=0x20
+#define set_PIPS4_PSEL0                  SFRS=2;PIPS4|=0x10
+#define set_PIPS4_BSEL2                  SFRS=2;PIPS4|=0x04
+#define set_PIPS4_BSEL1                  SFRS=2;PIPS4|=0x02
+#define set_PIPS4_BSEL0                  SFRS=2;PIPS4|=0x01
+
+#define clr_PIPS4_PSEL2                  SFRS=2;PIPS4&=0xBF
+#define clr_PIPS4_PSEL1                  SFRS=2;PIPS4&=0xDF
+#define clr_PIPS4_PSEL0                  SFRS=2;PIPS4&=0xEF
+#define clr_PIPS4_BSEL2                  SFRS=2;PIPS4&=0xFB
+#define clr_PIPS4_BSEL1                  SFRS=2;PIPS4&=0xFD
+#define clr_PIPS4_BSEL0                  SFRS=2;PIPS4&=0xFE
+
+/**** PIPS5  FEH  PAGE 2 ****/
+#define set_PIPS5_PSEL2                  SFRS=2;PIPS5|=0x40
+#define set_PIPS5_PSEL1                  SFRS=2;PIPS5|=0x20
+#define set_PIPS5_PSEL0                  SFRS=2;PIPS5|=0x10
+#define set_PIPS5_BSEL2                  SFRS=2;PIPS5|=0x04
+#define set_PIPS5_BSEL1                  SFRS=2;PIPS5|=0x02
+#define set_PIPS5_BSEL0                  SFRS=2;PIPS5|=0x01
+
+#define clr_PIPS5_PSEL2                  SFRS=2;PIPS5&=0xBF
+#define clr_PIPS5_PSEL1                  SFRS=2;PIPS5&=0xDF
+#define clr_PIPS5_PSEL0                  SFRS=2;PIPS5&=0xEF
+#define clr_PIPS5_BSEL2                  SFRS=2;PIPS5&=0xFB
+#define clr_PIPS5_BSEL1                  SFRS=2;PIPS5&=0xFD
+#define clr_PIPS5_BSEL0                  SFRS=2;PIPS5&=0xFE
+
+/**** PIPS6  FFH  PAGE 2 ****/
+#define set_PIPS6_PSEL2                  SFRS=2;PIPS6|=0x40
+#define set_PIPS6_PSEL1                  SFRS=2;PIPS6|=0x20
+#define set_PIPS6_PSEL0                  SFRS=2;PIPS6|=0x10
+#define set_PIPS6_BSEL2                  SFRS=2;PIPS6|=0x04
+#define set_PIPS6_BSEL1                  SFRS=2;PIPS6|=0x02
+#define set_PIPS6_BSEL0                  SFRS=2;PIPS6|=0x01
+
+#define clr_PIPS6_PSEL2                  SFRS=2;PIPS6&=0xBF
+#define clr_PIPS6_PSEL1                  SFRS=2;PIPS6&=0xDF
+#define clr_PIPS6_PSEL0                  SFRS=2;PIPS6&=0xEF
+#define clr_PIPS6_BSEL2                  SFRS=2;PIPS6&=0xFB
+#define clr_PIPS6_BSEL1                  SFRS=2;PIPS6&=0xFD
+#define clr_PIPS6_BSEL0                  SFRS=2;PIPS6&=0xFE
+

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/function_define_n76e003.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/function_define_n76e003.h
@@ -1,0 +1,853 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  function_define_n76e003.h                                                      */
+/*  All IP function define for Nuvoton                                                  */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE /                                     */
+/*--------------------------------------------------------------------------------------*/
+
+#ifdef __CDT_PARSER__         /* For __SDCC__ */
+  #define __data
+  #define __near
+  #define __idata
+  #define __xdata
+  #define __far
+  #define __pdata
+  #define __code
+  #define __bit
+  #define __sfr
+  #define __sbit
+  #define __critical
+  #define __at(x)             /* use "__at (0xab)" instead of "__at 0xab" */
+  #define __using(x)
+  #define __interrupt(x)
+  #define __naked
+#endif
+
+typedef unsigned char         UINT8;
+typedef unsigned int          UINT16;
+typedef unsigned long         UINT32;
+typedef signed char           INT8;
+typedef signed int            INT16;
+typedef signed long           INT32;
+
+#if defined __C51__
+typedef bit                   BIT;
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __ICC8051__
+#define BIT __no_init bool __bit
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __SDCC__
+typedef __bit                 BIT;
+#endif
+
+#define Disable  0
+#define Enable   1
+
+#define DISABLE  0
+#define ENABLE   1 
+
+#define TRUE     1  
+#define FALSE    0  
+                    
+#define FAIL     1  
+#define PASS     0  
+                  
+//16 --> 8 x 2
+#define HIBYTE(v1)              ((UINT8)((v1)>>8))                      //v1 is UINT16
+#define LOBYTE(v1)              ((UINT8)((v1)&0xFF))
+//8 x 2 --> 16
+#define MAKEWORD(v1,v2)         ((((UINT16)(v1))<<8)+(UINT16)(v2))      //v1,v2 is UINT8
+//8 x 4 --> 32
+#define MAKELONG(v1,v2,v3,v4)   (UINT32)((v1<<32)+(v2<<16)+(v3<<8)+v4)  //v1,v2,v3,v4 is UINT8
+//32 --> 16 x 2
+#define YBYTE1(v1)              ((UINT16)((v1)>>16))                    //v1 is UINT32
+#define YBYTE0(v1)              ((UINT16)((v1)&0xFFFF))
+//32 --> 8 x 4
+#define TBYTE3(v1)              ((UINT8)((v1)>>24))                     //v1 is UINT32
+#define TBYTE2(v1)              ((UINT8)((v1)>>16))
+#define TBYTE1(v1)              ((UINT8)((v1)>>8)) 
+#define TBYTE0(v1)              ((UINT8)((v1)&0xFF))
+
+#define SET_BIT0        0x01
+#define SET_BIT1        0x02
+#define SET_BIT2        0x04
+#define SET_BIT3        0x08
+#define SET_BIT4        0x10
+#define SET_BIT5        0x20
+#define SET_BIT6        0x40
+#define SET_BIT7        0x80
+
+#define CLR_BIT0        0xFE
+#define CLR_BIT1        0xFD
+#define CLR_BIT2        0xFB
+#define CLR_BIT3        0xF7
+#define CLR_BIT4        0xEF
+#define CLR_BIT5        0xDF
+#define CLR_BIT6        0xBF
+#define CLR_BIT7        0x7F
+
+/*****************************************************************************/
+/*   Stack and NOP                                                           */
+/*****************************************************************************/
+#if defined __C51__
+#define   nop                                  _nop_()
+#define   CALL_NOP                             _nop_()
+#define   PUSH_SFRS                            _push_(SFRS)
+#define   POP_SFRS                             _pop_(SFRS)
+#elif defined __ICC8051__
+#define _nop_()                                asm("nop") 
+#define nop                                    asm("nop")
+#define CALL_NOP                               asm("nop")
+#define PUSH_SFRS                              asm(" PUSH 0x91")
+#define POP_SFRS                               asm(" POP 0x91")
+#define _push_(SFRS)                           asm(" PUSH 0x91")
+#define _pop_(SFRS)                            asm(" POP 0x91")
+#elif defined __SDCC__
+#define _nop_()                                __asm__("nop;")
+#define nop                                    __asm__("nop;")
+#define CALL_NOP                               __asm__("nop;")
+#define PUSH_SFRS                              __asm__(" PUSH 0x91;")
+#define POP_SFRS                               __asm__(" POP 0x91;")
+#define _push_(SFRS)                           __asm__(" PUSH 0x91;")
+#define _pop_(SFRS)                            __asm__(" POP 0x91;")
+#endif
+
+/*****************************************************************************/
+/*   sfr page select                                                          */
+/*****************************************************************************/
+#define    ENABLE_SFR_PAGE1                    set_SFRS_SFRPAGE
+#define    ENABLE_SFR_PAGE0                    clr_SFRS_SFRPAGE
+
+/*****************************************************************************/
+/*   Software reset                                                          */
+/*****************************************************************************/
+#define    ENABLE_SOFTWARE_RESET_TO_APROM      clr_CHPCON_BS;set_CHPCON_SWRST
+#define    ENABLE_SOFTWARE_RESET_TO_LDROM      set_CHPCON_BS;set_CHPCON_SWRST
+
+/*****************************************************************************/
+/*   Power down / idle mode define                                           */
+/*****************************************************************************/
+#define    ENABLE_POWERDOWN_MODE               set_PCON_PD
+#define    ENABLE_IDLE_MODE                    set_PCON_IDLE
+
+/*****************************************************************************/
+/*   BOD Define                                                              */
+/*****************************************************************************/
+#define    BOD_ENABLE               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    BOD_RESET_ENABLE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    BOD_DISABLE              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+ /****/
+#define    ENABLE_BOD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    ENABLE_BOD_RESET         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    DISABLE_BOD              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+
+/*****************************************************************************/
+/*    IAP function process                                                   */ 
+/*****************************************************************************/
+#define    PAGE_SIZE               128
+
+#define    READ_CID                0x0B
+#define    READ_DID                0x0C
+#define    READ_UID                0x04
+
+#define    PAGE_ERASE_APROM        0x22
+#define    BYTE_READ_APROM         0x00
+#define    BYTE_PROGRAM_APROM      0x21
+
+#define    PAGE_ERASE_LDROM        0x62
+#define    BYTE_READ_LDROM         0x40
+#define    BYTE_PROGRAM_LDROM      0x61
+
+#define    ENABLE_SPROM            set_IAPUEN_SPMEN
+#define    PAGE_ERASE_SPROM        0xA2
+#define    BYTE_READ_SPROM         0x80
+#define    BYTE_PROGRAM_SPROM      0xA1
+
+#define    PAGE_ERASE_CONFIG       0xE2
+#define    BYTE_READ_CONFIG        0xC0
+#define    BYTE_PROGRAM_CONFIG     0xE1
+
+#define    CID_READ                0x0B
+#define    DID_READ                0x0C
+
+/*****************************************************************************/
+/*    interrupt function process                                             */ 
+/*****************************************************************************/
+#define    ENABLE_GLOBAL_INTERRUPT       set_IE_EA
+#define    DISABLE_GLOBAL_INTERRUPT      clr_IE_EA
+
+/*Enable Interrupt*/
+#define    ENABLE_ADC_INTERRUPT          set_IE_EADC
+#define    ENABLE_BOD_INTERRUPT          set_IE_EBOD
+#define    ENABLE_UART0_INTERRUPT        set_IE_ES
+#define    ENABLE_TIMER1_INTERRUPT       set_IE_ET1
+#define    ENABLE_INT1_INTERRUPT         set_IE_EX1
+#define    ENABLE_TIMER0_INTERRUPT       set_IE_ET0
+#define    ENABLE_INT0_INTERRUPT         set_IE_EX0
+
+#define    ENABLE_TIMER2_INTERRUPT       set_EIE_ET2
+#define    ENABLE_SPI0_INTERRUPT         set_EIE_ESPI
+#define    ENABLE_PWM0_FB_INTERRUPT      set_EIE_EFB0
+#define    ENABLE_WDT_INTERRUPT          set_EIE_EWDT
+#define    ENABLE_PWM0_INTERRUPT         set_EIE_EPWM
+#define    ENABLE_CAPTURE_INTERRUPT      set_EIE_ECAP
+#define    ENABLE_PIN_INTERRUPT          set_EIE_EPI
+#define    ENABLE_I2C_INTERRUPT          set_EIE_EI2C
+
+#define    ENABLE_WKT_INTERRUPT          set_EIE1_EWKT
+#define    ENABLE_TIMER3_INTERRUPT       set_EIE1_ET3
+#define    ENABLE_UART1_INTERRUPT        set_EIE1_ES_1
+
+/*Disable Interrupt*/ 
+#define    DISABLE_ADC_INTERRUPT         clr_IE_EADC
+#define    DISABLE_BOD_INTERRUPT         clr_IE_EBOD
+#define    DISABLE_UART0_INTERRUPT       clr_IE_ES
+#define    DISABLE_TIMER1_INTERRUPT      clr_IE_ET1
+#define    DISABLE_INT1_INTERRUPT        clr_IE_EX1
+#define    DISABLE_TIMER0_INTERRUPT      clr_IE_ET0
+#define    DISABLE_INT0_INTERRUPT        clr_IE_EX0
+
+#define    DISABLE_TIMER2_INTERRUPT      clr_EIE_ET2
+#define    DISABLE_SPI0_INTERRUPT        clr_EIE_ESPI
+#define    DISABLE_PWM0_FB_INTERRUPT     clr_EIE_EFB0
+#define    DISABLE_WDT_INTERRUPT         clr_EIE_EWDT
+#define    DISABLE_PWM0_INTERRUPT        clr_EIE_EPWM
+#define    DISABLE_CAPTURE_INTERRUPT     clr_EIE_ECAP
+#define    DISABLE_PIN_INTERRUPT         clr_EIE_EPI
+#define    DISABLE_I2C_INTERRUPT         clr_EIE_EI2C
+
+#define    DISABLE_WKT_INTERRUPT         clr_EIE1_EWKT
+#define    DISABLE_TIMER3_INTERRUPT      clr_EIE1_ET3
+#define    DISABLE_UART1_INTERRUPT       clr_EIE1_ES_1
+
+/* Setting Interrupt Priority */
+#define   SET_INT_INT0_LEVEL0          clr_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL1          clr_IP_PX0; set_IPH_PX0H
+#define   SET_INT_INT0_LEVEL2          set_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL3          set_IP_PX0; set_IPH_PX0H
+
+#define   SET_INT_BOD_LEVEL0           clr_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL1           clr_IP_PBOD; set_IPH_PBODH
+#define   SET_INT_BOD_LEVEL2           set_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL3           set_IP_PBOD; set_IPH_PBODH
+
+#define   SET_INT_WDT_LEVEL0           clr_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL1           clr_EIP_PWDT; set_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL2           set_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL3           set_EIP_PWDT; set_EIPH_PWDTH
+
+#define   SET_INT_TIMER0_LEVEL0        clr_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL1        clr_IP_PT0; set_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL2        set_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL3        set_IP_PT0; set_IPH_PT0H
+
+#define   SET_INT_I2C0_LEVEL0          clr_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL1          clr_EIP_PI2C; set_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL2          set_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL3          set_EIP_PI2C; set_EIPH_PI2CH
+
+#define   SET_INT_ADC_LEVEL0           clr_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL1           clr_IP_PADC; set_IPH_PADCH
+#define   SET_INT_ADC_LEVEL2           set_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL3           set_IP_PADC; set_IPH_PADCH
+
+#define   SET_INT_INT1_LEVEL0          clr_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL1          clr_IP_PX1; set_IPH_PX1H
+#define   SET_INT_INT1_LEVEL2          set_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL3          set_IP_PX1; set_IPH_PX1H
+
+#define   SET_INT_PIT_LEVEL0           clr_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL1           clr_EIP_PPI; set_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL2           set_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL3           set_EIP_PPI; set_EIPH_PPIH
+
+#define   SET_INT_Timer1_LEVEL0        clr_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL1        clr_IP_PT1; set_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL2        set_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL3        set_IP_PT1; set_IPH_PT1H
+
+#define   SET_INT_UART0_LEVEL0         clr_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL1         clr_IP_PS; set_IPH_PSH
+#define   SET_INT_UART0_LEVEL2         set_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL3         set_IP_PS; set_IPH_PSH
+
+#define   SET_INT_PWM0_BRAKE_LEVEL0    clr_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL1    clr_EIP_PFB; set_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL2    set_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL3    set_EIP_PFB; set_EIPH_PFBH
+
+#define   SET_INT_SPI_LEVEL0           clr_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL1           clr_EIP_PSPI; set_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL2           set_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL3           set_EIP_PSPI; set_EIPH_PSPIH
+
+#define   SET_INT_Timer2_LEVEL0        clr_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL1        clr_EIP_PT2; set_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL2        set_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL3        set_EIP_PT2; set_EIPH_PT2H
+
+#define   SET_INT_CAPTURE_LEVEL0       clr_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL1       clr_EIP_PCAP; set_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL2       set_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL3       set_EIP_PCAP; set_EIPH_PCAPH
+
+#define   SET_INT_PWM_LEVEL0           clr_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL1           clr_EIP_PPWM; set_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL2           set_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL3           set_EIP_PPWM; set_EIPH_PPWMH
+
+#define   SET_INT_UART1_LEVEL0         clr_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL1         clr_EIP1_PS_1; set_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL2         set_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL3         set_EIP1_PS_1; set_EIPH1_PSH_1
+
+#define   SET_INT_Timer3_LEVEL0        clr_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL1        clr_EIP1_PT3; set_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL2        set_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL3        set_EIP1_PT3; set_EIPH1_PT3H
+
+#define   SET_INT_WKT_LEVEL0           clr_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL1           clr_EIP1_PWKT; set_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL2           set_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL3           set_EIP1_PWKT; set_EIPH1_PWKTH
+
+/* Clear Interrupt Flag */
+#define    CLEAR_ADC_INTERRUPT_FLAG          clr_ADCCON0_ADCF
+#define    CLEAR_BOD_INTERRUPT_FLAG          clr_BODCON0_BOF
+#define    CLEAR_BOD_RESET_FLAG              clr_BODCON0_BORF
+#define    CLEAR_UART0_INTERRUPT_TX_FLAG     clr_SCON_TI
+#define    CLEAR_UART0_INTERRUPT_RX_FLAG     clr_SCON_RI
+#define    CLEAR_TIMER1_INTERRUPT_FLAG       clr_TCON_TF1
+#define    CLEAR_INT1_INTERRUPT_FLAG         clr_TCON_IE1
+#define    CLEAR_TIMER0_INTERRUPT_FLAG       clr_TCON_TF0
+#define    CLEAR_INT0_INTERRUPT_FLAG         clr_TCON_IE0
+#define    CLEAR_TIMER2_INTERRUPT_FLAG       clr_T2CON_TF2
+#define    CLEAR_SPI0_INTERRUPT_FLAG         clr_SPSR_SPIF
+#define    CLEAR_PWM0_FB_INTERRUPT_FLAG      clr_PWM0FBD_FBF
+#define    CLEAR_WDT_INTERRUPT_FLAG          clr_WDCON_WDTF
+#define    CLEAR_PWM0_INTERRUPT_FLAG         clr_PWM1CON0_PWMF
+#define    CLEAR_CAPTURE_INTERRUPT_IC0_FLAG  clr_CAPCON0_CAPF0
+#define    CLEAR_CAPTURE_INTERRUPT_IC1_FLAG  clr_CAPCON0_CAPF1
+#define    CLEAR_CAPTURE_INTERRUPT_IC2_FLAG  clr_CAPCON0_CAPF2
+#define    CLEAR_PIN_INTERRUPT_PIT0_FLAG     clr_PIF_PIF0
+#define    CLEAR_PIN_INTERRUPT_PIT1_FLAG     clr_PIF_PIF1
+#define    CLEAR_PIN_INTERRUPT_PIT2_FLAG     clr_PIF_PIF2
+#define    CLEAR_PIN_INTERRUPT_PIT3_FLAG     clr_PIF_PIF3
+#define    CLEAR_PIN_INTERRUPT_PIT4_FLAG     clr_PIF_PIF4
+#define    CLEAR_PIN_INTERRUPT_PIT5_FLAG     clr_PIF_PIF5
+#define    CLEAR_PIN_INTERRUPT_PIT6_FLAG     clr_PIF_PIF6
+#define    CLEAR_PIN_INTERRUPT_PIT7_FLAG     clr_PIF_PIF7
+#define    CLEAR_I2C_TIMEOUT_INTERRUPT_FLAG  clr_I2TOC_I2TOF
+#define    CLEAR_WKT_INTERRUPT_FLAG          clr_WKCON_WKTF
+#define    CLEAR_TIMER3_INTERRUPT_FLAG       clr_T3CON_TF3
+#define    CLEAR_UART1_INTERRUPT_FLAG        clr_EIE1_ES_1 
+
+/*****************************************************************************/
+/*    For GPIO Mode setting                                                  */ 
+/*****************************************************************************/
+#define    P00_QUASI_MODE            P0M1&=0xFE;P0M2&=0xFE
+#define    P01_QUASI_MODE            P0M1&=0xFD;P0M2&=0xFD
+#define    P02_QUASI_MODE            P0M1&=0xFB;P0M2&=0xFB
+#define    P03_QUASI_MODE            P0M1&=0xF7;P0M2&=0xF7
+#define    P04_QUASI_MODE            P0M1&=0xEF;P0M2&=0xEF
+#define    P05_QUASI_MODE            P0M1&=0xDF;P0M2&=0xDF
+#define    P06_QUASI_MODE            P0M1&=0xBF;P0M2&=0xBF
+#define    P07_QUASI_MODE            P0M1&=0x7F;P0M2&=0x7F
+#define    P10_QUASI_MODE            P1M1&=0xFE;P1M2&=0xFE
+#define    P11_QUASI_MODE            P1M1&=0xFD;P1M2&=0xFD
+#define    P12_QUASI_MODE            P1M1&=0xFB;P1M2&=0xFB
+#define    P13_QUASI_MODE            P1M1&=0xF7;P1M2&=0xF7
+#define    P14_QUASI_MODE            P1M1&=0xEF;P1M2&=0xEF
+#define    P15_QUASI_MODE            P1M1&=0xDF;P1M2&=0xDF
+#define    P16_QUASI_MODE            P1M1&=0xBF;P1M2&=0xBF
+#define    P17_QUASI_MODE            P1M1&=0x7F;P1M2&=0x7F
+#define    P30_QUASI_MODE            P3M1&=0xFE;P3M2&=0xFE
+#define    ALL_GPIO_QUASI_MODE       P0M1=0;P0M2=0;P1M1=0;P1M2=0;P3M1=0;P3M2=0
+
+#define    P00_PUSHPULL_MODE         P0M1&=0xFE;P0M2|=0x01
+#define    P01_PUSHPULL_MODE         P0M1&=0xFD;P0M2|=0x02
+#define    P02_PUSHPULL_MODE         P0M1&=0xFB;P0M2|=0x04
+#define    P03_PUSHPULL_MODE         P0M1&=0xF7;P0M2|=0x08
+#define    P04_PUSHPULL_MODE         P0M1&=0xEF;P0M2|=0x10
+#define    P05_PUSHPULL_MODE         P0M1&=0xDF;P0M2|=0x20
+#define    P06_PUSHPULL_MODE         P0M1&=0xBF;P0M2|=0x40
+#define    P07_PUSHPULL_MODE         P0M1&=0x7F;P0M2|=0x80
+#define    P10_PUSHPULL_MODE         P1M1&=0xFE;P1M2|=0x01
+#define    P11_PUSHPULL_MODE         P1M1&=0xFD;P1M2|=0x02
+#define    P12_PUSHPULL_MODE         P1M1&=0xFB;P1M2|=0x04
+#define    P13_PUSHPULL_MODE         P1M1&=0xF7;P1M2|=0x08
+#define    P14_PUSHPULL_MODE         P1M1&=0xEF;P1M2|=0x10
+#define    P15_PUSHPULL_MODE         P1M1&=0xDF;P1M2|=0x20
+#define    P16_PUSHPULL_MODE         P1M1&=0xBF;P1M2|=0x40
+#define    P17_PUSHPULL_MODE         P1M1&=0x7F;P1M2|=0x80
+#define    P30_PUSHPULL_MODE         P3M1&=0xFE;P3M2|=0x01
+#define    ALL_GPIO_PUSHPULL_MODE    P0M1=0;P0M2=0xFF;P1M1=0;P1M2=0xFF;P3M1=0;P3M2=0xFF
+
+#define    P00_INPUT_MODE            P0M1|=0x01;P0M2&=0xFE
+#define    P01_INPUT_MODE            P0M1|=0x02;P0M2&=0xFD
+#define    P02_INPUT_MODE            P0M1|=0x04;P0M2&=0xFB
+#define    P03_INPUT_MODE            P0M1|=0x08;P0M2&=0xF7
+#define    P04_INPUT_MODE            P0M1|=0x10;P0M2&=0xEF
+#define    P05_INPUT_MODE            P0M1|=0x20;P0M2&=0xDF
+#define    P06_INPUT_MODE            P0M1|=0x40;P0M2&=0xBF
+#define    P07_INPUT_MODE            P0M1|=0x80;P0M2&=0x7F
+#define    P10_INPUT_MODE            P1M1|=0x01;P1M2&=0xFE
+#define    P11_INPUT_MODE            P1M1|=0x02;P1M2&=0xFD
+#define    P12_INPUT_MODE            P1M1|=0x04;P1M2&=0xFB
+#define    P13_INPUT_MODE            P1M1|=0x08;P1M2&=0xF7
+#define    P14_INPUT_MODE            P1M1|=0x10;P1M2&=0xEF
+#define    P15_INPUT_MODE            P1M1|=0x20;P1M2&=0xDF
+#define    P16_INPUT_MODE            P1M1|=0x40;P1M2&=0xBF
+#define    P17_INPUT_MODE            P1M1|=0x80;P1M2&=0x7F
+#define    P30_INPUT_MODE            P3M1|=0x01;P3M2&=0xFE
+#define    ALL_GPIO_INPUT_MODE       P0M1=0xFF;P0M2=0;P1M1=0xFF;P1M2=0;P3M1=0xFF;P3M2=0
+
+#define    P00_OPENDRAIN_MODE        P0M1|=0x01;P0M2|=0x01
+#define    P01_OPENDRAIN_MODE        P0M1|=0x02;P0M2|=0x02
+#define    P02_OPENDRAIN_MODE        P0M1|=0x04;P0M2|=0x04
+#define    P03_OPENDRAIN_MODE        P0M1|=0x08;P0M2|=0x08
+#define    P04_OPENDRAIN_MODE        P0M1|=0x10;P0M2|=0x10
+#define    P05_OPENDRAIN_MODE        P0M1|=0x20;P0M2|=0x20
+#define    P06_OPENDRAIN_MODE        P0M1|=0x40;P0M2|=0x40
+#define    P07_OPENDRAIN_MODE        P0M1|=0x80;P0M2|=0x80
+#define    P10_OPENDRAIN_MODE        P1M1|=0x01;P1M2|=0x01
+#define    P11_OPENDRAIN_MODE        P1M1|=0x02;P1M2|=0x02
+#define    P12_OPENDRAIN_MODE        P1M1|=0x04;P1M2|=0x04
+#define    P13_OPENDRAIN_MODE        P1M1|=0x08;P1M2|=0x08
+#define    P14_OPENDRAIN_MODE        P1M1|=0x10;P1M2|=0x10
+#define    P15_OPENDRAIN_MODE        P1M1|=0x20;P1M2|=0x20
+#define    P16_OPENDRAIN_MODE        P1M1|=0x40;P1M2|=0x40
+#define    P17_OPENDRAIN_MODE        P1M1|=0x80;P1M2|=0x80
+#define    P30_OPENDRAIN_MODE        P3M1|=0x01;P3M2|=0x01
+#define    ALL_GPIO_OPENDRAIN_MODE   P0M1=0xFF;P0M2=0xFF;P1M1=0xFF;P1M2=0xFF;P3M1=0xFF;P3M2=0xFF
+
+/*****************************************************************************/
+/*    For GPIO Schmitt Trig / TTL Type Seetting                              */ 
+/*****************************************************************************/
+#define    ENABLE_P00_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_ST_MODE        ENABLE_SFR_PAGE1;P2S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_ST_MODE        ENABLE_SFR_PAGE1;P3S|=0x01;ENABLE_SFR_PAGE0
+
+#define    ENABLE_P00_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_TTL_MODE       ENABLE_SFR_PAGE1;P2S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_TTL_MODE       ENABLE_SFR_PAGE1;P3S&=0xFE;ENABLE_SFR_PAGE0
+
+/*****************************************************************************/
+/*    Enable GPIO Pin Interrupt port 0~3                                     */ 
+/*****************************************************************************/
+#define    ENABLE_INT_PORT0               PICON &= 0xFB;
+#define    ENABLE_INT_PORT1               PICON |= 0x01;
+#define    ENABLE_INT_PORT2               PICON |= 0x02;
+#define    ENABLE_INT_PORT3               PICON |= 0x03;
+/*    Bit low level trig mode   */
+#define    ENABLE_BIT7_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_LOWLEVEL_TRIG      PICON&=0xDF;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_LOWLEVEL_TRIG      PICON&=0xEF;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_LOWLEVEL_TRIG      PICON&=0xF7;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_LOWLEVEL_TRIG      PICON&=0xFD;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit high level trig mode    */
+#define    ENABLE_BIT7_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_HIGHLEVEL_TRIG     PICON&=0xDF;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_HIGHLEVEL_TRIG     PICON&=0xEF;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_HIGHLEVEL_TRIG     PICON&=0xF7;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_HIGHLEVEL_TRIG     PICON&=0xFD;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit falling edge trig mode   */
+#define    ENABLE_BIT7_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_FALLINGEDGE_TRIG   PICON|=0x20;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_FALLINGEDGE_TRIG   PICON|=0x10;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_FALLINGEDGE_TRIG   PICON|=0x08;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_FALLINGEDGE_TRIG   PICON|=0x04;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit rising edge trig mode    */
+#define    ENABLE_BIT7_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_RISINGEDGE_TRIG    PICON|=0x20;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_RISINGEDGE_TRIG    PICON|=0x10;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_RISINGEDGE_TRIG    PICON|=0x08;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_RISINGEDGE_TRIG    PICON|=0x04;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit both edge trig mode    */
+#define    ENABLE_BIT7_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x80;PIPEN|=0x80
+#define    ENABLE_BIT6_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x40;PIPEN|=0x40
+#define    ENABLE_BIT5_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x20;PIPEN|=0x20
+#define    ENABLE_BIT4_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x10;PIPEN|=0x10
+#define    ENABLE_BIT3_BOTHEDGE_TRIG      PICON|=0x20;PINEN|=0x08;PIPEN|=0x08
+#define    ENABLE_BIT2_BOTHEDGE_TRIG      PICON|=0x10;PINEN|=0x04;PIPEN|=0x04
+#define    ENABLE_BIT1_BOTHEDGE_TRIG      PICON|=0x08;PINEN|=0x02;PIPEN|=0x02
+#define    ENABLE_BIT0_BOTHEDGE_TRIG      PICON|=0x04;PINEN|=0x01;PIPEN|=0x01
+
+/*****************************************************************************/
+/*    TIMER Function Define                                                  */ 
+/*****************************************************************************/
+#define    ENABLE_CLOCK_OUT             set_CKCON_CLOEN;
+/*    Timer0 basic define  */
+#define    ENABLE_TIMER0_MODE0           TMOD&=0xF0
+#define    ENABLE_TIMER0_MODE1           TMOD&=0xF0;TMOD|=0x01
+#define    ENABLE_TIMER0_MODE2           TMOD&=0xF0;TMOD|=0x02
+#define    ENABLE_TIMER0_MODE3           TMOD&=0xF0;TMOD|=0x03
+#define    TIMER0_FSYS                   set_CKCON_T0M
+#define    TIMER0_FSYS_DIV12             clr_CKCON_T0M
+#define    TIMER0_MODE0_ENABLE           TMOD&=0xF0
+#define    TIMER0_MODE1_ENABLE           TMOD&=0xF0;TMOD|=0x01
+#define    TIMER0_MODE2_ENABLE           TMOD&=0xF0;TMOD|=0x02
+#define    TIMER0_MODE3_ENABLE           TMOD&=0xF0;TMOD|=0x03
+/*    Timer1 basic define  */
+#define    ENABLE_TIMER1_MODE0           TMOD&=0x0F
+#define    ENABLE_TIMER1_MODE1           TMOD&=0x0F;TMOD|=0x10
+#define    ENABLE_TIMER1_MODE2           TMOD&=0x0F;TMOD|=0x20
+#define    ENABLE_TIMER1_MODE3           TMOD&=0x0F;TMOD|=0x30
+#define    TIMER1_FSYS                   set_CKCON_T1M
+#define    TIMER1_FSYS_DIV12             clr_CKCON_T1M
+#define    TIMER1_MODE0_ENABLE           TMOD&=0x0F
+#define    TIMER1_MODE1_ENABLE           TMOD&=0x0F;TMOD|=0x10
+#define    TIMER1_MODE2_ENABLE           TMOD&=0x0F;TMOD|=0x20
+#define    TIMER1_MODE3_ENABLE           TMOD&=0x0F;TMOD|=0x30
+/*    Timer2 function define  */
+#define    TIMER2_DIV_4                  T2MOD|=0x10;T2MOD&=0x9F
+#define    TIMER2_DIV_16                 T2MOD|=0x20;T2MOD&=0xAF
+#define    TIMER2_DIV_32                 T2MOD|=0x30;T2MOD&=0xBF
+#define    TIMER2_DIV_64                 T2MOD|=0x40;T2MOD&=0xCF
+#define    TIMER2_DIV_128                T2MOD|=0x50;T2MOD&=0xDF
+#define    TIMER2_DIV_256                T2MOD|=0x60;T2MOD&=0xEF
+#define    TIMER2_DIV_512                T2MOD|=0x70
+#define    TIMER2_AUTO_RELOAD_DELAY_MODE T2CON&=0xFE;T2MOD|=0x80;T2MOD|=0x08
+#define    TIMER2_COMPARE_CAPTURE_MODE   T2CON|=0x01;T2MOD&=0x7F;T2MOD|=0x04
+#define    TIMER2_CAP0_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x89
+#define    TIMER2_CAP1_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8A
+#define    TIMER2_CAP2_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8B
+#define    DISABLE_TIMER2_CAP0           CAPCON0&=0xBF
+#define    DISABLE_TIMER2_CAP1           CAPCON0&=0xDF
+#define    DISABLE_TIMER2_CAP2           CAPCON0&=0xEF
+
+/*    Timer2 Capture define  */
+#define    IC0_P12_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON0|=0x20
+#define    IC2_P10_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x10;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x20;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x30;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x40;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x50;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x60;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x70;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x80;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+/*****************************************************************************/
+/*     For PWM setting                                                       */
+/*****************************************************************************/
+/*     PMW0 clock source select define    */
+#define    PWM0_CLOCK_FSYS                   CKCON&=0xBF
+#define    PWM0_CLOCK_TIMER1                 CKCON|=0x40
+/*     PWM type define    */
+#define    PWM0_EDGE_TYPE                    PWMCON1&=0xEF
+#define    PWM0_CENTER_TYPE                  PWMCON1|=0x10      
+/*      PWM mode define   */
+#define    PWM0_IMDEPENDENT_MODE             PWMCON1&=0x3F
+#define    PWM0_COMPLEMENTARY_MODE           PWMCON1&=0x3F;PWMCON1|=0x40 
+#define    PWM0_SYNCHRONIZED_MODE            PWMCON1&=0x3F;PWMCON1|=0x80 
+#define    PWM0_GP_MODE_ENABLE               PWMCON1|=0x20
+#define    PWM0_GP_MODE_DISABLE              PWMCON1&=0xDF
+/*      PWM0 clock devide define    */
+#define    PWM0_CLOCK_DIV_1                  PWMCON1&=0xF8;PWMCON1|=0x00
+#define    PWM0_CLOCK_DIV_2                  PWMCON1&=0xF8;PWMCON1|=0x01
+#define    PWM0_CLOCK_DIV_4                  PWMCON1&=0xF8;PWMCON1|=0x02
+#define    PWM0_CLOCK_DIV_8                  PWMCON1&=0xF8;PWMCON1|=0x03
+#define    PWM0_CLOCK_DIV_16                 PWMCON1&=0xF8;PWMCON1|=0x04
+#define    PWM0_CLOCK_DIV_32                 PWMCON1&=0xF8;PWMCON1|=0x05
+#define    PWM0_CLOCK_DIV_64                 PWMCON1&=0xF8;PWMCON1|=0x06
+#define    PWM0_CLOCK_DIV_128                PWMCON1&=0xF8;PWMCON1|=0x07
+/*      PWM0 I/O select define    */
+#define    ENABLE_PWM0_CH5_P15_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x20;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output enable 
+#define    ENABLE_PWM0_CH5_P03_OUTPUT        PIOCON0|=0x20                                                                                 //P0.3 as PWM5               
+#define    ENABLE_PWM0_CH4_P01_OUTPUT        PIOCON0|=0x10                                                                                 //P0.1 as PWM4 output enable 
+#define    ENABLE_PWM0_CH3_P04_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x08;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output enable 
+#define    ENABLE_PWM0_CH3_P00_OUTPUT        PIOCON0|=0x08                                                                                 //P0.0 as PWM3               
+#define    ENABLE_PWM0_CH2_P05_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x04;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output enable 
+#define    ENABLE_PWM0_CH2_P10_OUTPUT        PIOCON0|=0x04                                                                                 //P1.0 as PWM2               
+#define    ENABLE_PWM0_CH1_P14_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x02;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output enable 
+#define    ENABLE_PWM0_CH1_P11_OUTPUT        PIOCON0|=0x02                                                                                 //P1.1 as PWM1               
+#define    ENABLE_PWM0_CH0_P12_OUTPUT        PIOCON0|=0x01                                                                                 //P1.2 as PWM0 output enable 
+#define    ENABLE_ALL_PWM0_OUTPUT            PIOCON0=0xFF;PIOCON1=0xFF
+
+#define    DISABLE_PWM0_CH5_P15_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xDF;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output disable
+#define    DISABLE_PWM0_CH5_P03_OUTPUT       PIOCON0&=0xDF                                                                                 //P0.3 as PWM5               
+#define    DISABLE_PWM0_CH4_P01_OUTPUT       PIOCON0&=0xEF                                                                                 //P0.1 as PWM4 output disable
+#define    DISABLE_PWM0_CH3_P04_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xF7;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output disable
+#define    DISABLE_PWM0_CH3_P00_OUTPUT       PIOCON0&=0xF7                                                                                 //P0.0 as PWM3               
+#define    DISABLE_PWM0_CH2_P05_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFB;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output disable
+#define    DISABLE_PWM0_CH2_P10_OUTPUT       PIOCON0&=0xFB                                                                                 //P1.0 as PWM2               
+#define    DISABLE_PWM0_CH1_P14_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFD;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output disable
+#define    DISABLE_PWM0_CH1_P11_OUTPUT       PIOCON0&=0xFD                                                                                 //P1.1 as PWM1               
+#define    DISABLE_PWM0_CH0_P12_OUTPUT       PIOCON0&=0xFE                                                                                 //P1.2 as PWM0 output disable
+#define    DISABLE_ALL_PWM0_OUTPUT           PIOCON0=0x00;PIOCON1=0x00
+/*       PWM0 I/O Polarity Control     */
+#define    PWM0_CH5_OUTPUT_INVERSE           PNP|=0x20
+#define    PWM0_CH4_OUTPUT_INVERSE           PNP|=0x10
+#define    PWM0_CH3_OUTPUT_INVERSE           PNP|=0x08
+#define    PWM0_CH2_OUTPUT_INVERSE           PNP|=0x04
+#define    PWM0_CH1_OUTPUT_INVERSE           PNP|=0x02
+#define    PWM0_CH0_OUTPUT_INVERSE           PNP|=0x01
+#define    PWM0_OUTPUT_ALL_INVERSE           PNP|=0xFF
+#define    PWM0_CH5_OUTPUT_NORMAL            PNP&=0xDF
+#define    PWM0_CH4_OUTPUT_NORMAL            PNP&=0xEF
+#define    PWM0_CH3_OUTPUT_NORMAL            PNP&=0xF7
+#define    PWM0_CH2_OUTPUT_NORMAL            PNP&=0xFB
+#define    PWM0_CH1_OUTPUT_NORMAL            PNP&=0xFD
+#define    PWM0_CH0_OUTPUT_NORMAL            PNP&=0xFE
+#define    PWM0_OUTPUT_ALL_NORMAL            PNP&=0x00
+/*      PMW0 interrupt setting     */
+#define    PWM0_FALLING_INT                  ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_RISING_INT                   ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x10;ENABLE_SFR_PAGE0
+#define    PWM0_CENTRAL_POINT_INT            ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x20;ENABLE_SFR_PAGE0
+#define    PWM0_PERIOD_END_INT               ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x30;ENABLE_SFR_PAGE0
+/*      PWM0 interrupt pin select    */
+#define    PWM0_INT_PWM0                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM1                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x01;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM2                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x02;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM3                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x03;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM4                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x04;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM5                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x05;ENABLE_SFR_PAGE0
+/*      PWM0 Dead time setting     */
+#define    ENABLE_PWM0_CH45_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define    ENABLE_PWM0_CH23_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define    ENABLE_PWM0_CH01_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+
+/*****************************************************************************/
+/*     For ADC INIT setting                                                  */
+/*****************************************************************************/
+#define    ENABLE_ADC                        set_ADCCON1_ADCEN
+#define    DISABLE_ADC                       clr_ADCCON1_ADCEN
+
+#define    ENABLE_ADC_BANDGAP                DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x08;ADCCON0&=0xF8;ENABLE_ADC  
+#define    ENABLE_ADC_AIN0                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_AIN1                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_AIN2                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_AIN3                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_AIN4                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC    //P05
+#define    ENABLE_ADC_AIN5                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_AIN6                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_AIN7                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+
+#define    ENABLE_ADC_CH0                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_CH1                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_CH2                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_CH3                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_CH4                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC   //P05
+#define    ENABLE_ADC_CH5                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_CH6                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_CH7                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+/*      GPIO trig ADC start define*/
+#define    P04_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P13_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1|=0x40;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P04_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    P13_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xF7;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+/*      PWM trig ADC start define */ 
+#define    PWM0_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM2_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM4_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM2_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM4_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM2_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM4_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM2_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM4_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+#define    PWM0_CH0_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH2_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH4_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH0_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH2_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH4_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x06;ADCCON1|=0x02
+#define    PWM0_CH0_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH2_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH4_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH0_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH2_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH4_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+/*****************************************************************************/
+/*     For SPI INIT setting                                                  */
+/*****************************************************************************/
+#define    SPICLK_FSYS_DIV2                  SPCR&=0xFC
+#define    SPICLK_FSYS_DIV4                  SPCR&=0xFC;SPCR|=0x01
+#define    SPICLK_FSYS_DIV8                  SPCR&=0xFC;SPCR|=0x02
+#define    SPICLK_FSYS_DIV16                 SPCR&=0xFC;SPCR|=0x03
+#define    SS    P15
+/*****************************************************************************/
+/*     For UART0 and UART1 and printf funcion                                */
+/*****************************************************************************/
+#define    ENABLE_UART0_PRINTF                set_SCON_TI;PRINTFG=1            //For printf function must setting TI = 1
+#define    DISABLE_UART0_PRINTF               clr_SCON_TI;PRINTFG=0
+#define    ENABLE_UART1_PRINTF                set_SCON_1_TI_1;PRINTFG=1
+#define    DISABLE_UART1_PRINTF               clr_SCON_1_TI_1;PRINTFG=0
+/*****************************************************************************/
+/*     INT0 setting                                                          */
+/*****************************************************************************/
+#define    INT0_FALLING_EDGE_TRIG             set_TCON_IT0
+#define    INT0_LOW_LEVEL_TRIG                clr_TCON_IT0
+/*****************************************************************************/
+/*     INT1 setting                                                          */
+/*****************************************************************************/
+#define    INT1_FALLING_EDGE_TRIG             set_TCON_IT1
+#define    INT1_LOW_LEVEL_TRIG                clr_TCON_IT1
+
+/*****************************************************************************/
+/*     WDT setting                                                           */
+/*****************************************************************************/
+#define    WDT_TIMEOUT_6MS                    TA=0xAA;TA=0x55;WDCON&=0xF8
+#define    WDT_TIMEOUT_25MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x01
+#define    WDT_TIMEOUT_50MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x02
+#define    WDT_TIMEOUT_100MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x03
+#define    WDT_TIMEOUT_200MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x04
+#define    WDT_TIMEOUT_400MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x05
+#define    WDT_TIMEOUT_800MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x06
+#define    WDT_TIMEOUT_1_6S                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x07
+
+#define    WDT_RUN_IN_POWERDOWN_ENABLE        set_WDCON_WIDPD
+#define    WDT_RUN_IN_POWERDOWN_DISABLE       clr_WDCON_WIDPD
+#define    WDT_COUNTER_CLEAR                  set_WDCON_WDCLR
+#define    WDT_COUNTER_RUN                    set_WDCON_WDTR
+
+
+
+/*****************************************************************************/
+/*     Power-on-Reset setting                                                */
+/*****************************************************************************/
+
+/** Per N76E003 errata sheet rev. 1.02, section 2.1, it is recommended that POR be disabled before entering power-down mode. */
+#define DISABLE_POWER_ON_RESET              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;PORDIS=0x5A;TA=0xAA;TA=0x55;PORDIS=0xA5;EA=BIT_TMP

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_iar.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_iar.h
@@ -1,0 +1,531 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  n76e003_iar.h                                                                       */
+/*  Header file of Nuvoton                                                              */
+/*  N76E003AT20 / N76E003AQ20                                                           */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76e003.h"
+
+/*  BYTE Registers  */
+/*  SFR page 0      */
+__sfr __no_init volatile union
+{
+  unsigned char P0; /* Port 0 */
+  struct /* Port 0 */
+  { 
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P0_bit;
+} @ 0x80;
+__sfr __no_init volatile unsigned char  SP          @ 0x81;
+__sfr __no_init volatile unsigned char  DPL         @ 0x82;
+__sfr __no_init volatile unsigned char  DPH         @ 0x83;
+__sfr __no_init volatile unsigned char  RCTRIM0     @ 0x84;
+__sfr __no_init volatile unsigned char  RCTRIM1     @ 0x85;  
+__sfr __no_init volatile unsigned char  RWK         @ 0x86;
+__sfr __no_init volatile unsigned char  PCON        @ 0x87;
+
+__sfr __no_init volatile union
+{
+  unsigned char TCON; /* Timer Control */
+  struct /* Timer Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } TCON_bit;
+} @ 0x88;                            
+__sfr __no_init volatile unsigned char  TMOD        @ 0x89;
+__sfr __no_init volatile unsigned char  TL0         @ 0x8A;
+__sfr __no_init volatile unsigned char  TL1         @ 0x8B;
+__sfr __no_init volatile unsigned char  TH0         @ 0x8C;
+__sfr __no_init volatile unsigned char  TH1         @ 0x8D;
+__sfr __no_init volatile unsigned char  CKCON       @ 0x8E;
+__sfr __no_init volatile unsigned char  WKCON       @ 0x8F;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char P1; /* Port 1 */
+  struct /* Port 1 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } P1_bit;
+} @ 0x90;
+__sfr __no_init volatile unsigned char SFRS        @ 0x91; //TA Protection
+__sfr __no_init volatile unsigned char CAPCON0     @ 0x92;
+__sfr __no_init volatile unsigned char CAPCON1     @ 0x93;
+__sfr __no_init volatile unsigned char CAPCON2     @ 0x94;
+__sfr __no_init volatile unsigned char CKDIV       @ 0x95;
+__sfr __no_init volatile unsigned char CKSWT       @ 0x96; //TA Protection
+__sfr __no_init volatile unsigned char CKEN        @ 0x97; //TA Protection
+
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON; /* Serial Control */
+  struct /* Serial Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_bit;
+} @ 0x98;
+__sfr __no_init volatile unsigned char SBUF        @ 0x99;
+__sfr __no_init volatile unsigned char SBUF_1      @ 0x9A;
+__sfr __no_init volatile unsigned char EIE         @ 0x9B;
+__sfr __no_init volatile unsigned char EIE1        @ 0x9C;
+__sfr __no_init volatile unsigned char CHPCON      @ 0x9F; //TA Protection
+   
+__sfr __no_init volatile union
+{
+  unsigned char P2; /* Port 2 */
+  struct /* Port 2 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P2_bit;
+} @ 0xA0;
+__sfr __no_init volatile unsigned char AUXR1       @ 0xA2;
+__sfr __no_init volatile unsigned char BODCON0     @ 0xA3; //TA Protection
+__sfr __no_init volatile unsigned char IAPTRG      @ 0xA4; //TA Protection
+__sfr __no_init volatile unsigned char IAPUEN      @ 0xA5;  //TA Protection
+__sfr __no_init volatile unsigned char IAPAL       @ 0xA6;
+__sfr __no_init volatile unsigned char IAPAH       @ 0xA7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IE; /* Interrupt Enable */
+  struct /* Interrupt Enable */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IE_bit;
+} @ 0xA8;
+__sfr __no_init volatile unsigned char SADDR       @ 0xA9;
+__sfr __no_init volatile unsigned char WDCON       @ 0xAA; //TA Protection
+__sfr __no_init volatile unsigned char BODCON1     @ 0xAB; //TA Protection
+__sfr __no_init volatile unsigned char P3M1        @ 0xAC;
+__sfr __no_init volatile unsigned char P3S         @ 0xAC; //Page1
+__sfr __no_init volatile unsigned char P3M2        @ 0xAD;
+__sfr __no_init volatile unsigned char P3SR        @ 0xAD; //Page1
+__sfr __no_init volatile unsigned char IAPFD       @ 0xAE;
+__sfr __no_init volatile unsigned char IAPCN       @ 0xAF;
+
+__sfr __no_init volatile union
+{
+  unsigned char P3; /* Port 3 */
+  struct /* Port 3 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P3_bit;
+} @ 0xB0;
+__sfr __no_init volatile unsigned char P0M1        @ 0xB1;
+__sfr __no_init volatile unsigned char P0S         @ 0xB1; //Page1
+__sfr __no_init volatile unsigned char P0M2        @ 0xB2;
+__sfr __no_init volatile unsigned char P0SR        @ 0xB2; //Page1
+__sfr __no_init volatile unsigned char P1M1        @ 0xB3;
+__sfr __no_init volatile unsigned char P1S         @ 0xB3; //Page1
+__sfr __no_init volatile unsigned char P1M2        @ 0xB4;
+__sfr __no_init volatile unsigned char P1SR        @ 0xB4; //Page1
+__sfr __no_init volatile unsigned char P2S         @ 0xB5; 
+__sfr __no_init volatile unsigned char IPH         @ 0xB7;
+__sfr __no_init volatile unsigned char PWMINTC     @ 0xB7;  //Page1
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IP; /* IP  */
+  struct /* IP  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IP_bit;
+} @ 0xB8;
+__sfr __no_init volatile unsigned char SADEN       @ 0xB9;
+__sfr __no_init volatile unsigned char SADEN_1     @ 0xBA;
+__sfr __no_init volatile unsigned char SADDR_1     @ 0xBB;
+__sfr __no_init volatile unsigned char I2DAT       @ 0xBC;
+__sfr __no_init volatile unsigned char I2STAT      @ 0xBD;
+__sfr __no_init volatile unsigned char I2CLK       @ 0xBE;
+__sfr __no_init volatile unsigned char I2TOC       @ 0xBF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char I2CON; /* I2CON  */
+  struct /* I2CON  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } I2CON_bit;
+} @ 0xC0;
+__sfr __no_init volatile unsigned char I2ADDR      @ 0xC1;
+__sfr __no_init volatile unsigned char ADCRL       @ 0xC2;
+__sfr __no_init volatile unsigned char ADCRH       @ 0xC3;
+__sfr __no_init volatile unsigned char T3CON       @ 0xC4;
+__sfr __no_init volatile unsigned char PWM4H       @ 0xC4; //Page1
+__sfr __no_init volatile unsigned char RL3         @ 0xC5;
+__sfr __no_init volatile unsigned char PWM5H       @ 0xC5;  //Page1
+__sfr __no_init volatile unsigned char RH3         @ 0xC6;
+__sfr __no_init volatile unsigned char PIOCON1     @ 0xC6; //Page1
+__sfr __no_init volatile unsigned char TA          @ 0xC7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char T2CON; /* Timer 2 Control */
+  struct /* Timer 2 Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } T2CON_bit;
+} @ 0xC8;
+__sfr __no_init volatile unsigned char T2MOD       @ 0xC9;
+__sfr __no_init volatile unsigned char RCMP2L      @ 0xCA;
+__sfr __no_init volatile unsigned char RCMP2H      @ 0xCB;
+__sfr __no_init volatile unsigned char TL2         @ 0xCC; 
+__sfr __no_init volatile unsigned char PWM4L       @ 0xCC; //Page1
+__sfr __no_init volatile unsigned char TH2         @ 0xCD;
+__sfr __no_init volatile unsigned char PWM5L       @ 0xCD; //Page1
+__sfr __no_init volatile unsigned char ADCMPL      @ 0xCE;
+__sfr __no_init volatile unsigned char ADCMPH      @ 0xCF;
+
+__sfr __no_init volatile union
+{
+  unsigned char PSW; /* Program Status Word */
+  struct /* Program Status Word */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PSW_bit;
+} @ 0xD0;
+__sfr __no_init volatile unsigned char PWMPH        @ 0xD1;
+__sfr __no_init volatile unsigned char PWM0H        @ 0xD2;
+__sfr __no_init volatile unsigned char PWM1H        @ 0xD3;
+__sfr __no_init volatile unsigned char PWM2H        @ 0xD4;
+__sfr __no_init volatile unsigned char PWM3H        @ 0xD5;
+__sfr __no_init volatile unsigned char PNP          @ 0xD6;
+__sfr __no_init volatile unsigned char FBD          @ 0xD7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char PWMCON0; /* PWMCON0  */
+  struct /* PWMCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PWMCON0_bit;
+} @ 0xD8;
+__sfr __no_init volatile unsigned char PWMPL        @ 0xD9;
+__sfr __no_init volatile unsigned char PWM0L        @ 0xDA;
+__sfr __no_init volatile unsigned char PWM1L        @ 0xDB;
+__sfr __no_init volatile unsigned char PWM2L        @ 0xDC;
+__sfr __no_init volatile unsigned char PWM3L        @ 0xDD;
+__sfr __no_init volatile unsigned char PIOCON0      @ 0xDE;
+__sfr __no_init volatile unsigned char PWMCON1      @ 0xDF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ACC; /* Accumulator */
+  struct /* Accumulator */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } ACC_bit;
+} @ 0xE0;
+__sfr __no_init volatile unsigned char ADCCON1     @ 0xE1;
+__sfr __no_init volatile unsigned char ADCCON2     @ 0xE2;
+__sfr __no_init volatile unsigned char ADCDLY      @ 0xE3;
+__sfr __no_init volatile unsigned char C0L         @ 0xE4;
+__sfr __no_init volatile unsigned char C0H         @ 0xE5;
+__sfr __no_init volatile unsigned char C1L         @ 0xE6;
+__sfr __no_init volatile unsigned char C1H         @ 0xE7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ADCCON0; /* ADCCON0  */
+  struct /* ADCCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } ADCCON0_bit;
+} @ 0xE8;
+__sfr __no_init volatile unsigned char PICON       @ 0xE9;
+__sfr __no_init volatile unsigned char PINEN       @ 0xEA;
+__sfr __no_init volatile unsigned char PIPEN       @ 0xEB;
+__sfr __no_init volatile unsigned char PIF         @ 0xEC;
+__sfr __no_init volatile unsigned char C2L         @ 0xED;
+__sfr __no_init volatile unsigned char C2H         @ 0xEE;
+__sfr __no_init volatile unsigned char EIP         @ 0xEF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char B; /* B Register */
+  struct /* B Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } B_bit;
+} @ 0xF0;
+__sfr __no_init volatile unsigned char CAPCON3      @ 0xF1;
+__sfr __no_init volatile unsigned char CAPCON4      @ 0xF2;
+__sfr __no_init volatile unsigned char SPCR         @ 0xF3;
+__sfr __no_init volatile unsigned char SPCR2        @ 0xF3; //Page1
+__sfr __no_init volatile unsigned char SPSR         @ 0xF4;
+__sfr __no_init volatile unsigned char SPDR         @ 0xF5;
+__sfr __no_init volatile unsigned char AINDIDS      @ 0xF6;
+__sfr __no_init volatile unsigned char EIPH         @ 0xF7;
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON_1 ; /* SCON_1  Register */
+  struct /* SCON_1  Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_1_bit;
+} @ 0xF8;
+__sfr __no_init volatile unsigned char PDTEN       @ 0xF9; //TA Protection
+__sfr __no_init volatile unsigned char PDTCNT      @ 0xFA; //TA Protection
+__sfr __no_init volatile unsigned char PMEN        @ 0xFB;
+__sfr __no_init volatile unsigned char PMD         @ 0xFC;
+__sfr __no_init volatile unsigned char PORDIS      @ 0xFD; //TA Protection
+__sfr __no_init volatile unsigned char EIP1        @ 0xFE;
+__sfr __no_init volatile unsigned char EIPH1       @ 0xFF;
+
+/*  BIT Registers  */
+/*  BIT Registers  */
+/*  P0  */
+#define P07         P0_bit.BIT7
+#define P06         P0_bit.BIT6
+#define P05         P0_bit.BIT5
+#define P04         P0_bit.BIT4
+#define P03         P0_bit.BIT3
+#define P02         P0_bit.BIT2
+#define P01         P0_bit.BIT1
+#define P00         P0_bit.BIT0
+
+/*  TCON  */
+#define TF1         TCON_bit.BIT7
+#define TR1         TCON_bit.BIT6
+#define TF0         TCON_bit.BIT5
+#define TR0         TCON_bit.BIT4
+#define IE1         TCON_bit.BIT3
+#define IT1         TCON_bit.BIT2
+#define IE0         TCON_bit.BIT1
+#define IT0         TCON_bit.BIT0
+                    
+/*  P1  */
+#define P17         P1_bit.BIT7
+#define P16         P1_bit.BIT6
+#define P15         P1_bit.BIT5
+#define P14         P1_bit.BIT4
+#define P13         P1_bit.BIT3
+#define P12         P1_bit.BIT2
+#define P11         P1_bit.BIT1
+#define P10         P1_bit.BIT0
+
+/*  SCON  */
+#define SM0         SCON_bit.BIT7 
+#define FE          SCON_bit.BIT7 
+#define SM1         SCON_bit.BIT6 
+#define SM2         SCON_bit.BIT5 
+#define REN         SCON_bit.BIT4 
+#define TB8         SCON_bit.BIT3 
+#define RB8         SCON_bit.BIT2 
+#define TI          SCON_bit.BIT1 
+#define RI          SCON_bit.BIT0 
+
+/*  P2  */ 
+#define P20         P2_bit.BIT0
+
+/*  IE  */
+#define EA          IE_bit.BIT7
+#define EADC        IE_bit.BIT6
+#define EBOD        IE_bit.BIT5
+#define ES          IE_bit.BIT4
+#define ET1         IE_bit.BIT3
+#define EX1         IE_bit.BIT2
+#define ET0         IE_bit.BIT1
+#define EX0         IE_bit.BIT0
+
+/*  P3  */  
+#define P30	    P3_bit.BIT0
+
+/*  IP  */
+#define PADC        IP_bit.BIT6
+#define PBOD        IP_bit.BIT5
+#define PS          IP_bit.BIT4
+#define PT1         IP_bit.BIT3
+#define PX1         IP_bit.BIT2
+#define PT0         IP_bit.BIT1
+#define PX0         IP_bit.BIT0
+
+/*  I2CON  */
+#define I2CEN       I2CON_bit.BIT6
+#define STA         I2CON_bit.BIT5
+#define STO         I2CON_bit.BIT4
+#define SI          I2CON_bit.BIT3
+#define AA          I2CON_bit.BIT2
+#define I2CPX	    I2CON_bit.BIT0
+
+/*  T2CON  */
+#define TF2         T2CON_bit.BIT7
+#define TR2         T2CON_bit.BIT2
+#define CM_RL2      T2CON_bit.BIT0
+
+/*  PSW */
+#define CY          PSW.BIT7
+#define AC          PSW.BIT6
+#define F0          PSW.BIT5
+#define RS1         PSW.BIT4
+#define RS0         PSW.BIT3
+#define OV          PSW.BIT2
+#define P           PSW.BIT0
+
+/*  PWMCON0  */
+#define PWMRUN      PWMCON0_bit.BIT7
+#define LOAD        PWMCON0_bit.BIT6
+#define PWMF        PWMCON0_bit.BIT5
+#define CLRPWM      PWMCON0_bit.BIT4
+
+/*  ADCCON0  */
+#define ADCF        ADCCON0_bit.BIT7
+#define ADCS        ADCCON0_bit.BIT6
+#define ETGSEL1     ADCCON0_bit.BIT5
+#define ETGSEL0     ADCCON0_bit.BIT4
+#define ADCHS3      ADCCON0_bit.BIT3
+#define ADCHS2      ADCCON0_bit.BIT2
+#define ADCHS1      ADCCON0_bit.BIT1
+#define ADCHS0      ADCCON0_bit.BIT0
+
+/*  SCON_1  */
+#define SM0_1       SCON_1_bit.BIT7
+#define FE_1        SCON_1_bit.BIT7 
+#define SM1_1       SCON_1_bit.BIT6 
+#define SM2_1       SCON_1_bit.BIT5 
+#define REN_1       SCON_1_bit.BIT4 
+#define TB8_1       SCON_1_bit.BIT3 
+#define RB8_1       SCON_1_bit.BIT2 
+#define TI_1        SCON_1_bit.BIT1 
+#define RI_1        SCON_1_bit.BIT0
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_keil.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_keil.h
@@ -1,0 +1,306 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  n76E003_keil.h                                                                      */
+/*  Header file of Nuvoton                                                              */
+/*  N76E003AT20 / N76E003AQ20 / N76E003BQ20                                             */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76e003.h"
+
+
+sfr P0          = 0x80;
+sfr SP          = 0x81;
+sfr DPL         = 0x82;
+sfr DPH         = 0x83;
+sfr RCTRIM0     = 0x84;
+sfr RCTRIM1     = 0x85;  
+sfr RWK         = 0x86;
+sfr PCON        = 0x87;
+
+sfr TCON        = 0x88;
+sfr TMOD        = 0x89;
+sfr TL0         = 0x8A;
+sfr TL1         = 0x8B;
+sfr TH0         = 0x8C;
+sfr TH1         = 0x8D;
+sfr CKCON       = 0x8E;
+sfr WKCON       = 0x8F;
+
+sfr P1          = 0x90;
+sfr SFRS        = 0x91; //TA Protection
+sfr CAPCON0     = 0x92;
+sfr CAPCON1     = 0x93;
+sfr CAPCON2     = 0x94;
+sfr CKDIV       = 0x95;
+sfr CKSWT       = 0x96; //TA Protection
+sfr CKEN        = 0x97; //TA Protection
+
+sfr SCON        = 0x98;
+sfr SBUF        = 0x99;
+sfr SBUF_1      = 0x9A;
+sfr EIE         = 0x9B;
+sfr EIE1        = 0x9C;
+sfr CHPCON      = 0x9F; //TA Protection
+
+sfr P2          = 0xA0;
+sfr AUXR1       = 0xA2;
+sfr BODCON0     = 0xA3; //TA Protection
+sfr IAPTRG      = 0xA4; //TA Protection
+sfr IAPUEN      = 0xA5;  //TA Protection
+sfr IAPAL       = 0xA6;
+sfr IAPAH       = 0xA7;
+
+sfr IE          = 0xA8;
+sfr SADDR       = 0xA9;
+sfr WDCON       = 0xAA; //TA Protection
+sfr BODCON1     = 0xAB; //TA Protection
+sfr P3M1        = 0xAC;
+sfr P3S         = 0xAC; //Page1
+sfr P3M2        = 0xAD;
+sfr P3SR        = 0xAD; //Page1
+sfr IAPFD       = 0xAE;
+sfr IAPCN       = 0xAF;
+
+sfr P3          = 0xB0;
+sfr P0M1        = 0xB1;
+sfr P0S         = 0xB1; //Page1
+sfr P0M2        = 0xB2;
+sfr P0SR        = 0xB2; //Page1
+sfr P1M1        = 0xB3;
+sfr P1S         = 0xB3; //Page1
+sfr P1M2        = 0xB4;
+sfr P1SR        = 0xB4; //Page1
+sfr P2S         = 0xB5; 
+sfr IPH         = 0xB7;
+sfr PWMINTC     = 0xB7; //Page1
+
+sfr IP          = 0xB8;
+sfr SADEN       = 0xB9;
+sfr SADEN_1     = 0xBA;
+sfr SADDR_1     = 0xBB;
+sfr I2DAT       = 0xBC;
+sfr I2STAT      = 0xBD;
+sfr I2CLK       = 0xBE;
+sfr I2TOC       = 0xBF;
+
+sfr I2CON       = 0xC0;
+sfr I2ADDR      = 0xC1;
+sfr ADCRL       = 0xC2;
+sfr ADCRH       = 0xC3;
+sfr T3CON       = 0xC4;
+sfr PWM4H       = 0xC4; //Page1
+sfr RL3         = 0xC5;
+sfr PWM5H       = 0xC5; //Page1
+sfr RH3         = 0xC6;
+sfr PIOCON1     = 0xC6; //Page1
+sfr TA          = 0xC7;
+
+sfr T2CON       = 0xC8;
+sfr T2MOD       = 0xC9;
+sfr RCMP2L      = 0xCA;
+sfr RCMP2H      = 0xCB;
+sfr TL2         = 0xCC; 
+sfr PWM4L       = 0xCC; //Page1
+sfr TH2         = 0xCD;
+sfr PWM5L       = 0xCD; //Page1
+sfr ADCMPL      = 0xCE;
+sfr ADCMPH      = 0xCF;
+
+sfr PSW         = 0xD0;
+sfr PWMPH       = 0xD1;
+sfr PWM0H       = 0xD2;
+sfr PWM1H       = 0xD3;
+sfr PWM2H       = 0xD4;
+sfr PWM3H       = 0xD5;
+sfr PNP         = 0xD6;
+sfr FBD         = 0xD7;
+
+sfr PWMCON0     = 0xD8;
+sfr PWMPL       = 0xD9;
+sfr PWM0L       = 0xDA;
+sfr PWM1L       = 0xDB;
+sfr PWM2L       = 0xDC;
+sfr PWM3L       = 0xDD;
+sfr PIOCON0     = 0xDE;
+sfr PWMCON1     = 0xDF;
+
+sfr ACC         = 0xE0;
+sfr ADCCON1     = 0xE1;
+sfr ADCCON2     = 0xE2;
+sfr ADCDLY      = 0xE3;
+sfr C0L         = 0xE4;
+sfr C0H         = 0xE5;
+sfr C1L         = 0xE6;
+sfr C1H         = 0xE7;
+
+sfr ADCCON0     = 0xE8;
+sfr PICON       = 0xE9;
+sfr PINEN       = 0xEA;
+sfr PIPEN       = 0xEB;
+sfr PIF         = 0xEC;
+sfr C2L         = 0xED;
+sfr C2H         = 0xEE;
+sfr EIP         = 0xEF;
+
+sfr B           = 0xF0;
+sfr CAPCON3     = 0xF1;
+sfr CAPCON4     = 0xF2;
+sfr SPCR        = 0xF3;
+sfr SPCR2       = 0xF3; //Page1
+sfr SPSR        = 0xF4;
+sfr SPDR        = 0xF5;
+sfr AINDIDS     = 0xF6;
+sfr EIPH        = 0xF7;
+
+sfr SCON_1      = 0xF8;
+sfr PDTEN       = 0xF9; //TA Protection
+sfr PDTCNT      = 0xFA; //TA Protection
+sfr PMEN        = 0xFB;
+sfr PMD         = 0xFC;
+sfr PORDIS      = 0xFD; //TA Protection
+sfr EIP1        = 0xFE;
+sfr EIPH1       = 0xFF;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+sbit SM0_1      = SCON_1^7;
+sbit FE_1       = SCON_1^7; 
+sbit SM1_1      = SCON_1^6; 
+sbit SM2_1      = SCON_1^5; 
+sbit REN_1      = SCON_1^4; 
+sbit TB8_1      = SCON_1^3; 
+sbit RB8_1      = SCON_1^2; 
+sbit TI_1       = SCON_1^1; 
+sbit RI_1       = SCON_1^0; 
+
+/*  ADCCON0  */
+sbit ADCF       = ADCCON0^7;
+sbit ADCS       = ADCCON0^6;
+sbit ETGSEL1    = ADCCON0^5;
+sbit ETGSEL0    = ADCCON0^4;
+sbit ADCHS3     = ADCCON0^3;
+sbit ADCHS2     = ADCCON0^2;
+sbit ADCHS1     = ADCCON0^1;
+sbit ADCHS0     = ADCCON0^0;
+
+/*  PWMCON0  */
+sbit PWMRUN     = PWMCON0^7;
+sbit LOAD       = PWMCON0^6;
+sbit PWMF       = PWMCON0^5;
+sbit CLRPWM     = PWMCON0^4;
+
+
+/*  PSW */
+sbit CY         = PSW^7;
+sbit AC         = PSW^6;
+sbit F0         = PSW^5;
+sbit RS1        = PSW^4;
+sbit RS0        = PSW^3;
+sbit OV         = PSW^2;
+sbit P          = PSW^0;
+
+/*  T2CON  */
+sbit TF2        = T2CON^7;
+sbit TR2        = T2CON^2;
+sbit CM_RL2     = T2CON^0;
+ 
+/*  I2CON  */
+sbit I2CEN      = I2CON^6;
+sbit STA        = I2CON^5;
+sbit STO        = I2CON^4;
+sbit SI         = I2CON^3;
+sbit AA         = I2CON^2;
+sbit I2CPX      = I2CON^0;
+
+/*  IP  */  
+sbit PADC       = IP^6;
+sbit PBOD       = IP^5;
+sbit PS         = IP^4;
+sbit PT1        = IP^3;
+sbit PX1        = IP^2;
+sbit PT0        = IP^1;
+sbit PX0        = IP^0;
+
+/*  P3  */  
+sbit P30        = P3^0;
+
+
+/*  IE  */
+sbit EA         = IE^7;
+sbit EADC       = IE^6;
+sbit EBOD       = IE^5;
+sbit ES         = IE^4;
+sbit ET1        = IE^3;
+sbit EX1        = IE^2;
+sbit ET0        = IE^1;
+sbit EX0        = IE^0;
+
+/*  P2  */ 
+sbit P20        = P2^0;
+
+/*  SCON  */
+sbit SM0        = SCON^7;
+sbit FE         = SCON^7; 
+sbit SM1        = SCON^6; 
+sbit SM2        = SCON^5; 
+sbit REN        = SCON^4; 
+sbit TB8        = SCON^3; 
+sbit RB8        = SCON^2; 
+sbit TI         = SCON^1; 
+sbit RI         = SCON^0; 
+
+/*  P1  */     
+sbit P17        = P1^7;
+sbit P16        = P1^6;
+sbit TXD_1      = P1^6; 
+sbit P15        = P1^5;
+sbit P14        = P1^4;
+sbit SDA        = P1^4;    
+sbit P13        = P1^3;
+sbit SCL        = P1^3;  
+sbit P12        = P1^2; 
+sbit P11        = P1^1;
+sbit P10        = P1^0;
+
+/*  TCON  */
+sbit TF1        = TCON^7;
+sbit TR1        = TCON^6;
+sbit TF0        = TCON^5;
+sbit TR0        = TCON^4;
+sbit IE1        = TCON^3;
+sbit IT1        = TCON^2;
+sbit IE0        = TCON^1;
+sbit IT0        = TCON^0;
+
+/*  P0  */  
+
+sbit P07        = P0^7;
+sbit RXD        = P0^7;
+sbit P06        = P0^6;
+sbit TXD        = P0^6;
+sbit P05        = P0^5;
+sbit P04        = P0^4;
+sbit STADC      = P0^4;
+sbit P03        = P0^3;
+sbit P02        = P0^2;
+sbit RXD_1      = P0^2;
+sbit P01        = P0^1;
+sbit MISO       = P0^1;
+sbit P00        = P0^0;
+sbit MOSI       = P0^0;
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_sdcc.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/n76e003_sdcc.h
@@ -1,0 +1,296 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  n76e003_sdcc.h                                                                      */
+/*  Header file of Nuvoton                                                              */
+/*  N76E003AT20 / N76E003AQ20 / N76E003BQ20                                             */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76e003.h"
+
+/******************************************************************************/
+/*                         Macro define header files                          */
+/******************************************************************************/
+__sfr __at   (0x80) P0        ;
+__sfr __at   (0x81) SP        ;
+__sfr __at   (0x82) DPL       ;
+__sfr __at   (0x83) DPH       ;
+__sfr __at   (0x84) RCTRIM0   ;
+__sfr __at   (0x85) RCTRIM1   ;
+__sfr __at   (0x86) RWK       ;
+__sfr __at   (0x87) PCON      ;
+
+__sfr  __at  (0x88)TCON       ;
+__sfr  __at  (0x89)TMOD       ;
+__sfr  __at  (0x8A)TL0        ;
+__sfr  __at  (0x8B)TL1        ;
+__sfr  __at  (0x8C)TH0        ;
+__sfr  __at  (0x8D)TH1        ;
+__sfr  __at  (0x8E)CKCON      ;
+__sfr  __at  (0x8F)WKCON      ;
+
+__sfr  __at  (0x90)P1         ;
+__sfr  __at  (0x91)SFRS       ; //TA Protection
+__sfr  __at  (0x92)CAPCON0    ;
+__sfr  __at  (0x93)CAPCON1    ;
+__sfr  __at  (0x94)CAPCON2    ;
+__sfr  __at  (0x95)CKDIV      ;
+__sfr  __at  (0x96)CKSWT      ; //TA Protection
+__sfr  __at  (0x97)CKEN       ; //TA Protection
+
+__sfr  __at  (0x98) SCON      ;
+__sfr  __at  (0x99) SBUF      ;
+__sfr  __at  (0x9A) SBUF_1    ;
+__sfr  __at  (0x9B) EIE       ;
+__sfr  __at  (0x9C) EIE1      ;
+__sfr  __at  (0x9F) CHPCON    ; //TA Protection
+
+__sfr  __at  (0xA0) P2        ;
+__sfr  __at  (0xA2) AUXR1     ;
+__sfr  __at  (0xA3) BODCON0   ; //TA Protection
+__sfr  __at  (0xA4) IAPTRG    ; //TA Protection
+__sfr  __at  (0xA5) IAPUEN    ; //TA Protection
+__sfr  __at  (0xA6) IAPAL     ;
+__sfr  __at  (0xA7) IAPAH     ;
+
+__sfr  __at  (0xA8) IE        ;
+__sfr  __at  (0xA9) SADDR     ;
+__sfr  __at  (0xAA) WDCON     ; //TA Protection
+__sfr  __at  (0xAB) BODCON1   ; //TA Protection
+__sfr  __at  (0xAC) P3M1      ;
+__sfr  __at  (0xAC) P3S       ; //Page1
+__sfr  __at  (0xAD) P3M2      ;
+__sfr  __at  (0xAD) P3SR      ; //Page1
+__sfr  __at  (0xAE) IAPFD     ;
+__sfr  __at  (0xAF) IAPCN     ;
+
+__sfr  __at  (0xB0) P3        ;
+__sfr  __at  (0xB1) P0M1      ;
+__sfr  __at  (0xB1) P0S       ; //Page1
+__sfr  __at  (0xB2) P0M2      ;
+__sfr  __at  (0xB2) P0SR      ; //Page1
+__sfr  __at  (0xB3) P1M1      ;
+__sfr  __at  (0xB3) P1S       ; //Page1
+__sfr  __at  (0xB4) P1M2      ;
+__sfr  __at  (0xB4) P1SR      ; //Page1
+__sfr  __at  (0xB5) P2S       ; 
+__sfr  __at  (0xB7) IPH       ;
+__sfr  __at  (0xB7) PWMINTC   ;  //Page1
+
+__sfr  __at  (0xB8) IP        ;
+__sfr  __at  (0xB9) SADEN     ;
+__sfr  __at  (0xBA) SADEN_1   ;
+__sfr  __at  (0xBB) SADDR_1   ;
+__sfr  __at  (0xBC) I2DAT     ;
+__sfr  __at  (0xBD) I2STAT    ;
+__sfr  __at  (0xBE) I2CLK     ;
+__sfr  __at  (0xBF) I2TOC     ;
+
+__sfr  __at  (0xC0) I2CON     ;
+__sfr  __at  (0xC1) I2ADDR    ;
+__sfr  __at  (0xC2) ADCRL     ;
+__sfr  __at  (0xC3) ADCRH     ;
+__sfr  __at  (0xC4) T3CON     ;
+__sfr  __at  (0xC4) PWM4H     ; //Page1
+__sfr  __at  (0xC5) RL3       ;
+__sfr  __at  (0xC5) PWM5H     ;  //Page1
+__sfr  __at  (0xC6) RH3       ;
+__sfr  __at  (0xC6) PIOCON1   ; //Page1
+__sfr  __at  (0xC7) TA        ;
+
+__sfr  __at  (0xC8) T2CON     ;
+__sfr  __at  (0xC9) T2MOD     ;
+__sfr  __at  (0xCA) RCMP2L    ;
+__sfr  __at  (0xCB) RCMP2H    ;
+__sfr  __at  (0xCC) TL2       ; 
+__sfr  __at  (0xCC) PWM4L     ; //Page1
+__sfr  __at  (0xCD) TH2       ;
+__sfr  __at  (0xCD) PWM5L     ; //Page1
+__sfr  __at  (0xCE) ADCMPL    ;
+__sfr  __at  (0xCF) ADCMPH    ;
+
+__sfr  __at  (0xD0) PSW       ;
+__sfr  __at  (0xD1) PWMPH     ;
+__sfr  __at  (0xD2) PWM0H     ;
+__sfr  __at  (0xD3) PWM1H     ;
+__sfr  __at  (0xD4) PWM2H     ;
+__sfr  __at  (0xD5) PWM3H     ;
+__sfr  __at  (0xD6) PNP       ;
+__sfr  __at  (0xD7) FBD       ;
+
+__sfr  __at  (0xD8) PWMCON0   ;
+__sfr  __at  (0xD9) PWMPL     ;
+__sfr  __at  (0xDA) PWM0L     ;
+__sfr  __at  (0xDB) PWM1L     ;
+__sfr  __at  (0xDC) PWM2L     ;
+__sfr  __at  (0xDD) PWM3L     ;
+__sfr  __at  (0xDE) PIOCON0   ;
+__sfr  __at  (0xDF) PWMCON1   ;
+
+__sfr  __at  (0xE0) ACC       ;
+__sfr  __at  (0xE1) ADCCON1   ;
+__sfr  __at  (0xE2) ADCCON2   ;
+__sfr  __at  (0xE3) ADCDLY    ;
+__sfr  __at  (0xE4) C0L       ;
+__sfr  __at  (0xE5) C0H       ;
+__sfr  __at  (0xE6) C1L       ;
+__sfr  __at  (0xE7) C1H       ;
+
+__sfr  __at  (0xE8) ADCCON0   ;
+__sfr  __at  (0xE9) PICON     ;
+__sfr  __at  (0xEA) PINEN     ;
+__sfr  __at  (0xEB) PIPEN     ;
+__sfr  __at  (0xEC) PIF       ;
+__sfr  __at  (0xED) C2L       ;
+__sfr  __at  (0xEE) C2H       ;
+__sfr  __at  (0xEF) EIP       ;
+
+__sfr  __at  (0xF0) B         ;
+__sfr  __at  (0xF1) CAPCON3   ;
+__sfr  __at  (0xF2) CAPCON4   ;
+__sfr  __at  (0xF3) SPCR      ;
+__sfr  __at  (0xF3) SPCR2     ; //Page1
+__sfr  __at  (0xF4) SPSR      ;
+__sfr  __at  (0xF5) SPDR      ;
+__sfr  __at  (0xF6) AINDIDS   ;
+__sfr  __at  (0xF7) EIPH      ;
+
+__sfr  __at  (0xF8) SCON_1    ;
+__sfr  __at  (0xF9) PDTEN     ; //TA Protection
+__sfr  __at  (0xFA) PDTCNT    ; //TA Protection
+__sfr  __at  (0xFB) PMEN      ;
+__sfr  __at  (0xFC) PMD       ;
+__sfr  __at  (0xFD) PORDIS    ; //TA Protection
+__sfr  __at  (0xFE) EIP1      ;
+__sfr  __at  (0xFF) EIPH1     ;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+__sbit  __at (0xF8+7) SM0_1   ; //SCON_1^7;
+__sbit  __at (0xF8+7) FE_1    ; //SCON_1^7
+__sbit  __at (0xF8+6) SM1_1   ; //SCON_1^6
+__sbit  __at (0xF8+5) SM2_1   ; //SCON_1^5
+__sbit  __at (0xF8+4) REN_1   ; //SCON_1^4
+__sbit  __at (0xF8+3) TB8_1   ; //SCON_1^3
+__sbit  __at (0xF8+2) RB8_1   ; //SCON_1^2
+__sbit  __at (0xF8+1) TI_1    ; //SCON_1^1
+__sbit  __at (0xF8+0) RI_1    ; //SCON_1^0
+
+/*  ADCCON0  */
+__sbit  __at (0xE8+7) ADCF    ; //ADCCON0^7
+__sbit  __at (0xE8+6) ADCS    ; //ADCCON0^6
+__sbit  __at (0xE8+5) ETGSEL1 ; //ADCCON0^5
+__sbit  __at (0xE8+4) ETGSEL0 ; //ADCCON0^4
+__sbit  __at (0xE8+3) ADCHS3  ; //ADCCON0^3
+__sbit  __at (0xE8+2) ADCHS2  ; //ADCCON0^2
+__sbit  __at (0xE8+1) ADCHS1  ; //ADCCON0^1
+__sbit  __at (0xE8+0) ADCHS0  ; //ADCCON0^0
+
+/*  PWMCON0  */
+__sbit  __at (0xD8+7) PWMRUN  ; //PWMCON0^7
+__sbit  __at (0xD8+6) LOAD    ; //PWMCON0^6
+__sbit  __at (0xD8+5) PWMF    ; //PWMCON0^5
+__sbit  __at (0xD8+4) CLRPWM  ; //PWMCON0^4
+
+
+/*  PSW */
+__sbit  __at (0xD0+7) CY       ; //PSW^7
+__sbit  __at (0xD0+6) AC       ; //PSW^6
+__sbit  __at (0xD0+5) F0       ; //PSW^5
+__sbit  __at (0xD0+4) RS1      ; //PSW^4
+__sbit  __at (0xD0+3) RS0      ; //PSW^3
+__sbit  __at (0xD0+2) OV       ; //PSW^2
+__sbit  __at (0xD0+0) P        ; //PSW^0
+
+/*  T2CON  */
+__sbit  __at (0xC8+7) TF2      ; //T2CON^7
+__sbit  __at (0xC8+2) TR2      ; //T2CON^2
+__sbit  __at (0xC8+0) CM_RL2   ; //T2CON^0
+ 
+/*  I2CON  */
+__sbit  __at (0xC0+6) I2CEN    ; //I2CON^6
+__sbit  __at (0xC0+5) STA      ; //I2CON^5
+__sbit  __at (0xC0+4) STO      ; //I2CON^4
+__sbit  __at (0xC0+3) SI       ; //I2CON^3
+__sbit  __at (0xC0+2) AA       ; //I2CON^2
+__sbit  __at (0xC0+0) I2CPX    ; //I2CON^0
+
+/*  IP  */  
+__sbit  __at (0xB8+6) PADC     ; //IP^6
+__sbit  __at (0xB8+5) PBOD     ; //IP^5
+__sbit  __at (0xB8+4) PS       ; //IP^4
+__sbit  __at (0xB8+3) PT1      ; //IP^3
+__sbit  __at (0xB8+2) PX1      ; //IP^2
+__sbit  __at (0xB8+1) PT0      ; //IP^1
+__sbit  __at (0xB8+0) PX0      ; //IP^0
+
+/*  P3  */  
+__sbit  __at (0xB0+0) P30      ; //P3^0
+
+
+/*  IE  */
+__sbit  __at (0xA8+7) EA       ; //IE^7
+__sbit  __at (0xA8+6) EADC     ; //IE^6
+__sbit  __at (0xA8+5) EBOD     ; //IE^5
+__sbit  __at (0xA8+4) ES       ; //IE^4
+__sbit  __at (0xA8+3) ET1      ; //IE^3
+__sbit  __at (0xA8+2) EX1      ; //IE^2
+__sbit  __at (0xA8+1) ET0      ; //IE^1
+__sbit  __at (0xA8+0) EX0      ; //IE^0
+
+/*  P2  */ 
+__sbit  __at (0xA0+0) P20      ; //P2^0
+
+/*  SCON  */
+__sbit  __at (0x98+7) SM0      ; //SCON^7
+__sbit  __at (0x98+7) FE       ; //SCON^7
+__sbit  __at (0x98+6) SM1      ; //SCON^6
+__sbit  __at (0x98+5) SM2      ; //SCON^5
+__sbit  __at (0x98+4) REN      ; //SCON^4
+__sbit  __at (0x98+3) TB8      ; //SCON^3
+__sbit  __at (0x98+2) RB8      ; //SCON^2
+__sbit  __at (0x98+1) TI       ; //SCON^1
+__sbit  __at (0x98+0) RI       ; //SCON^0
+
+/*  P1  */     
+__sbit  __at (0x90+7) P17      ; //P1^7
+__sbit  __at (0x90+6) P16      ; //P1^6
+__sbit  __at (0x90+6) TXD_1    ; //P1^6
+__sbit  __at (0x90+5) P15      ; //P1^5
+__sbit  __at (0x90+4) P14      ; //P1^4
+__sbit  __at (0x90+4) SDA      ; //P1^4
+__sbit  __at (0x90+3) P13      ; //P1^3
+__sbit  __at (0x90+3) SCL      ; //P1^3
+__sbit  __at (0x90+2) P12      ; //P1^2
+__sbit  __at (0x90+1) P11      ; //P1^1
+__sbit  __at (0x90+0) P10      ; //P1^0
+
+/*  TCON  */
+__sbit  __at (0x88+7) TF1      ; //TCON^7
+__sbit  __at (0x88+6) TR1      ; //TCON^6
+__sbit  __at (0x88+5) TF0      ; //TCON^5
+__sbit  __at (0x88+4) TR0      ; //TCON^4
+__sbit  __at (0x88+3) IE1      ; //TCON^3
+__sbit  __at (0x88+2) IT1      ; //TCON^2
+__sbit  __at (0x88+1) IE0      ; //TCON^1
+__sbit  __at (0x88+0) IT0      ; //TCON^0
+
+/*  P0  */  
+__sbit  __at (0x80+7) P07      ; //P0^7
+__sbit  __at (0x80+7) RXD      ; //P0^7
+__sbit  __at (0x80+6) P06      ; //P0^6
+__sbit  __at (0x80+6) TXD      ; //P0^6
+__sbit  __at (0x80+5) P05      ; //P0^5
+__sbit  __at (0x80+4) P04      ; //P0^4
+__sbit  __at (0x80+4) STADC    ; //P0^4
+__sbit  __at (0x80+3) P03      ; //P0^3
+__sbit  __at (0x80+2) P02      ; //P0^2
+__sbit  __at (0x80+2) RXD_1    ; //P0^2
+__sbit  __at (0x80+1) P01      ; //P0^1
+__sbit  __at (0x80+1) MISO     ; //P0^1
+__sbit  __at (0x80+0) P00      ; //P0^0
+__sbit  __at (0x80+0) MOSI     ; //P0^0
+

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/numicro_8051.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/numicro_8051.h
@@ -1,0 +1,14 @@
+
+/* for Keil */
+#if defined __C51__
+#include "n76e003_keil.h"
+
+/* for IAR */
+#elif defined __ICC8051__
+#include "n76e003_iar.h"
+
+/* for SDCC */
+#elif defined __SDCC__
+#include "n76e003_sdcc.h"
+
+#endif

--- a/hardware/victims/firmware/numicro8051/inc/N76E003/sfr_macro_n76e003.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76E003/sfr_macro_n76e003.h
@@ -1,0 +1,2269 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  sfr_macro_n76e003.h                                                            */
+/*  SFR Macro define for Nuvoton                                                        */
+/*  N76E003AT20 / N76E003AQ20                                                           */
+/*--------------------------------------------------------------------------------------*/
+#if defined __C51__
+#include <stdio.h>
+#include <string.h>
+#include <absacc.h>
+#include <intrins.h>
+
+#elif defined __ICC8051__
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+
+#elif defined __SDCC__
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <float.h>
+
+#endif
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "function_define_n76e003.h"
+
+#ifdef INC_STD_DRIVER
+#include "adc.h"
+#include "bod.h"
+#include "capture.h"
+#include "common.h"
+#include "delay.h"
+#include "eeprom_sprom.h"
+#include "eeprom.h"
+#include "i2c.h"
+#include "iap_sprom.h"
+#include "iap.h"
+#include "isr.h"
+#include "pwm.h"
+#include "spi.h"
+#include "sys.h"
+#include "timer.h"
+#include "uart.h"
+#include "wdt.h"
+#include "wkt.h"
+#endif
+
+/********************************************************************/
+/*  <Macro define                                                   */
+/********************************************************************/
+
+/**** SP   81H ****/
+/**** DPH  82H ****/
+/**** DPL  83H ****/
+/**** RWK  86H ****/
+
+/**** PCON  87H ****/
+#define set_PCON_SMOD            PCON|=0x80
+#define set_PCON_SMOD0           PCON|=0x40
+#define set_PCON_POF             PCON|=0x10
+#define set_PCON_GF1             PCON|=0x08
+#define set_PCON_GF0             PCON|=0x04 
+#define set_PCON_PD              PCON|=0x02
+#define set_PCON_IDLE            PCON|=0x01
+                                    
+#define clr_PCON_SMOD            PCON&=0x7F
+#define clr_PCON_SMOD0           PCON&=0xBF
+#define clr_PCON_POF             PCON&=0xEF
+#define clr_PCON_GF1             PCON&=0xF7
+#define clr_PCON_GF0             PCON&=0xFB 
+#define clr_PCON_PD              PCON&=0xFD
+#define clr_PCON_IDLE            PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TCON_TF1             TF1=1
+#define set_TCON_TR1             TR1=1
+#define set_TCON_TF0             TF0=1
+#define set_TCON_TR0             TR0=1
+#define set_TCON_IE1             IE1=1
+#define set_TCON_IT1             IT1=1
+#define set_TCON_IE0             IE0=1
+#define set_TCON_IT0             IT0=1
+                                 
+#define clr_TCON_TF1             TF1=0
+#define clr_TCON_TR1             TR1=0
+#define clr_TCON_TF0             TF0=0
+#define clr_TCON_TR0             TR0=0
+#define clr_TCON_IE1             IE1=0
+#define clr_TCON_IT1             IT1=0
+#define clr_TCON_IE0             IE0=0
+#define clr_TCON_IT0             IT0=0
+
+/**** TMOD    89H ****/
+#define set_TMOD_GATE_T1         TMOD|=0x80
+#define set_TMOD_CT_T1           TMOD|=0x40
+#define set_TMOD_M1_T1           TMOD|=0x20
+#define set_TMOD_M0_T1           TMOD|=0x10
+#define set_TMOD_GATE_T0         TMOD|=0x08
+#define set_TMOD_CT_T0           TMOD|=0x04
+#define set_TMOD_M1_T0           TMOD|=0x02
+#define set_TMOD_M0_T0           TMOD|=0x01
+                                  
+#define clr_TMOD_GATE_T1         TMOD&=0x7F
+#define clr_TMOD_CT_T1           TMOD&=0xBF
+#define clr_TMOD_M1_T1           TMOD&=0xDF
+#define clr_TMOD_M0_T1           TMOD&=0xEF
+#define clr_TMOD_GATE_T0         TMOD&=0xF7
+#define clr_TMOD_CT_T0           TMOD&=0xFB
+#define clr_TMOD_M1_T0           TMOD&=0xFD
+#define clr_TMOD_M0_T0           TMOD&=0xFE
+
+/**** TH1    8AH ****/
+/**** TH0    8BH ****/
+/**** TL1    8CH  ****/ 
+/**** TL0    8DH ****/
+
+/**** CKCON  8EH ****/
+#define set_CKCON_PWMCKS         CKCON|=0x40
+#define set_CKCON_T1M            CKCON|=0x10
+#define set_CKCON_T0M            CKCON|=0x08
+#define set_CKCON_CLOEN          CKCON|=0x02
+                                   
+#define clr_CKCON_PWMCKS         CKCON&=0xBF
+#define clr_CKCON_T1M            CKCON&=0xEF
+#define clr_CKCON_T0M            CKCON&=0xF7
+#define clr_CKCON_CLOEN          CKCON&=0xFD
+                                 
+/**** WKCON  8FH ****/          
+#define set_WKCON_WKTCK          WKCON|=0x20
+#define set_WKCON_WKTF           WKCON|=0x10
+#define set_WKCON_WKTR           WKCON|=0x08
+#define set_WKCON_WKPS2          WKCON|=0x04
+#define set_WKCON_WKPS1          WKCON|=0x02
+#define set_WKCON_WKPS0          WKCON|=0x01
+                                   
+#define clr_WKCON_WKTCK          WKCON&=0xDF
+#define clr_WKCON_WKTF           WKCON&=0xEF
+#define clr_WKCON_WKTR           WKCON&=0xF7
+#define clr_WKCON_WKPS2          WKCON&=0xFB
+#define clr_WKCON_WKPS1          WKCON&=0xFD
+#define clr_WKCON_WKPS0          WKCON&= 0xFE
+
+/****SFRS    91H ****/
+#define set_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPCON0_CAPEN2       CAPCON0|=0x40
+#define set_CAPCON0_CAPEN1       CAPCON0|=0x20
+#define set_CAPCON0_CAPEN0       CAPCON0|=0x10
+#define set_CAPCON0_CAPF2        CAPCON0|=0x04
+#define set_CAPCON0_CAPF1        CAPCON0|=0x02
+#define set_CAPCON0_CAPF0        CAPCON0|=0x01
+                                 
+#define clr_CAPCON0_CAPEN2       CAPCON0&=0xBF
+#define clr_CAPCON0_CAPEN1       CAPCON0&=0xDF
+#define clr_CAPCON0_CAPEN0       CAPCON0&=0xEF
+#define clr_CAPCON0_CAPF2        CAPCON0&=0xFB
+#define clr_CAPCON0_CAPF1        CAPCON0&=0xFD
+#define clr_CAPCON0_CAPF0        CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAPCON1_CAP2LS1      CAPCON1|=0x20
+#define set_CAPCON1_CAP2LS0      CAPCON1|=0x10
+#define set_CAPCON1_CAP1LS1      CAPCON1|=0x08
+#define set_CAPCON1_CAP1LS0      CAPCON1|=0x04
+#define set_CAPCON1_CAP0LS1      CAPCON1|=0x02
+#define set_CAPCON1_CAP0LS0      CAPCON1|=0x01
+                                 
+#define clr_CAPCON1_CAP2LS1      CAPCON1&=0xDF
+#define clr_CAPCON1_CAP2LS0      CAPCON1&=0xEF
+#define clr_CAPCON1_CAP1LS1      CAPCON1&=0xF7
+#define clr_CAPCON1_CAP1LS0      CAPCON1&=0xFB
+#define clr_CAPCON1_CAP0LS1      CAPCON1&=0xFD
+#define clr_CAPCON1_CAP0LS0      CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_CAPCON2_ENF2         CAPCON2|=0x40
+#define set_CAPCON2_ENF1         CAPCON2|=0x20
+#define set_CAPCON2_ENF0         CAPCON2|=0x10
+                                   
+#define clr_CAPCON2_ENF2         CAPCON2&=0xBF
+#define clr_CAPCON2_ENF1         CAPCON2&=0xDF
+#define clr_CAPCON2_ENF0         CAPCON2&=0xEF
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H   TA protect register ****/
+#define set_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+
+#define clr_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/ 
+#define set_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+
+#define clr_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_SCON_FE              FE =1
+#define set_SCON_SM1             SM1=1
+#define set_SCON_SM2             SM2=1
+#define set_SCON_REN             REN=1
+#define set_SCON_TB8             TB8=1
+#define set_SCON_RB8             RB8=1
+#define set_SCON_TI              TI =1
+#define set_SCON_RI              RI =1
+                                 
+#define clr_SCON_FE              FE =0
+#define clr_SCON_SM1             SM1=0
+#define clr_SCON_SM2             SM2=0
+#define clr_SCON_REN             REN=0
+#define clr_SCON_TB8             TB8=0
+#define clr_SCON_RB8             RB8=0
+#define clr_SCON_TI              TI =0
+#define clr_SCON_RI              RI =0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                     
+#define set_EIE_ET2              EIE|=0x80
+#define set_EIE_ESPI             EIE|=0x40
+#define set_EIE_EFB              EIE|=0x20
+#define set_EIE_EWDT             EIE|=0x10
+#define set_EIE_EPWM             EIE|=0x08
+#define set_EIE_ECAP             EIE|=0x04
+#define set_EIE_EPI              EIE|=0x02
+#define set_EIE_EI2C             EIE|=0x01
+                                    
+#define clr_EIE_ET2              EIE&=0x7F
+#define clr_EIE_ESPI             EIE&=0xBF
+#define clr_EIE_EFB              EIE&=0xDF
+#define clr_EIE_EWDT             EIE&=0xEF
+#define clr_EIE_EPWM             EIE&=0xF7
+#define clr_EIE_ECAP             EIE&=0xFB
+#define clr_EIE_EPI              EIE&=0xFD
+#define clr_EIE_EI2C             EIE&=0xFE
+
+/**** EIE1    9CH ****/                     
+#define set_EIE1_EWKT            EIE1|=0x04
+#define set_EIE1_ET3             EIE1|=0x02
+#define set_EIE1_ES_1            EIE1|=0x01
+                                    
+#define clr_EIE1_EWKT            EIE1&=0xFB
+#define clr_EIE1_ET3             EIE1&=0xFD
+#define clr_EIE1_ES_1            EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register  ****/
+#define set_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_AUXR1_SWRF           AUXR1|=0x80
+#define set_AUXR1_RSTPINF        AUXR1|=0x40
+#define set_AUXR1_HARDF          AUXR1|=0x20
+#define set_AUXR1_GF2            AUXR1|=0x08
+#define set_AUXR1_UART0PX        AUXR1|=0x04
+#define set_AUXR1_DPS            AUXR1|=0x01
+                                   
+#define clr_AUXR1_SWRF           AUXR1&=0x7F
+#define clr_AUXR1_RSTPINF        AUXR1&=0xBF
+#define clr_AUXR1_HARDF          AUXR1&=0xDF
+#define clr_AUXR1_GF2            AUXR1&=0xF7
+#define clr_AUXR1_UART0PX        AUXR1&=0xFB
+#define clr_AUXR1_DPS            AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BODCON0_BOV2         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define set_IAPTRG_IAPGO_WDCLR   BIT_TMP=EA;EA=0;set_WDCON_WDCLR;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define clr_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG&=0xFE;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/ 
+#define set_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x10;EA=BIT_TMP
+#define set_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x08;EA=BIT_TMP
+#define set_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                 
+#define clr_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xEF;EA=BIT_TMP
+#define clr_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xF7;EA=BIT_TMP
+#define clr_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_IE_EA                EA  =1
+#define set_IE_EADC              EADC=1
+#define set_IE_EBOD              EBOD=1
+#define set_IE_ES                ES  =1
+#define set_IE_ET1               ET1 =1
+#define set_IE_EX1               EX1 =1
+#define set_IE_ET0               ET0 =1
+#define set_IE_EX0               EX0 =1
+                                 
+#define clr_IE_EA                EA  =0
+#define clr_IE_EADC              EADC=0
+#define clr_IE_EBOD              EBOD=0
+#define clr_IE_ES                ES  =0
+#define clr_IE_ET1               ET1 =0
+#define clr_IE_EX1               EX1 =0
+#define clr_IE_ET0               ET0 =0
+#define clr_IE_EX0               EX0 =0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WDCON_WIDPD          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_IAPCN_FOEN           IAPN|=0x20
+#define set_IAPCN_FCEN           IAPN|=0x10
+#define set_IAPCN_FCTRL3         IAPN|=0x08
+#define set_IAPCN_FCTRL2         IAPN|=0x04
+#define set_IAPCN_FCTRL1         IAPN|=0x02
+#define set_IAPCN_FCTRL0         IAPN|=0x01
+                                   
+#define clr_IAPCN_FOEN           IAPN&=0xDF
+#define clr_IAPCN_FCEN           IAPN&=0xEF
+#define clr_IAPCN_FCTRL3         IAPN&=0xF7
+#define clr_IAPCN_FCTRL2         IAPN&=0xFB
+#define clr_IAPCN_FCTRL1         IAPN&=0xFD
+#define clr_IAPCN_FCTRL0         IAPN&=0xFE
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7               clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6               clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5               clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4               clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3               clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2               clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1               clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0               clr_SFRS_SFRPAGE;P0M1|=0x01
+                                 
+#define clr_P0M1_7               clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6               clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5               clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4               clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3               clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2               clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1               clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0               clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/
+#define set_P0S_7                set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6                set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5                set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4                set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3                set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2                set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1                set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0                set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7                set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6                set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5                set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4                set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3                set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2                set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1                set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0                set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7               clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6               clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5               clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4               clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3               clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2               clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1               clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0               clr_SFRS_SFRPAGE;P0M2|=0x01
+                                 
+#define clr_P0M2_7               clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6               clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5               clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4               clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3               clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2               clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1               clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0               clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7               set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6               set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5               set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4               set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3               set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2               set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1               set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0               set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7               set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6               set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5               set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4               set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3               set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2               set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1               set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0               set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7                set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6                set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5                set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4                set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3                set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2                set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1                set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0                set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1S_7                set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6                set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5                set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4                set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3                set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2                set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1                set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0                set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7               set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6               set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5               set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4               set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3               set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2               set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1               set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0               set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1SR_7               set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6               set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5               set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4               set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3               set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2               set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1               set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0               set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_P20UP            P2S|=0x80
+#define set_P2S_T1OE             P2S|=0x08
+#define set_P2S_T0OE             P2S|=0x04
+#define set_P2S_P2S0             P2S|=0x01
+                                 
+#define clr_P2S_P20UP            P2S&=0x7F
+#define clr_P2S_T1OE             P2S&=0xF7
+#define clr_P2S_T0OE             P2S&=0xFB
+#define clr_P2S_P2S0             P2S&=0xFE
+                                 
+/**** IPH    B7H PAGE0 ****/                     
+#define set_IPH_PADCH            clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_IPH_PBODH            clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_IPH_PSH              clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_IPH_PT1H             clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_IPH_PX1H             clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_IPH_PT0H             clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_IPH_PX0H             clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_IPH_PADCH            clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_IPH_PBODH            clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_IPH_PSH              clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_IPH_PT1H             clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_IPH_PX1H             clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_IPH_PT0H             clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_IPH_PX0H             clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/ 
+#define set_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+                                
+#define clr_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_IP_PADC              PADC=1
+#define set_IP_PBOD              PBOD=1
+#define set_IP_PS                PS  =1
+#define set_IP_PT1               PT1 =1
+#define set_IP_PX1               PX1 =1
+#define set_IP_PT0               PT0 =1
+#define set_IP_PX0               PX0 =1
+                                 
+#define clr_IP_PADC              PADC=0
+#define clr_IP_PBOD              PBOD=0
+#define clr_IP_PS                PS  =0
+#define clr_IP_PT1               PT1 =0
+#define clr_IP_PX1               PX1 =0
+#define clr_IP_PT0               PT0 =0
+#define clr_IP_PX0               PX0 =0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOC_I2TOCEN       I2TOC|=0x04
+#define set_I2TOC_DIV           I2TOC|=0x02
+#define set_I2TOC_I2TOF         I2TOC|=0x01
+                                
+#define clr_I2TOC_I2TOCEN       I2TOC&=0xFB
+#define clr_I2TOC_DIV           I2TOC&=0xFD
+#define clr_I2TOC_I2TOF         I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CON_I2CEN         I2CEN    = 1
+#define set_I2CON_STA           STA      = 1
+#define set_I2CON_STO           STO      = 1
+#define set_I2CON_SI            SI       = 1
+#define set_I2CON_AA            AA       = 1
+#define set_I2CON_I2CPX         I2CPX    = 1
+            
+#define clr_I2CON_I2CEN         I2CEN    = 0
+#define clr_I2CON_STA           STA      = 0
+#define clr_I2CON_STO           STO      = 0
+#define clr_I2CON_SI            SI       = 0
+#define clr_I2CON_AA            AA       = 0
+#define clr_I2CON_I2CPX         I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_I2ADDR_GC           I2ADDR|= 0x01
+#define clr_I2ADDR_GC           I2ADDR&= 0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON|=0x01
+
+#define clr_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_T2CON_TF2           TF2      = 1
+#define set_T2CON_TR2           TR2      = 1
+#define set_T2CON_CMRL2         CM_RL2   = 1
+                                
+#define clr_T2CON_TF2           TF2      = 0
+#define clr_T2CON_TR2           TR2      = 0
+#define clr_T2CON_CMRL2         CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_T2MOD_LDEN          T2MOD|=0x80
+#define set_T2MOD_T2DIV2        T2MOD|=0x40
+#define set_T2MOD_T2DIV1        T2MOD|=0x20
+#define set_T2MOD_T2DIV0        T2MOD|=0x10
+#define set_T2MOD_CAPCR         T2MOD|=0x08
+#define set_T2MOD_CMPCR         T2MOD|=0x04
+#define set_T2MOD_LDTS1         T2MOD|=0x02
+#define set_T2MOD_LDTS0         T2MOD|=0x01
+                                       
+#define clr_T2MOD_LDEN          T2MOD&=0x7F
+#define clr_T2MOD_T2DIV2        T2MOD&=0xBF
+#define clr_T2MOD_T2DIV1        T2MOD&=0xDF
+#define clr_T2MOD_T2DIV0        T2MOD&=0xEF
+#define clr_T2MOD_CAPCR         T2MOD&=0xF7
+#define clr_T2MOD_CMPCR         T2MOD&=0xFB
+#define clr_T2MOD_LDTS1         T2MOD&=0xFD
+#define clr_T2MOD_LDTS0         T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L  CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_PSW_CY              CY  = 1
+#define set_PSW_AC              AC  = 1
+#define set_PSW_F0              F0  = 1 
+#define set_PSW_RS1             RS1 = 1
+#define set_PSW_RS0             RS0 = 1
+#define set_PSW_OV              OV   = 1
+#define set_PSW_P               P    = 1
+                                
+#define clr_PSW_CY              CY  = 0
+#define clr_PSW_AC              AC  = 0
+#define clr_PSW_F0              F0  = 0 
+#define clr_PSW_RS1             RS1 = 0
+#define clr_PSW_RS0             RS0 = 0
+#define clr_PSW_OV              OV   = 0
+#define clr_PSW_P               P    = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** FBD    D7H ****/
+#define set_FBD_FBF             FBD|=0x80
+#define set_FBD_FBINLS          FBD|=0x40
+#define set_FBD_FBD5            FBD|=0x20
+#define set_FBD_FBD4            FBD|=0x10
+#define set_FBD_FBD3            FBD|=0x08
+#define set_FBD_FBD2            FBD|=0x04
+#define set_FBD_FBD1            FBD|=0x02
+#define set_FBD_FBD0            FBD|=0x01
+                                
+#define clr_FBD_FBF             FBD&=0x7F
+#define clr_FBD_FBINLS          FBD&=0xBF
+#define clr_FBD_FBD5            FBD&=0xDF
+#define clr_FBD_FBD4            FBD&=0xEF
+#define clr_FBD_FBD3            FBD&=0xF7
+#define clr_FBD_FBD2            FBD&=0xFB
+#define clr_FBD_FBD1            FBD&=0xFD
+#define clr_FBD_FBD0            FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMCON0_PWMRUN      PWMRUN   = 1
+#define set_PWMCON0_LOAD        LOAD     = 1
+#define set_PWMCON0_PWMF        PWMF     = 1
+#define set_PWMCON0_CLRPWM      CLRPWM   = 1
+                                
+#define clr_PWMCON0_PWMRUN      PWMRUN   = 0
+#define clr_PWMCON0_LOAD        LOAD     = 0
+#define clr_PWMCON0_PWMF        PWMF     = 0 
+#define clr_PWMCON0_CLRPWM      CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIOCON0_PIO05       PIOCON0|=0x20
+#define set_PIOCON0_PIO04       PIOCON0|=0x10
+#define set_PIOCON0_PIO03       PIOCON0|=0x08
+#define set_PIOCON0_PIO02       PIOCON0|=0x04
+#define set_PIOCON0_PIO01       PIOCON0|=0x02
+#define set_PIOCON0_PIO00       PIOCON0|=0x01
+                                
+#define clr_PIOCON0_PIO05       PIOCON0&=0xDF
+#define clr_PIOCON0_PIO04       PIOCON0&=0xEF
+#define clr_PIOCON0_PIO03       PIOCON0&=0xF7
+#define clr_PIOCON0_PIO02       PIOCON0&=0xFB
+#define clr_PIOCON0_PIO01       PIOCON0&=0xFD
+#define clr_PIOCON0_PIO00       PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMCON1_PWMMOD1     PWMCON1|=0x80
+#define set_PWMCON1_PWMMOD0     PWMCON1|=0x40
+#define set_PWMCON1_GP          PWMCON1|=0x20
+#define set_PWMCON1_PWMTYP      PWMCON1|=0x10
+#define set_PWMCON1_FBINEN      PWMCON1|=0x08
+#define set_PWMCON1_PWMDIV2     PWMCON1|=0x04 
+#define set_PWMCON1_PWMDIV1     PWMCON1|=0x02
+#define set_PWMCON1_PWMDIV0     PWMCON1|=0x01
+                                
+#define clr_PWMCON1_PWMMOD1     PWMCON1&=0x7F
+#define clr_PWMCON1_PWMMOD0     PWMCON1&=0xBF
+#define clr_PWMCON1_GP          PWMCON1&=0xDF
+#define clr_PWMCON1_PWMTYP      PWMCON1&=0xEF
+#define clr_PWMCON1_FBINEN      PWMCON1&=0xF7
+#define clr_PWMCON1_PWMDIV2     PWMCON1&=0xFB 
+#define clr_PWMCON1_PWMDIV1     PWMCON1&=0xFD
+#define clr_PWMCON1_PWMDIV0     PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1|=0x40
+#define set_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1|=0x08
+#define set_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1|=0x04
+#define set_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1|=0x02
+#define set_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1|=0x01
+
+#define clr_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1&=0xBF
+#define clr_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1&=0xF7
+#define clr_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1&=0xFB                                                   
+#define clr_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1&=0xFD
+#define clr_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/                    
+#define set_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2|=0x80
+#define set_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2|=0x40
+#define set_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2|=0x20
+#define set_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2|=0x10
+
+#define clr_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2&=0x7F
+#define clr_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2&=0xBF
+#define clr_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2&=0xDF
+#define clr_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=1
+#define set_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=1
+#define set_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=1
+#define set_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=1
+#define set_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=1
+#define set_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=1
+#define set_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=1
+#define set_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=1
+
+#define clr_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=0
+#define clr_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=0
+#define clr_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=0
+#define clr_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=0
+#define clr_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=0
+#define clr_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=0
+#define clr_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=0
+#define clr_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=0
+
+/**** PICON  E9H ****/
+#define set_PICON_PIT67         PICON|=0x80
+#define set_PICON_PIT45         PICON|=0x40
+#define set_PICON_PIT3          PICON|=0x20
+#define set_PICON_PIT2          PICON|=0x10
+#define set_PICON_PIT1          PICON|=0x08
+#define set_PICON_PIT0          PICON|=0x04
+#define set_PICON_PIPS1         PICON|=0x02
+#define set_PICON_PIPS0         PICON|=0x01
+                                  
+#define clr_PICON_PIT67         PICON&=0x7F
+#define clr_PICON_PIT45         PICON&=0xBF
+#define clr_PICON_PIT3          PICON&=0xDF
+#define clr_PICON_PIT2          PICON&=0xEF
+#define clr_PICON_PIT1          PICON&=0xF7
+#define clr_PICON_PIT0          PICON&=0xFB
+#define clr_PICON_PIPS1         PICON&=0xFD
+#define clr_PICON_PIPS0         PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN_PINEN7        PINEN|=0x80
+#define set_PINEN_PINEN6        PINEN|=0x40
+#define set_PINEN_PINEN5        PINEN|=0x20
+#define set_PINEN_PINEN4        PINEN|=0x10
+#define set_PINEN_PINEN3        PINEN|=0x08
+#define set_PINEN_PINEN2        PINEN|=0x04
+#define set_PINEN_PINEN1        PINEN|=0x02
+#define set_PINEN_PINEN0        PINEN|=0x01
+                                  
+#define clr_PINEN_PINEN7        PINEN&=0x7F
+#define clr_PINEN_PINEN6        PINEN&=0xBF
+#define clr_PINEN_PINEN5        PINEN&=0xDF
+#define clr_PINEN_PINEN4        PINEN&=0xEF
+#define clr_PINEN_PINEN3        PINEN&=0xF7
+#define clr_PINEN_PINEN2        PINEN&=0xFB
+#define clr_PINEN_PINEN1        PINEN&=0xFD
+#define clr_PINEN_PINEN0        PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN_PIPEN7        PIPEN|=0x80
+#define set_PIPEN_PIPEN6        PIPEN|=0x40
+#define set_PIPEN_PIPEN5        PIPEN|=0x20
+#define set_PIPEN_PIPEN4        PIPEN|=0x10
+#define set_PIPEN_PIPEN3        PIPEN|=0x08
+#define set_PIPEN_PIPEN2        PIPEN|=0x04
+#define set_PIPEN_PIPEN1        PIPEN|=0x02
+#define set_PIPEN_PIPEN0        PIPEN|=0x01
+                                  
+#define clr_PIPEN_PIPEN7        PIPEN&=0x7F
+#define clr_PIPEN_PIPEN6        PIPEN&=0xBF
+#define clr_PIPEN_PIPEN5        PIPEN&=0xDF
+#define clr_PIPEN_PIPEN4        PIPEN&=0xEF
+#define clr_PIPEN_PIPEN3        PIPEN&=0xF7
+#define clr_PIPEN_PIPEN2        PIPEN&=0xFB
+#define clr_PIPEN_PIPEN1        PIPEN&=0xFD
+#define clr_PIPEN_PIPEN0        PIPEN&=0xFE
+
+/**** PIF ECH ****/
+#define set_PIF_PIF7             PIF|=0x80
+#define set_PIF_PIF6             PIF|=0x40
+#define set_PIF_PIF5             PIF|=0x20
+#define set_PIF_PIF4             PIF|=0x10
+#define set_PIF_PIF3             PIF|=0x08
+#define set_PIF_PIF2             PIF|=0x04
+#define set_PIF_PIF1             PIF|=0x02
+#define set_PIF_PIF0             PIF|=0x01
+                                 
+#define clr_PIF_PIF7             PIF&=0x7F
+#define clr_PIF_PIF6             PIF&=0xBF
+#define clr_PIF_PIF5             PIF&=0xDF
+#define clr_PIF_PIF4             PIF&=0xEF
+#define clr_PIF_PIF3             PIF&=0xF7
+#define clr_PIF_PIF2             PIF&=0xFB
+#define clr_PIF_PIF1             PIF&=0xFD
+#define clr_PIF_PIF0             PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_EIP_PT2             EIP|=0x80
+#define set_EIP_PSPI            EIP|=0x40
+#define set_EIP_PFB             EIP|=0x20
+#define set_EIP_PWDT            EIP|=0x10
+#define set_EIP_PPWM            EIP|=0x08
+#define set_EIP_PCAP            EIP|=0x04
+#define set_EIP_PPI             EIP|=0x02
+#define set_EIP_PI2C            EIP|=0x01
+                                   
+#define clr_EIP_PT2             EIP&=0x7F
+#define clr_EIP_PSPI            EIP&=0xBF
+#define clr_EIP_PFB             EIP&=0xDF
+#define clr_EIP_PWDT            EIP&=0xEF
+#define clr_EIP_PPWM            EIP&=0xF7
+#define clr_EIP_PCAP            EIP&=0xFB
+#define clr_EIP_PPI             EIP&=0xFD
+#define clr_EIP_PI2C            EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAPCON3_CAP13       CAPCON3|=0x80
+#define set_CAPCON3_CAP12       CAPCON3|=0x40
+#define set_CAPCON3_CAP11       CAPCON3|=0x20
+#define set_CAPCON3_CAP10       CAPCON3|=0x10
+#define set_CAPCON3_CAP03       CAPCON3|=0x08
+#define set_CAPCON3_CAP02       CAPCON3|=0x04
+#define set_CAPCON3_CAP01       CAPCON3|=0x02
+#define set_CAPCON3_CAP00       CAPCON3|=0x01
+                                
+#define clr_CAPCON3_CAP13       CAPCON3&=0x7F
+#define clr_CAPCON3_CAP12       CAPCON3&=0xBF
+#define clr_CAPCON3_CAP11       CAPCON3&=0xDF
+#define clr_CAPCON3_CAP10       CAPCON3&=0xEF
+#define clr_CAPCON3_CAP03       CAPCON3&=0xF7
+#define clr_CAPCON3_CAP02       CAPCON3&=0xFB
+#define clr_CAPCON3_CAP01       CAPCON3&=0xFD
+#define clr_CAPCON3_CAP00       CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAPCON4_CAP23       CAPCON4|=0x08
+#define set_CAPCON4_CAP22       CAPCON4|=0x04
+#define set_CAPCON4_CAP21       CAPCON4|=0x02
+#define set_CAPCON4_CAP20       CAPCON4|=0x01
+                                
+#define clr_CAPCON4_CAP23       CAPCON4&=0xF7
+#define clr_CAPCON4_CAP22       CAPCON4&=0xFB
+#define clr_CAPCON4_CAP21       CAPCON4&=0xFD
+#define clr_CAPCON4_CAP20       CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR|=0x01
+                                
+#define clr_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPSR_SPIF           SPSR|=0x80
+#define set_SPSR_WCOL           SPSR|=0x40
+#define set_SPSR_SPIOVF         SPSR|=0x20
+#define set_SPSR_MODF           SPSR|=0x10
+#define set_SPSR_DISMODF        SPSR|=0x08
+                                   
+#define clr_SPSR_SPIF           SPSR&=0x7F
+#define clr_SPSR_WCOL           SPSR&=0xBF
+#define clr_SPSR_SPIOVF         SPSR&=0xDF
+#define clr_SPSR_MODF           SPSR&=0xEF
+#define clr_SPSR_DISMODF        SPSR&=0xF7
+
+/**** SPDR    F5H PAGE0 ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                
+#define clr_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH|=0x01
+                                   
+#define clr_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_SCON_1_FE_1         FE_1  = 1
+#define set_SCON_1_SM1_1        SM1_1 = 1
+#define set_SCON_1_SM2_1        SM2_1 = 1
+#define set_SCON_1_REN_1        REN_1 = 1
+#define set_SCON_1_TB8_1        TB8_1 = 1
+#define set_SCON_1_RB8_1        RB8_1 = 1
+#define set_SCON_1_TI_1         TI_1  = 1
+#define set_SCON_1_RI_1         RI_1  = 1
+                                
+#define clr_SCON_1_FE_1         FE_1  = 0
+#define clr_SCON_1_SM1_1        SM1_1 = 0
+#define clr_SCON_1_SM2_1        SM2_1 = 0
+#define clr_SCON_1_REN_1        REN_1 = 0
+#define clr_SCON_1_TB8_1        TB8_1 = 0
+#define clr_SCON_1_RB8_1        RB8_1 = 0
+#define clr_SCON_1_TI_1         TI_1  = 0
+#define clr_SCON_1_RI_1         RI_1  = 0
+
+/**** PDTEN    F9H ****/
+#define set_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN_5               PMEN|=0x20
+#define set_PMEN_4               PMEN|=0x10
+#define set_PMEN_3               PMEN|=0x08
+#define set_PMEN_2               PMEN|=0x04
+#define set_PMEN_1               PMEN|=0x02
+#define set_PMEN_0               PMEN|=0x01
+                                    
+#define clr_PMEN_5               PMEN&=0xDF
+#define clr_PMEN_4               PMEN&=0xEF
+#define clr_PMEN_3               PMEN&=0xF7
+#define clr_PMEN_2               PMEN&=0xFB
+#define clr_PMEN_1               PMEN&=0xFD
+#define clr_PMEN_0               PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD_7                PMD|=0x80
+#define set_PMD_6                PMD|=0x40
+#define set_PMD_5                PMD|=0x20
+#define set_PMD_4                PMD|=0x10
+#define set_PMD_3                PMD|=0x08
+#define set_PMD_2                PMD|=0x04
+#define set_PMD_1                PMD|=0x02
+#define set_PMD_0                PMD|=0x01
+                                   
+#define clr_PMD_7                PMD&=0x7F
+#define clr_PMD_6                PMD&=0xBF
+#define clr_PMD_5                PMD&=0xDF
+#define clr_PMD_4                PMD&=0xEF
+#define clr_PMD_3                PMD&=0xF7
+#define clr_PMD_2                PMD&=0xFB
+#define clr_PMD_1                PMD&=0xFD
+#define clr_PMD_0                PMD&=0xFE
+
+/****  EIP1     FEH PAGE0 ****/                   
+#define set_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1|=0x01
+                                   
+#define clr_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1&=0xFE
+
+/**** EIPH1    FFH ****/                
+#define set_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                  
+#define clr_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1&=0xFE
+
+ /********************************************************/
+/*  <Define rule II> "set or clr _ register bit name     */
+/*********************************************************/
+/**** P0    80H ****/
+#define set_P00                 P00=1
+#define set_P01                 P01=1
+#define set_P02                 P02=1
+#define set_P03                 P03=1
+#define set_P04                 P04=1
+#define set_P05                 P05=1
+#define set_P06                 P06=1
+#define set_P07                 P07=1
+                                
+#define clr_P00                 P00=0
+#define clr_P01                 P01=0
+#define clr_P02                 P02=0
+#define clr_P03                 P03=0
+#define clr_P04                 P04=0
+#define clr_P05                 P05=0
+#define clr_P06                 P06=0
+#define clr_P07                 P07=0
+
+/**** SP    81H ****/ 
+/**** DPH  82H ****/ 
+/**** DPL  83H ****/ 
+/**** RWK  86H ****/ 
+
+/**** PCON  87H ****/
+#define set_SMOD                PCON|=0x80
+#define set_SMOD0               PCON|=0x40
+#define set_POF                 PCON|=0x10
+#define set_GF1                 PCON|=0x08
+#define set_GF0                 PCON|=0x04 
+#define set_PD                  PCON|=0x02
+#define set_IDL                 PCON|=0x01
+                                    
+#define clr_SMOD                PCON&=0x7F
+#define clr_SMOD0               PCON&=0xBF
+#define clr_POF                 PCON&=0xEF
+#define clr_GF1                 PCON&=0xF7
+#define clr_GF0                 PCON&=0xFB 
+#define clr_PD                  PCON&=0xFD
+#define clr_IDL                 PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TF1                 TF1=1
+#define set_TR1                 TR1=1
+#define set_TF0                 TF0=1
+#define set_TR0                 TR0=1
+#define set_IE1                 IE1=1
+#define set_IT1                 IT1=1
+#define set_IE0                 IE0=1
+#define set_IT0                 IT0=1
+                                
+#define clr_TF1                 TF1=0
+#define clr_TR1                 TR1=0
+#define clr_TF0                 TF0=0
+#define clr_TR0                 TR0=0
+#define clr_IE1                 IE1=0
+#define clr_IT1                 IT1=0
+#define clr_IE0                 IE0=0
+#define clr_IT0                 IT0=0
+
+/**** TMOD    89H ****/ 
+#define set_GATE_T1             TMOD|=0x80
+#define set_CT_T1               TMOD|=0x40
+#define set_M1_T1               TMOD|=0x20
+#define set_M0_T1               TMOD|=0x10
+#define set_GATE_T0             TMOD|=0x08
+#define set_CT_T0               TMOD|=0x04
+#define set_M1_T0               TMOD|=0x02
+#define set_M0_T0               TMOD|=0x01
+                                    
+#define clr_GATE_T1             TMOD&=0x7F
+#define clr_CT_T1               TMOD&=0xBF
+#define clr_M1_T1               TMOD&=0xDF
+#define clr_M0_T1               TMOD&=0xEF
+#define clr_GATE_T0             TMOD&=0xF7
+#define clr_CT_T0               TMOD&=0xFB
+#define clr_M1_T0               TMOD&=0xFD
+#define clr_M0_T0               TMOD&=0xFE
+
+/**** TH1    8AH ****/ 
+/**** TH0    8BH ****/ 
+/**** TL1    8CH ****/
+/**** TL0    8DH ****/ 
+
+/**** CKCON  8EH ****/
+#define set_PWMCKS              CKCON|=0x40
+#define set_T1M                 CKCON|=0x10
+#define set_T0M                 CKCON|=0x08
+#define set_CLOEN               CKCON|=0x02
+                                     
+#define clr_PWMCKS              CKCON&=0xBF
+#define clr_T1M                 CKCON&=0xEF
+#define clr_T0M                 CKCON&=0xF7
+#define clr_CLOEN               CKCON&=0xFD
+
+/**** WKCON  8FH ****/
+#define set_WKTCK               WKCON|=0x20
+#define set_WKTF                WKCON|=0x10
+#define set_WKTR                WKCON|=0x08
+#define set_WKPS2               WKCON|=0x04
+#define set_WKPS1               WKCON|=0x02
+#define set_WKPS0               WKCON|=0x01
+                                     
+#define clr_WKTCK               WKCON&=0xDF
+#define clr_WKTF                WKCON&=0xEF
+#define clr_WKTR                WKCON&=0xF7
+#define clr_WKPS2               WKCON&=0xFB
+#define clr_WKPS1               WKCON&=0xFD
+#define clr_WKPS0               WKCON&=0xFE
+
+/**** P1    90H ****/
+#define set_P10                 P10=1
+#define set_P11                 P11=1
+#define set_P12                 P12=1
+#define set_P13                 P13=1
+#define set_P14                 P14=1
+#define set_P15                 P15=1
+#define set_P16                 P16=1
+#define set_P17                 P17=1
+                                
+#define clr_P10                 P10=0
+#define clr_P11                 P11=0
+#define clr_P12                 P12=0
+#define clr_P13                 P13=0
+#define clr_P14                 P14=0
+#define clr_P15                 P15=0
+#define clr_P16                 P16=0
+#define clr_P17                 P17=0
+
+/****SFRS    91H ****/
+#define set_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPEN2              CAPCON0|=0x40
+#define set_CAPEN1              CAPCON0|=0x20
+#define set_CAPEN0              CAPCON0|=0x10
+#define set_CAPF2               CAPCON0|=0x04
+#define set_CAPF1               CAPCON0|=0x02
+#define set_CAPF0               CAPCON0|=0x01
+                                
+#define clr_CAPEN2              CAPCON0&=0xBF
+#define clr_CAPEN1              CAPCON0&=0xDF
+#define clr_CAPEN0              CAPCON0&=0xEF
+#define clr_CAPF2               CAPCON0&=0xFB
+#define clr_CAPF1               CAPCON0&=0xFD
+#define clr_CAPF0               CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAP2LS1             CAPCON1|=0x20
+#define set_CAP2LS0             CAPCON1|=0x10
+#define set_CAP1LS1             CAPCON1|=0x08
+#define set_CAP1LS0             CAPCON1|=0x04
+#define set_CAP0LS1             CAPCON1|=0x02
+#define set_CAP0LS0             CAPCON1|=0x01
+                                
+#define clr_CAP2LS1             CAPCON1&=0xDF
+#define clr_CAP2LS0             CAPCON1&=0xEF
+#define clr_CAP1LS1             CAPCON1&=0xF7
+#define clr_CAP1LS0             CAPCON1&=0xFB
+#define clr_CAP0LS1             CAPCON1&=0xFD
+#define clr_CAP0LS0             CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_ENF2                CAPCON2|=0x40
+#define set_ENF1                CAPCON2|=0x20
+#define set_ENF0                CAPCON2|=0x10
+                                       
+#define clr_ENF2                CAPCON2&=0xBF
+#define clr_ENF1                CAPCON2&=0xDF
+#define clr_ENF0                CAPCON2&=0xEF
+
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H ****/
+#define set_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+                                
+#define clr_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/
+#define set_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+                                
+#define clr_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_FE                  FE    = 1
+#define set_SM1                 SM1   = 1
+#define set_SM2                 SM2   = 1
+#define set_REN                 REN   = 1
+#define set_TB8                 TB8   = 1
+#define set_RB8                 RB8   = 1
+#define set_TI                  TI    = 1
+#define set_RI                  RI    = 1
+                                
+#define clr_FE                  FE    = 0
+#define clr_SM1                 SM1   = 0
+#define clr_SM2                 SM2   = 0
+#define clr_REN                 REN   = 0
+#define clr_TB8                 TB8   = 0
+#define clr_RB8                 RB8   = 0
+#define clr_TI                  TI    = 0
+#define clr_RI                  RI    = 0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                      
+#define set_ET2                 EIE|=0x80
+#define set_ESPI                EIE|=0x40
+#define set_EFB                 EIE|=0x20
+#define set_EWDT                EIE|=0x10
+#define set_EPWM                EIE|=0x08
+#define set_ECAP                EIE|=0x04
+#define set_EPI                 EIE|=0x02
+#define set_EI2C                EIE|=0x01
+                                   
+#define clr_ET2                 EIE&=0x7F
+#define clr_ESPI                EIE&=0xBF
+#define clr_EFB                 EIE&=0xDF
+#define clr_EWDT                EIE&=0xEF
+#define clr_EPWM                EIE&=0xF7
+#define clr_ECAP                EIE&=0xFB
+#define clr_EPI                 EIE&=0xFD
+#define clr_EI2C                EIE&=0xFE
+
+/**** EIE1    9CH ****/                      
+#define set_EWKT                EIE1|=0x04
+#define set_ET3                 EIE1|=0x02
+#define set_ES_1                EIE1|=0x01
+                                    
+#define clr_EWKT                EIE1&=0xFB
+#define clr_ET3                 EIE1&=0xFD
+#define clr_ES_1                EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register ****/
+#define set_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                
+#define clr_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_SWRF                AUXR1|=0x80
+#define set_RSTPINF             AUXR1|=0x40
+#define set_HARDF               AUXR1|=0x20
+#define set_GF2                 AUXR1|=0x08
+#define set_UART0PX             AUXR1|=0x04
+#define set_DPS                 AUXR1|=0x01
+                                     
+#define clr_SWRF                AUXR1&=0x7F
+#define clr_RSTPINF             AUXR1&=0xBF
+#define clr_HARDF               AUXR1&=0xDF
+#define clr_GF2                 AUXR1&=0xF7
+#define clr_UART0PX             AUXR1&=0xFB
+#define clr_DPS                 AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                
+#define clr_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BOV2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPGO               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/
+#define set_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                
+#define clr_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_EA                  EA       = 1
+#define set_EADC                EADC     = 1
+#define set_EBOD                EBOD     = 1
+#define set_ES                  ES       = 1
+#define set_ET1                 ET1      = 1
+#define set_EX1                 EX1      = 1
+#define set_ET0                 ET0      = 1
+#define set_EX0                 EX0      = 1
+                                
+#define clr_EA                  EA       = 0
+#define clr_EADC                EADC     = 0
+#define clr_EBOD                EBOD     = 0
+#define clr_ES                  ES       = 0
+#define clr_ET1                 ET1      = 0
+#define clr_EX1                 EX1      = 0
+#define clr_ET0                 ET0      = 0
+#define clr_EX0                 EX0      = 0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WIDPD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                
+#define clr_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                
+#define clr_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** P3M1    ACH PAGE0 ****/
+#define set_P3M1_0              clr_SFRS_SFRPAGE;P3M1|=0x01
+#define clr_P3M1_0              clr_SFRS_SFRPAGE;P3M1&=0xFE
+
+/**** P3S    ACH PAGE1 ****/ 
+#define set_P3S_0               set_SFRS_SFRPAGE;P3S|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3S_0               set_SFRS_SFRPAGE;P3S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P3M2    ADH PAGE0 ****/
+#define set_P3M2_0              clr_SFRS_SFRPAGE;P3M2|=0x01
+#define clr_P3M2_0              clr_SFRS_SFRPAGE;P3M2&=0xFE
+
+/**** P3SR    ADH PAGE1 ****/ 
+#define set_P3SR_0              set_SFRS_SFRPAGE;P3SR|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3SR_0              set_SFRS_SFRPAGE;P3SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_FOEN                IAPN|=0x20
+#define set_FCEN                IAPN|=0x10
+#define set_FCTRL3              IAPN|=0x08
+#define set_FCTRL2              IAPN|=0x04
+#define set_FCTRL1              IAPN|=0x02
+#define set_FCTRL0              IAPN|=0x01
+                                      
+#define clr_FOEN                IAPN&=0xDF
+#define clr_FCEN                IAPN&=0xEF
+#define clr_FCTRL3              IAPN&=0xF7
+#define clr_FCTRL2              IAPN&=0xFB
+#define clr_FCTRL1              IAPN&=0xFD
+#define clr_FCTRL0              IAPN&=0xFE
+
+/**** P3    B0H ****/
+#define set_P30                 P30= 1
+#define clr_P30                 P30= 0
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7              clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6              clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5              clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4              clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3              clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2              clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1              clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0              clr_SFRS_SFRPAGE;P0M1|=0x01
+                                
+#define clr_P0M1_7              clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6              clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5              clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4              clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3              clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2              clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1              clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0              clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/ 
+#define set_P0S_7               set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6               set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5               set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4               set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3               set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2               set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1               set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0               set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7               set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6               set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5               set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4               set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3               set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2               set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1               set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0               set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7              clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6              clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5              clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4              clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3              clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2              clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1              clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0              clr_SFRS_SFRPAGE;P0M2|=0x01
+                                
+#define clr_P0M2_7              clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6              clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5              clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4              clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3              clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2              clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1              clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0              clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7              set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6              set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5              set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4              set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3              set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2              set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1              set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0              set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7              set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6              set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5              set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4              set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3              set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2              set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1              set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0              set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M1  B3H PAGE0 ****/
+#define set_P1M1_7              clr_SFRS_SFRPAGE;P1M1|=0x80
+#define set_P1M1_6              clr_SFRS_SFRPAGE;P1M1|=0x40
+#define set_P1M1_5              clr_SFRS_SFRPAGE;P1M1|=0x20 
+#define set_P1M1_4              clr_SFRS_SFRPAGE;P1M1|=0x10
+#define set_P1M1_3              clr_SFRS_SFRPAGE;P1M1|=0x08
+#define set_P1M1_2              clr_SFRS_SFRPAGE;P1M1|=0x04
+#define set_P1M1_1              clr_SFRS_SFRPAGE;P1M1|=0x02
+#define set_P1M1_0              clr_SFRS_SFRPAGE;P1M1|=0x01
+                                
+#define clr_P1M1_7              clr_SFRS_SFRPAGE;P1M1&=0x7F
+#define clr_P1M1_6              clr_SFRS_SFRPAGE;P1M1&=0xBF
+#define clr_P1M1_5              clr_SFRS_SFRPAGE;P1M1&=0xDF
+#define clr_P1M1_4              clr_SFRS_SFRPAGE;P1M1&=0xEF
+#define clr_P1M1_3              clr_SFRS_SFRPAGE;P1M1&=0xF7
+#define clr_P1M1_2              clr_SFRS_SFRPAGE;P1M1&=0xFB
+#define clr_P1M1_1              clr_SFRS_SFRPAGE;P1M1&=0xFD
+#define clr_P1M1_0              clr_SFRS_SFRPAGE;P1M1&=0xFE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7               set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6               set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5               set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4               set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3               set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2               set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1               set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0               set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+         
+#define clr_P1S_7               set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6               set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5               set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4               set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3               set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2               set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1               set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0               set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M2    B4H PAGE0 ****/                      
+#define set_P12UP               clr_SFRS_SFRPAGE;P1M2|=0x04
+#define set_P1M2_1              clr_SFRS_SFRPAGE;P1M2|=0x02
+#define set_P1M2_0              clr_SFRS_SFRPAGE;P1M2|=0x01
+                                    
+#define clr_P12UP               clr_SFRS_SFRPAGE;P1M2&=0xFB
+#define clr_P1M2_1              clr_SFRS_SFRPAGE;P1M2&=0xFD
+#define clr_P1M2_0              clr_SFRS_SFRPAGE;P1M2&=0xFE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7              set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6              set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5              set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4              set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3              set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2              set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1              set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0              set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                                            
+#define clr_P1SR_7              set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6              set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5              set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4              set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3              set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2              set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1              set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0              set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_0               P2S|= 0x01
+#define clr_P2S_0               P2S&= 0xFE
+
+/**** IPH    B7H PAGE0 ****/                    
+#define set_PADCH               clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_PBODH               clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_PSH                 clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_PT1H                clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_PX11                clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_PT0H                clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_PX0H                clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_PADCH               clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_PBODH               clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_PSH                 clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_PT1H                clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_PX11                clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_PT0H                clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_PX0H                clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/  
+#define set_INTTYP1             set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_INTTYP0             set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_INTSEL2             set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_INTSEL1             set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_INTSEL0             set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_INTTYP1             set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_INTTYP0             set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_INTSEL2             set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_INTSEL1             set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_INTSEL0             set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_PADC                PADC     = 1
+#define set_PBOD                PBOD     = 1
+#define set_PS                  PS       = 1
+#define set_PT1                 PT1      = 1
+#define set_PX1                 PX1      = 1
+#define set_PT0                 PT0      = 1
+#define set_PX0                 PX0      = 1
+                                
+#define clr_PADC                PADC     = 0
+#define clr_PBOD                PBOD     = 0
+#define clr_PS                  PS       = 0
+#define clr_PT1                 PT1      = 0
+#define clr_PX1                 PX1      = 0
+#define clr_PT0                 PT0      = 0
+#define clr_PX0                 PX0      = 0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOCEN             I2TOC|=0x04
+#define set_DIV                 I2TOC|=0x02
+#define set_I2TOF               I2TOC|=0x01
+                                
+#define clr_I2TOCEN             I2TOC&=0xFB
+#define clr_DIV                 I2TOC&=0xFD
+#define clr_I2TOF               I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CEN               I2CEN    = 1
+#define set_STA                 STA      = 1
+#define set_STO                 STO      = 1
+#define set_SI                  SI       = 1
+#define set_AA                  AA       = 1
+#define set_I2CPX               I2CPX    = 1
+
+#define clr_I2CEN               I2CEN    = 0
+#define clr_STA                 STA      = 0
+#define clr_STO                 STO      = 0
+#define clr_SI                  SI       = 0
+#define clr_AA                  AA       = 0
+#define clr_I2CPX               I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_GC                  I2ADDR|=0x01
+#define clr_GC                  I2ADDR&=0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_SMOD_1              clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_SMOD0_1             clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_BRCK                clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_TF3                 clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_TR3                 clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3PS2               clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3PS1               clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3PS0               clr_SFRS_SFRPAGE;T3CON|=0x01
+                                     
+#define clr_SMOD_1              clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_SMOD0_1             clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_BRCK                clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_TF3                 clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_TR3                 clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3PS2               clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3PS1               clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3PS0               clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIO15               set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIO13               set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIO12               set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIO11               set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIO15               set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIO13               set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIO12               set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIO11               set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_TF2                 TF2      = 1
+#define set_TR2                 TR2      = 1
+#define set_CMRL2               CM_RL2   = 1
+                                
+#define clr_TF2                 TF2      = 0
+#define clr_TR2                 TR2      = 0
+#define clr_CMRL2               CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_LDEN                T2MOD|=0x80
+#define set_T2DIV2              T2MOD|=0x40
+#define set_T2DIV1              T2MOD|=0x20
+#define set_T2DIV0              T2MOD|=0x10
+#define set_CAPCR               T2MOD|=0x08
+#define set_CMPCR               T2MOD|=0x04
+#define set_LDTS1               T2MOD|=0x02
+#define set_LDTS0               T2MOD|=0x01
+                                     
+#define clr_LDEN                T2MOD&=0x7F
+#define clr_T2DIV2              T2MOD&=0xBF
+#define clr_T2DIV1              T2MOD&=0xDF
+#define clr_T2DIV0              T2MOD&=0xEF
+#define clr_CAPCR               T2MOD&=0xF7
+#define clr_CMPCR               T2MOD&=0xFB
+#define clr_LDTS1               T2MOD&=0xFD
+#define clr_LDTS0               T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L   CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_CY                   CY  = 1
+#define set_AC                   AC  = 1
+#define set_F0                   F0  = 1 
+#define set_RS1                  RS1 = 1
+#define set_RS0                  RS0 = 1
+#define set_OV                   OV  = 1
+#define set_P                    P   = 1
+                                 
+#define clr_CY                   CY  = 0
+#define clr_AC                   AC  = 0
+#define clr_F0                   F0  = 0 
+#define clr_RS1                  RS1 = 0
+#define clr_RS0                  RS0 = 0
+#define clr_OV                   OV  = 0
+#define clr_P                    P   = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** PNP      D6H ****/
+#define set_PNP5                 PNP|=0x20
+#define set_PNP4                 PNP|=0x10
+#define set_PNP3                 PNP|=0x08
+#define set_PNP2                 PNP|=0x04
+#define set_PNP1                 PNP|=0x02
+#define set_PNP0                 PNP|=0x01
+                                 
+#define clr_PNP5                 PNP&=0xDF
+#define clr_PNP4                 PNP&=0xEF
+#define clr_PNP3                 PNP&=0xF7
+#define clr_PNP2                 PNP&=0xFB
+#define clr_PNP1                 PNP&=0xFD
+#define clr_PNP0                 PNP&=0xFE
+
+/**** FBD    D7H ****/
+#define set_FBF                  FBD|=0x80
+#define set_FBINLS               FBD|=0x40
+#define set_FBD5                 FBD|=0x20
+#define set_FBD4                 FBD|=0x10
+#define set_FBD3                 FBD|=0x08
+#define set_FBD2                 FBD|=0x04
+#define set_FBD1                 FBD|=0x02
+#define set_FBD0                 FBD|=0x01
+                                 
+#define clr_FBF                  FBD&=0x7F
+#define clr_FBINLS               FBD&=0xBF
+#define clr_FBD5                 FBD&=0xDF
+#define clr_FBD4                 FBD&=0xEF
+#define clr_FBD3                 FBD&=0xF7
+#define clr_FBD2                 FBD&=0xFB
+#define clr_FBD1                 FBD&=0xFD
+#define clr_FBD0                 FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMRUN               PWMRUN   = 1
+#define set_LOAD                 LOAD     = 1
+#define set_PWMF                 PWMF     = 1
+#define set_CLRPWM               CLRPWM   = 1
+                                 
+#define clr_PWMRUN               PWMRUN   = 0
+#define clr_LOAD                 LOAD     = 0
+#define clr_PWMF                 PWMF     = 0 
+#define clr_CLRPWM               CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIO05                PIOCON0|=0x20
+#define set_PIO04                PIOCON0|=0x10
+#define set_PIO03                PIOCON0|=0x08
+#define set_PIO02                PIOCON0|=0x04
+#define set_PIO01                PIOCON0|=0x02
+#define set_PIO00                PIOCON0|=0x01
+                                 
+#define clr_PIO05                PIOCON0&=0xDF
+#define clr_PIO04                PIOCON0&=0xEF
+#define clr_PIO03                PIOCON0&=0xF7
+#define clr_PIO02                PIOCON0&=0xFB
+#define clr_PIO01                PIOCON0&=0xFD
+#define clr_PIO00                PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMMOD1              PWMCON1|=0x80
+#define set_PWMMOD0              PWMCON1|=0x40
+#define set_GP                   PWMCON1|=0x20
+#define set_PWMTYP               PWMCON1|=0x10
+#define set_FBINEN               PWMCON1|=0x08
+#define set_PWMDIV2              PWMCON1|=0x04 
+#define set_PWMDIV1              PWMCON1|=0x02
+#define set_PWMDIV0              PWMCON1|=0x01
+                                      
+#define clr_PWMMOD1              PWMCON1&=0x7F
+#define clr_PWMMOD0              PWMCON1&=0xBF
+#define clr_GP                   PWMCON1&=0xDF
+#define clr_PWMTYP               PWMCON1&=0xEF
+#define clr_FBINEN               PWMCON1&=0xF7
+#define clr_PWMDIV2              PWMCON1&=0xFB 
+#define clr_PWMDIV1              PWMCON1&=0xFD
+#define clr_PWMDIV0              PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_STADCPX              ADCCON1|=0x40
+#define set_ETGTYP1              ADCCON1|=0x08
+#define set_ETGTYP0              ADCCON1|=0x04
+#define set_ADCEX                ADCCON1|=0x02
+#define set_ADCEN                ADCCON1|=0x01
+                                 
+#define clr_STADCPX              ADCCON1&=0xBF
+#define clr_ETGTYP1              ADCCON1&=0xF7
+#define clr_ETGTYP0              ADCCON1&=0xFB
+#define clr_ADCEX                ADCCON1&=0xFD
+#define clr_ADCEN                ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/
+#define set_ADFBEN               ADCCON2|=0x80
+#define set_ADCMPOP              ADCCON2|=0x40
+#define set_ADCMPEN              ADCCON2|=0x20
+#define set_ADCMPO               ADCCON2|=0x10
+                                 
+#define clr_ADFBEN               ADCCON2&=0x7F
+#define clr_ADCMPOP              ADCCON2&=0xBF
+#define clr_ADCMPEN              ADCCON2&=0xDF
+#define clr_ADCMPO               ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 1
+#define set_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 1
+#define set_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 1
+#define set_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 1
+#define set_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 1
+#define set_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 1
+#define set_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 1
+#define set_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 1
+                                 
+#define clr_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 0
+#define clr_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 0
+#define clr_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 0
+#define clr_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 0
+#define clr_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 0
+#define clr_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 0
+#define clr_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 0
+#define clr_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 0
+
+/**** PICON  E9H ****/
+#define set_PIT67                PICON|=0x80
+#define set_PIT45                PICON|=0x40
+#define set_PIT3                 PICON|=0x20
+#define set_PIT2                 PICON|=0x10
+#define set_PIT1                 PICON|=0x08
+#define set_PIT0                 PICON|=0x04
+#define set_PIPS1                PICON|=0x02
+#define set_PIPS0                PICON|=0x01
+                                      
+#define clr_PIT67                PICON&=0x7F
+#define clr_PIT45                PICON&=0xBF
+#define clr_PIT3                 PICON&=0xDF
+#define clr_PIT2                 PICON&=0xEF
+#define clr_PIT1                 PICON&=0xF7
+#define clr_PIT0                 PICON&=0xFB
+#define clr_PIPS1                PICON&=0xFD
+#define clr_PIPS0                PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN7               PINEN|=0x80
+#define set_PINEN6               PINEN|=0x40
+#define set_PINEN5               PINEN|=0x20
+#define set_PINEN4               PINEN|=0x10
+#define set_PINEN3               PINEN|=0x08
+#define set_PINEN2               PINEN|=0x04
+#define set_PINEN1               PINEN|=0x02
+#define set_PINEN0               PINEN|=0x01
+                                      
+#define clr_PINEN7               PINEN&=0x7F
+#define clr_PINEN6               PINEN&=0xBF
+#define clr_PINEN5               PINEN&=0xDF
+#define clr_PINEN4               PINEN&=0xEF
+#define clr_PINEN3               PINEN&=0xF7
+#define clr_PINEN2               PINEN&=0xFB
+#define clr_PINEN1               PINEN&=0xFD
+#define clr_PINEN0               PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN7               PIPEN|=0x80
+#define set_PIPEN6               PIPEN|=0x40
+#define set_PIPEN5               PIPEN|=0x20
+#define set_PIPEN4               PIPEN|=0x10
+#define set_PIPEN3               PIPEN|=0x08
+#define set_PIPEN2               PIPEN|=0x04
+#define set_PIPEN1               PIPEN|=0x02
+#define set_PIPEN0               PIPEN|=0x01
+                                      
+#define clr_PIPEN7               PIPEN&=0x7F
+#define clr_PIPEN6               PIPEN&=0xBF
+#define clr_PIPEN5               PIPEN&=0xDF
+#define clr_PIPEN4               PIPEN&=0xEF
+#define clr_PIPEN3               PIPEN&=0xF7
+#define clr_PIPEN2               PIPEN&=0xFB
+#define clr_PIPEN1               PIPEN&=0xFD
+#define clr_PIPEN0               PIPEN&=0xFE
+   
+/**** PIF  ECH ****/
+#define set_PIF7                 PIF|=0x80
+#define set_PIF6                 PIF|=0x40
+#define set_PIF5                 PIF|=0x20
+#define set_PIF4                 PIF|=0x10
+#define set_PIF3                 PIF|=0x08
+#define set_PIF2                 PIF|=0x04
+#define set_PIF1                 PIF|=0x02
+#define set_PIF0                 PIF|=0x01
+                                 
+#define clr_PIF7                 PIF&=0x7F
+#define clr_PIF6                 PIF&=0xBF
+#define clr_PIF5                 PIF&=0xDF
+#define clr_PIF4                 PIF&=0xEF
+#define clr_PIF3                 PIF&=0xF7
+#define clr_PIF2                 PIF&=0xFB
+#define clr_PIF1                 PIF&=0xFD
+#define clr_PIF0                 PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_PT2                  clr_SFRS_SFRPAGE;EIP|=0x80
+#define set_PSPI                 clr_SFRS_SFRPAGE;EIP|=0x40
+#define set_PFB                  clr_SFRS_SFRPAGE;EIP|=0x20
+#define set_PWDT                 clr_SFRS_SFRPAGE;EIP|=0x10
+#define set_PPWM                 clr_SFRS_SFRPAGE;EIP|=0x08
+#define set_PCAP                 clr_SFRS_SFRPAGE;EIP|=0x04
+#define set_PPI                  clr_SFRS_SFRPAGE;EIP|=0x02
+#define set_PI2C                 clr_SFRS_SFRPAGE;EIP|=0x01
+                                    
+#define clr_PT2                  clr_SFRS_SFRPAGE;EIP&=0x7F
+#define clr_PSPI                 clr_SFRS_SFRPAGE;EIP&=0xBF
+#define clr_PFB                  clr_SFRS_SFRPAGE;EIP&=0xDF
+#define clr_PWDT                 clr_SFRS_SFRPAGE;EIP&=0xEF
+#define clr_PPWM                 clr_SFRS_SFRPAGE;EIP&=0xF7
+#define clr_PCAP                 clr_SFRS_SFRPAGE;EIP&=0xFB
+#define clr_PPI                  clr_SFRS_SFRPAGE;EIP&=0xFD
+#define clr_PI2C                 clr_SFRS_SFRPAGE;EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAP13                CAPCON3|=0x80
+#define set_CAP12                CAPCON3|=0x40
+#define set_CAP11                CAPCON3|=0x20
+#define set_CAP10                CAPCON3|=0x10
+#define set_CAP03                CAPCON3|=0x08
+#define set_CAP02                CAPCON3|=0x04
+#define set_CAP01                CAPCON3|=0x02
+#define set_CAP00                CAPCON3|=0x01
+                                 
+#define clr_CAP13                CAPCON3&=0x7F
+#define clr_CAP12                CAPCON3&=0xBF
+#define clr_CAP11                CAPCON3&=0xDF
+#define clr_CAP10                CAPCON3&=0xEF
+#define clr_CAP03                CAPCON3&=0xF7
+#define clr_CAP02                CAPCON3&=0xFB
+#define clr_CAP01                CAPCON3&=0xFD
+#define clr_CAP00                CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAP23                CAPCON4|=0x08
+#define set_CAP22                CAPCON4|=0x04
+#define set_CAP21                CAPCON4|=0x02
+#define set_CAP20                CAPCON4|=0x01
+                                 
+#define clr_CAP23                CAPCON4&=0xF7
+#define clr_CAP22                CAPCON4&=0xFB
+#define clr_CAP21                CAPCON4&=0xFD
+#define clr_CAP20                CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SSOE                 clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPIEN                clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_LSBFE                clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_MSTR                 clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_CPOL                 clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_CPHA                 clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPR1                 clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPR0                 clr_SFRS_SFRPAGE;SPCR|=0x01
+                                 
+#define clr_SSOE                 clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPIEN                clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_LSBFE                clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_MSTR                 clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_CPOL                 clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_CPHA                 clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPR1                 clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPR0                 clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPIS1                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPIS0                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPIS1                set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPIS0                set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPIF                 SPSR|=0x80
+#define set_WCOL                 SPSR|=0x40
+#define set_SPIOVF               SPSR|=0x20
+#define set_MODF                 SPSR|=0x10
+#define set_DISMODF              SPSR|=0x08
+                                     
+#define clr_SPIF                 SPSR&=0x7F
+#define clr_WCOL                 SPSR&=0xBF
+#define clr_SPIOVF               SPSR&=0xDF
+#define clr_MODF                 SPSR&=0xEF
+#define clr_DISMODF              SPSR&=0xF7
+
+/**** SPDR    F5H ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                 
+#define clr_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_PT2H                 clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_PSPIH                clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_PFBH                 clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_PWDTH                clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_PPWMH                clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_PCAPH                clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_PPIH                 clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_PI2CH                clr_SFRS_SFRPAGE;EIPH|=0x01
+                                     
+#define clr_PT2H                 clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_PSPIH                clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_PFBH                 clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_PWDTH                clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_PPWMH                clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_PCAPH                clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_PPIH                 clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_PI2CH                clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_FE_1                 FE_1  = 1
+#define set_SM1_1                SM1_1 = 1
+#define set_SM2_1                SM2_1 = 1
+#define set_REN_1                REN_1 = 1
+#define set_TB8_1                TB8_1 = 1
+#define set_RB8_1                RB8_1 = 1
+#define set_TI_1                 TI_1  = 1
+#define set_RI_1                 RI_1  = 1
+                                 
+#define clr_FE_1                 FE_1  = 0
+#define clr_SM1_1                SM1_1 = 0
+#define clr_SM2_1                SM2_1 = 0
+#define clr_REN_1                REN_1 = 0
+#define clr_TB8_1                TB8_1 = 0
+#define clr_RB8_1                RB8_1 = 0
+#define clr_TI_1                 TI_1  = 0
+#define clr_RI_1                 RI_1  = 0
+
+/**** PDTEN    F9H ****TA Protect ***/
+#define set_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN5                PMEN|=0x20
+#define set_PMEN4                PMEN|=0x10
+#define set_PMEN3                PMEN|=0x08
+#define set_PMEN2                PMEN|=0x04
+#define set_PMEN1                PMEN|=0x02
+#define set_PMEN0                PMEN|=0x01
+                                     
+#define clr_PMEN5                PMEN&=0xDF
+#define clr_PMEN4                PMEN&=0xEF
+#define clr_PMEN3                PMEN&=0xF7
+#define clr_PMEN2                PMEN&=0xFB
+#define clr_PMEN1                PMEN&=0xFD
+#define clr_PMEN0                PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD7                 PMD|=0x80
+#define set_PMD6                 PMD|=0x40
+#define set_PMD5                 PMD|=0x20
+#define set_PMD4                 PMD|=0x10
+#define set_PMD3                 PMD|=0x08
+#define set_PMD2                 PMD|=0x04
+#define set_PMD1                 PMD|=0x02
+#define set_PMD0                 PMD|=0x01
+                                    
+#define clr_PMD7                 PMD&=0x7F
+#define clr_PMD6                 PMD&=0xBF
+#define clr_PMD5                 PMD&=0xDF
+#define clr_PMD4                 PMD&=0xEF
+#define clr_PMD3                 PMD&=0xF7
+#define clr_PMD2                 PMD&=0xFB
+#define clr_PMD1                 PMD&=0xFD
+#define clr_PMD0                 PMD&=0xFE
+
+/****  PORDIS   FDH PAGE0 ****/
+/****  EIP1     FEH PAGE0 ****/                     
+#define set_PWKT                 clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_PT3                  clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_PS_1                 clr_SFRS_SFRPAGE;EIP1|=0x01
+                                     
+#define clr_PWKT                 clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_PT3                  clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_PS_1                 clr_SFRS_SFRPAGE;EIP1&=0xFE
+                                 
+/**** EIPH1    FFH PAGE0 ****/                
+#define set_PWKTH                clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_PT3H                 clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_PSH_1                clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                      
+#define clr_PWKTH                clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_PT3H                 clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_PSH_1                clr_SFRS_SFRPAGE;EIPH1&=0xFE

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/function_define_n76s003.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/function_define_n76s003.h
@@ -1,0 +1,846 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  function_define_N76S003.h                                                      */
+/*  All IP function define for Nuvoton                                                  */
+/*  MG51FB9AE / MG51XB9AE / MG51FC9AE / MG51XC9AE /                                     */
+/*--------------------------------------------------------------------------------------*/
+
+#ifdef __CDT_PARSER__         /* For __SDCC__ */
+  #define __data
+  #define __near
+  #define __idata
+  #define __xdata
+  #define __far
+  #define __pdata
+  #define __code
+  #define __bit
+  #define __sfr
+  #define __sbit
+  #define __critical
+  #define __at(x)             /* use "__at (0xab)" instead of "__at 0xab" */
+  #define __using(x)
+  #define __interrupt(x)
+  #define __naked
+#endif
+
+typedef unsigned char         UINT8;
+typedef unsigned int          UINT16;
+typedef unsigned long         UINT32;
+typedef signed char           INT8;
+typedef signed int            INT16;
+typedef signed long           INT32;
+
+#if defined __C51__
+typedef bit                   BIT;
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __ICC8051__
+#define BIT __no_init bool __bit
+typedef unsigned char         uint8_t;
+typedef unsigned int          uint16_t;
+typedef unsigned long         uint32_t;
+typedef signed char           int8_t;
+typedef signed int            int16_t;
+typedef signed long           int32_t;
+#elif defined __SDCC__
+typedef __bit                 BIT;
+#endif
+
+#define Disable  0
+#define Enable   1
+
+#define DISABLE  0
+#define ENABLE   1 
+
+#define TRUE     1  
+#define FALSE    0  
+                    
+#define FAIL     1  
+#define PASS     0  
+                  
+//16 --> 8 x 2
+#define HIBYTE(v1)              ((UINT8)((v1)>>8))                      //v1 is UINT16
+#define LOBYTE(v1)              ((UINT8)((v1)&0xFF))
+//8 x 2 --> 16
+#define MAKEWORD(v1,v2)         ((((UINT16)(v1))<<8)+(UINT16)(v2))      //v1,v2 is UINT8
+//8 x 4 --> 32
+#define MAKELONG(v1,v2,v3,v4)   (UINT32)((v1<<32)+(v2<<16)+(v3<<8)+v4)  //v1,v2,v3,v4 is UINT8
+//32 --> 16 x 2
+#define YBYTE1(v1)              ((UINT16)((v1)>>16))                    //v1 is UINT32
+#define YBYTE0(v1)              ((UINT16)((v1)&0xFFFF))
+//32 --> 8 x 4
+#define TBYTE3(v1)              ((UINT8)((v1)>>24))                     //v1 is UINT32
+#define TBYTE2(v1)              ((UINT8)((v1)>>16))
+#define TBYTE1(v1)              ((UINT8)((v1)>>8)) 
+#define TBYTE0(v1)              ((UINT8)((v1)&0xFF))
+
+#define SET_BIT0        0x01
+#define SET_BIT1        0x02
+#define SET_BIT2        0x04
+#define SET_BIT3        0x08
+#define SET_BIT4        0x10
+#define SET_BIT5        0x20
+#define SET_BIT6        0x40
+#define SET_BIT7        0x80
+
+#define CLR_BIT0        0xFE
+#define CLR_BIT1        0xFD
+#define CLR_BIT2        0xFB
+#define CLR_BIT3        0xF7
+#define CLR_BIT4        0xEF
+#define CLR_BIT5        0xDF
+#define CLR_BIT6        0xBF
+#define CLR_BIT7        0x7F
+
+/*****************************************************************************/
+/*   Stack and NOP                                                           */
+/*****************************************************************************/
+#if defined __C51__
+#define   nop                                  _nop_()
+#define   CALL_NOP                             _nop_()
+#define   PUSH_SFRS                            _push_(SFRS)
+#define   POP_SFRS                             _pop_(SFRS)
+#elif defined __ICC8051__
+#define _nop_()                                asm("nop") 
+#define nop                                    asm("nop")
+#define CALL_NOP                               asm("nop")
+#define PUSH_SFRS                              asm(" PUSH 0x91")
+#define POP_SFRS                               asm(" POP 0x91")
+#define _push_(SFRS)                           asm(" PUSH 0x91")
+#define _pop_(SFRS)                            asm(" POP 0x91")
+#elif defined __SDCC__
+#define _nop_()                                __asm__("nop;")
+#define nop                                    __asm__("nop;")
+#define CALL_NOP                               __asm__("nop;")
+#define PUSH_SFRS                              __asm__(" PUSH 0x91;")
+#define POP_SFRS                               __asm__(" POP 0x91;")
+#define _push_(SFRS)                           __asm__(" PUSH 0x91;")
+#define _pop_(SFRS)                            __asm__(" POP 0x91;")
+#endif
+
+/*****************************************************************************/
+/*   sfr page select                                                          */
+/*****************************************************************************/
+#define    ENABLE_SFR_PAGE1                    set_SFRS_SFRPAGE
+#define    ENABLE_SFR_PAGE0                    clr_SFRS_SFRPAGE
+
+/*****************************************************************************/
+/*   Software reset                                                          */
+/*****************************************************************************/
+#define    ENABLE_SOFTWARE_RESET_TO_APROM      clr_CHPCON_BS;set_CHPCON_SWRST
+#define    ENABLE_SOFTWARE_RESET_TO_LDROM      set_CHPCON_BS;set_CHPCON_SWRST
+
+/*****************************************************************************/
+/*   Power down / idle mode define                                           */
+/*****************************************************************************/
+#define    ENABLE_POWERDOWN_MODE               set_PCON_PD
+#define    ENABLE_IDLE_MODE                    set_PCON_IDLE
+
+/*****************************************************************************/
+/*   BOD Define                                                              */
+/*****************************************************************************/
+#define    BOD_ENABLE               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    BOD_RESET_ENABLE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    BOD_DISABLE              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+ /****/
+#define    ENABLE_BOD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define    ENABLE_BOD_RESET         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0|=0x84;EA=BIT_TMP
+#define    DISABLE_BOD              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;TA=0xAA;TA=0x55;BODCON0&=0x7B;EA=BIT_TMP
+
+/*****************************************************************************/
+/*    IAP function process                                                   */ 
+/*****************************************************************************/
+#define    PAGE_SIZE               128
+
+#define    READ_CID                0x0B
+#define    READ_DID                0x0C
+#define    READ_UID                0x04
+
+#define    PAGE_ERASE_APROM        0x22
+#define    BYTE_READ_APROM         0x00
+#define    BYTE_PROGRAM_APROM      0x21
+
+#define    PAGE_ERASE_LDROM        0x62
+#define    BYTE_READ_LDROM         0x40
+#define    BYTE_PROGRAM_LDROM      0x61
+
+#define    ENABLE_SPROM            set_IAPUEN_SPMEN
+#define    PAGE_ERASE_SPROM        0xA2
+#define    BYTE_READ_SPROM         0x80
+#define    BYTE_PROGRAM_SPROM      0xA1
+
+#define    PAGE_ERASE_CONFIG       0xE2
+#define    BYTE_READ_CONFIG        0xC0
+#define    BYTE_PROGRAM_CONFIG     0xE1
+
+#define    CID_READ                0x0B
+#define    DID_READ                0x0C
+
+/*****************************************************************************/
+/*    interrupt function process                                             */ 
+/*****************************************************************************/
+#define    ENABLE_GLOBAL_INTERRUPT       set_IE_EA
+#define    DISABLE_GLOBAL_INTERRUPT      clr_IE_EA
+
+/*Enable Interrupt*/
+#define    ENABLE_ADC_INTERRUPT          set_IE_EADC
+#define    ENABLE_BOD_INTERRUPT          set_IE_EBOD
+#define    ENABLE_UART0_INTERRUPT        set_IE_ES
+#define    ENABLE_TIMER1_INTERRUPT       set_IE_ET1
+#define    ENABLE_INT1_INTERRUPT         set_IE_EX1
+#define    ENABLE_TIMER0_INTERRUPT       set_IE_ET0
+#define    ENABLE_INT0_INTERRUPT         set_IE_EX0
+
+#define    ENABLE_TIMER2_INTERRUPT       set_EIE_ET2
+#define    ENABLE_SPI0_INTERRUPT         set_EIE_ESPI
+#define    ENABLE_PWM0_FB_INTERRUPT      set_EIE_EFB0
+#define    ENABLE_WDT_INTERRUPT          set_EIE_EWDT
+#define    ENABLE_PWM0_INTERRUPT         set_EIE_EPWM
+#define    ENABLE_CAPTURE_INTERRUPT      set_EIE_ECAP
+#define    ENABLE_PIN_INTERRUPT          set_EIE_EPI
+#define    ENABLE_I2C_INTERRUPT          set_EIE_EI2C
+
+#define    ENABLE_WKT_INTERRUPT          set_EIE1_EWKT
+#define    ENABLE_TIMER3_INTERRUPT       set_EIE1_ET3
+#define    ENABLE_UART1_INTERRUPT        set_EIE1_ES_1
+
+/*Disable Interrupt*/ 
+#define    DISABLE_ADC_INTERRUPT         clr_IE_EADC
+#define    DISABLE_BOD_INTERRUPT         clr_IE_EBOD
+#define    DISABLE_UART0_INTERRUPT       clr_IE_ES
+#define    DISABLE_TIMER1_INTERRUPT      clr_IE_ET1
+#define    DISABLE_INT1_INTERRUPT        clr_IE_EX1
+#define    DISABLE_TIMER0_INTERRUPT      clr_IE_ET0
+#define    DISABLE_INT0_INTERRUPT        clr_IE_EX0
+
+#define    DISABLE_TIMER2_INTERRUPT      clr_EIE_ET2
+#define    DISABLE_SPI0_INTERRUPT        clr_EIE_ESPI
+#define    DISABLE_PWM0_FB_INTERRUPT     clr_EIE_EFB0
+#define    DISABLE_WDT_INTERRUPT         clr_EIE_EWDT
+#define    DISABLE_PWM0_INTERRUPT        clr_EIE_EPWM
+#define    DISABLE_CAPTURE_INTERRUPT     clr_EIE_ECAP
+#define    DISABLE_PIN_INTERRUPT         clr_EIE_EPI
+#define    DISABLE_I2C_INTERRUPT         clr_EIE_EI2C
+
+#define    DISABLE_WKT_INTERRUPT         clr_EIE1_EWKT
+#define    DISABLE_TIMER3_INTERRUPT      clr_EIE1_ET3
+#define    DISABLE_UART1_INTERRUPT       clr_EIE1_ES_1
+
+/* Setting Interrupt Priority */
+#define   SET_INT_INT0_LEVEL0          clr_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL1          clr_IP_PX0; set_IPH_PX0H
+#define   SET_INT_INT0_LEVEL2          set_IP_PX0; clr_IPH_PX0H
+#define   SET_INT_INT0_LEVEL3          set_IP_PX0; set_IPH_PX0H
+
+#define   SET_INT_BOD_LEVEL0           clr_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL1           clr_IP_PBOD; set_IPH_PBODH
+#define   SET_INT_BOD_LEVEL2           set_IP_PBOD; clr_IPH_PBODH
+#define   SET_INT_BOD_LEVEL3           set_IP_PBOD; set_IPH_PBODH
+
+#define   SET_INT_WDT_LEVEL0           clr_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL1           clr_EIP_PWDT; set_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL2           set_EIP_PWDT; clr_EIPH_PWDTH
+#define   SET_INT_WDT_LEVEL3           set_EIP_PWDT; set_EIPH_PWDTH
+
+#define   SET_INT_TIMER0_LEVEL0        clr_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL1        clr_IP_PT0; set_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL2        set_IP_PT0; clr_IPH_PT0H
+#define   SET_INT_TIMER0_LEVEL3        set_IP_PT0; set_IPH_PT0H
+
+#define   SET_INT_I2C0_LEVEL0          clr_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL1          clr_EIP_PI2C; set_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL2          set_EIP_PI2C; clr_EIPH_PI2CH
+#define   SET_INT_I2C0_LEVEL3          set_EIP_PI2C; set_EIPH_PI2CH
+
+#define   SET_INT_ADC_LEVEL0           clr_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL1           clr_IP_PADC; set_IPH_PADCH
+#define   SET_INT_ADC_LEVEL2           set_IP_PADC; clr_IPH_PADCH
+#define   SET_INT_ADC_LEVEL3           set_IP_PADC; set_IPH_PADCH
+
+#define   SET_INT_INT1_LEVEL0          clr_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL1          clr_IP_PX1; set_IPH_PX1H
+#define   SET_INT_INT1_LEVEL2          set_IP_PX1; clr_IPH_PX1H
+#define   SET_INT_INT1_LEVEL3          set_IP_PX1; set_IPH_PX1H
+
+#define   SET_INT_PIT_LEVEL0           clr_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL1           clr_EIP_PPI; set_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL2           set_EIP_PPI; clr_EIPH_PPIH
+#define   SET_INT_PIT_LEVEL3           set_EIP_PPI; set_EIPH_PPIH
+
+#define   SET_INT_Timer1_LEVEL0        clr_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL1        clr_IP_PT1; set_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL2        set_IP_PT1; clr_IPH_PT1H
+#define   SET_INT_Timer1_LEVEL3        set_IP_PT1; set_IPH_PT1H
+
+#define   SET_INT_UART0_LEVEL0         clr_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL1         clr_IP_PS; set_IPH_PSH
+#define   SET_INT_UART0_LEVEL2         set_IP_PS; clr_IPH_PSH
+#define   SET_INT_UART0_LEVEL3         set_IP_PS; set_IPH_PSH
+
+#define   SET_INT_PWM0_BRAKE_LEVEL0    clr_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL1    clr_EIP_PFB; set_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL2    set_EIP_PFB; clr_EIPH_PFBH
+#define   SET_INT_PWM0_BRAKE_LEVEL3    set_EIP_PFB; set_EIPH_PFBH
+
+#define   SET_INT_SPI_LEVEL0           clr_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL1           clr_EIP_PSPI; set_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL2           set_EIP_PSPI; clr_EIPH_PSPIH
+#define   SET_INT_SPI_LEVEL3           set_EIP_PSPI; set_EIPH_PSPIH
+
+#define   SET_INT_Timer2_LEVEL0        clr_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL1        clr_EIP_PT2; set_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL2        set_EIP_PT2; clr_EIPH_PT2H
+#define   SET_INT_Timer2_LEVEL3        set_EIP_PT2; set_EIPH_PT2H
+
+#define   SET_INT_CAPTURE_LEVEL0       clr_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL1       clr_EIP_PCAP; set_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL2       set_EIP_PCAP; clr_EIPH_PCAPH
+#define   SET_INT_CAPTURE_LEVEL3       set_EIP_PCAP; set_EIPH_PCAPH
+
+#define   SET_INT_PWM_LEVEL0           clr_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL1           clr_EIP_PPWM; set_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL2           set_EIP_PPWM; clr_EIPH_PPWMH
+#define   SET_INT_PWM_LEVEL3           set_EIP_PPWM; set_EIPH_PPWMH
+
+#define   SET_INT_UART1_LEVEL0         clr_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL1         clr_EIP1_PS_1; set_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL2         set_EIP1_PS_1; clr_EIPH1_PSH_1
+#define   SET_INT_UART1_LEVEL3         set_EIP1_PS_1; set_EIPH1_PSH_1
+
+#define   SET_INT_Timer3_LEVEL0        clr_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL1        clr_EIP1_PT3; set_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL2        set_EIP1_PT3; clr_EIPH1_PT3H
+#define   SET_INT_Timer3_LEVEL3        set_EIP1_PT3; set_EIPH1_PT3H
+
+#define   SET_INT_WKT_LEVEL0           clr_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL1           clr_EIP1_PWKT; set_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL2           set_EIP1_PWKT; clr_EIPH1_PWKTH
+#define   SET_INT_WKT_LEVEL3           set_EIP1_PWKT; set_EIPH1_PWKTH
+
+/* Clear Interrupt Flag */
+#define    CLEAR_ADC_INTERRUPT_FLAG          clr_ADCCON0_ADCF
+#define    CLEAR_BOD_INTERRUPT_FLAG          clr_BODCON0_BOF
+#define    CLEAR_BOD_RESET_FLAG              clr_BODCON0_BORF
+#define    CLEAR_UART0_INTERRUPT_TX_FLAG     clr_SCON_TI
+#define    CLEAR_UART0_INTERRUPT_RX_FLAG     clr_SCON_RI
+#define    CLEAR_TIMER1_INTERRUPT_FLAG       clr_TCON_TF1
+#define    CLEAR_INT1_INTERRUPT_FLAG         clr_TCON_IE1
+#define    CLEAR_TIMER0_INTERRUPT_FLAG       clr_TCON_TF0
+#define    CLEAR_INT0_INTERRUPT_FLAG         clr_TCON_IE0
+#define    CLEAR_TIMER2_INTERRUPT_FLAG       clr_T2CON_TF2
+#define    CLEAR_SPI0_INTERRUPT_FLAG         clr_SPSR_SPIF
+#define    CLEAR_PWM0_FB_INTERRUPT_FLAG      clr_PWM0FBD_FBF
+#define    CLEAR_WDT_INTERRUPT_FLAG          clr_WDCON_WDTF
+#define    CLEAR_PWM0_INTERRUPT_FLAG         clr_PWM1CON0_PWMF
+#define    CLEAR_CAPTURE_INTERRUPT_IC0_FLAG  clr_CAPCON0_CAPF0
+#define    CLEAR_CAPTURE_INTERRUPT_IC1_FLAG  clr_CAPCON0_CAPF1
+#define    CLEAR_CAPTURE_INTERRUPT_IC2_FLAG  clr_CAPCON0_CAPF2
+#define    CLEAR_PIN_INTERRUPT_PIT0_FLAG     clr_PIF_PIF0
+#define    CLEAR_PIN_INTERRUPT_PIT1_FLAG     clr_PIF_PIF1
+#define    CLEAR_PIN_INTERRUPT_PIT2_FLAG     clr_PIF_PIF2
+#define    CLEAR_PIN_INTERRUPT_PIT3_FLAG     clr_PIF_PIF3
+#define    CLEAR_PIN_INTERRUPT_PIT4_FLAG     clr_PIF_PIF4
+#define    CLEAR_PIN_INTERRUPT_PIT5_FLAG     clr_PIF_PIF5
+#define    CLEAR_PIN_INTERRUPT_PIT6_FLAG     clr_PIF_PIF6
+#define    CLEAR_PIN_INTERRUPT_PIT7_FLAG     clr_PIF_PIF7
+#define    CLEAR_I2C_TIMEOUT_INTERRUPT_FLAG  clr_I2TOC_I2TOF
+#define    CLEAR_WKT_INTERRUPT_FLAG          clr_WKCON_WKTF
+#define    CLEAR_TIMER3_INTERRUPT_FLAG       clr_T3CON_TF3
+#define    CLEAR_UART1_INTERRUPT_FLAG        clr_EIE1_ES_1 
+
+/*****************************************************************************/
+/*    For GPIO Mode setting                                                  */ 
+/*****************************************************************************/
+#define    P00_QUASI_MODE            P0M1&=0xFE;P0M2&=0xFE
+#define    P01_QUASI_MODE            P0M1&=0xFD;P0M2&=0xFD
+#define    P02_QUASI_MODE            P0M1&=0xFB;P0M2&=0xFB
+#define    P03_QUASI_MODE            P0M1&=0xF7;P0M2&=0xF7
+#define    P04_QUASI_MODE            P0M1&=0xEF;P0M2&=0xEF
+#define    P05_QUASI_MODE            P0M1&=0xDF;P0M2&=0xDF
+#define    P06_QUASI_MODE            P0M1&=0xBF;P0M2&=0xBF
+#define    P07_QUASI_MODE            P0M1&=0x7F;P0M2&=0x7F
+#define    P10_QUASI_MODE            P1M1&=0xFE;P1M2&=0xFE
+#define    P11_QUASI_MODE            P1M1&=0xFD;P1M2&=0xFD
+#define    P12_QUASI_MODE            P1M1&=0xFB;P1M2&=0xFB
+#define    P13_QUASI_MODE            P1M1&=0xF7;P1M2&=0xF7
+#define    P14_QUASI_MODE            P1M1&=0xEF;P1M2&=0xEF
+#define    P15_QUASI_MODE            P1M1&=0xDF;P1M2&=0xDF
+#define    P16_QUASI_MODE            P1M1&=0xBF;P1M2&=0xBF
+#define    P17_QUASI_MODE            P1M1&=0x7F;P1M2&=0x7F
+#define    P30_QUASI_MODE            P3M1&=0xFE;P3M2&=0xFE
+#define    ALL_GPIO_QUASI_MODE       P0M1=0;P0M2=0;P1M1=0;P1M2=0;P3M1=0;P3M2=0
+
+#define    P00_PUSHPULL_MODE         P0M1&=0xFE;P0M2|=0x01
+#define    P01_PUSHPULL_MODE         P0M1&=0xFD;P0M2|=0x02
+#define    P02_PUSHPULL_MODE         P0M1&=0xFB;P0M2|=0x04
+#define    P03_PUSHPULL_MODE         P0M1&=0xF7;P0M2|=0x08
+#define    P04_PUSHPULL_MODE         P0M1&=0xEF;P0M2|=0x10
+#define    P05_PUSHPULL_MODE         P0M1&=0xDF;P0M2|=0x20
+#define    P06_PUSHPULL_MODE         P0M1&=0xBF;P0M2|=0x40
+#define    P07_PUSHPULL_MODE         P0M1&=0x7F;P0M2|=0x80
+#define    P10_PUSHPULL_MODE         P1M1&=0xFE;P1M2|=0x01
+#define    P11_PUSHPULL_MODE         P1M1&=0xFD;P1M2|=0x02
+#define    P12_PUSHPULL_MODE         P1M1&=0xFB;P1M2|=0x04
+#define    P13_PUSHPULL_MODE         P1M1&=0xF7;P1M2|=0x08
+#define    P14_PUSHPULL_MODE         P1M1&=0xEF;P1M2|=0x10
+#define    P15_PUSHPULL_MODE         P1M1&=0xDF;P1M2|=0x20
+#define    P16_PUSHPULL_MODE         P1M1&=0xBF;P1M2|=0x40
+#define    P17_PUSHPULL_MODE         P1M1&=0x7F;P1M2|=0x80
+#define    P30_PUSHPULL_MODE         P3M1&=0xFE;P3M2|=0x01
+#define    ALL_GPIO_PUSHPULL_MODE    P0M1=0;P0M2=0xFF;P1M1=0;P1M2=0xFF;P3M1=0;P3M2=0xFF
+
+#define    P00_INPUT_MODE            P0M1|=0x01;P0M2&=0xFE
+#define    P01_INPUT_MODE            P0M1|=0x02;P0M2&=0xFD
+#define    P02_INPUT_MODE            P0M1|=0x04;P0M2&=0xFB
+#define    P03_INPUT_MODE            P0M1|=0x08;P0M2&=0xF7
+#define    P04_INPUT_MODE            P0M1|=0x10;P0M2&=0xEF
+#define    P05_INPUT_MODE            P0M1|=0x20;P0M2&=0xDF
+#define    P06_INPUT_MODE            P0M1|=0x40;P0M2&=0xBF
+#define    P07_INPUT_MODE            P0M1|=0x80;P0M2&=0x7F
+#define    P10_INPUT_MODE            P1M1|=0x01;P1M2&=0xFE
+#define    P11_INPUT_MODE            P1M1|=0x02;P1M2&=0xFD
+#define    P12_INPUT_MODE            P1M1|=0x04;P1M2&=0xFB
+#define    P13_INPUT_MODE            P1M1|=0x08;P1M2&=0xF7
+#define    P14_INPUT_MODE            P1M1|=0x10;P1M2&=0xEF
+#define    P15_INPUT_MODE            P1M1|=0x20;P1M2&=0xDF
+#define    P16_INPUT_MODE            P1M1|=0x40;P1M2&=0xBF
+#define    P17_INPUT_MODE            P1M1|=0x80;P1M2&=0x7F
+#define    P30_INPUT_MODE            P3M1|=0x01;P3M2&=0xFE
+#define    ALL_GPIO_INPUT_MODE       P0M1=0xFF;P0M2=0;P1M1=0xFF;P1M2=0;P3M1=0xFF;P3M2=0
+
+#define    P00_OPENDRAIN_MODE        P0M1|=0x01;P0M2|=0x01
+#define    P01_OPENDRAIN_MODE        P0M1|=0x02;P0M2|=0x02
+#define    P02_OPENDRAIN_MODE        P0M1|=0x04;P0M2|=0x04
+#define    P03_OPENDRAIN_MODE        P0M1|=0x08;P0M2|=0x08
+#define    P04_OPENDRAIN_MODE        P0M1|=0x10;P0M2|=0x10
+#define    P05_OPENDRAIN_MODE        P0M1|=0x20;P0M2|=0x20
+#define    P06_OPENDRAIN_MODE        P0M1|=0x40;P0M2|=0x40
+#define    P07_OPENDRAIN_MODE        P0M1|=0x80;P0M2|=0x80
+#define    P10_OPENDRAIN_MODE        P1M1|=0x01;P1M2|=0x01
+#define    P11_OPENDRAIN_MODE        P1M1|=0x02;P1M2|=0x02
+#define    P12_OPENDRAIN_MODE        P1M1|=0x04;P1M2|=0x04
+#define    P13_OPENDRAIN_MODE        P1M1|=0x08;P1M2|=0x08
+#define    P14_OPENDRAIN_MODE        P1M1|=0x10;P1M2|=0x10
+#define    P15_OPENDRAIN_MODE        P1M1|=0x20;P1M2|=0x20
+#define    P16_OPENDRAIN_MODE        P1M1|=0x40;P1M2|=0x40
+#define    P17_OPENDRAIN_MODE        P1M1|=0x80;P1M2|=0x80
+#define    P30_OPENDRAIN_MODE        P3M1|=0x01;P3M2|=0x01
+#define    ALL_GPIO_OPENDRAIN_MODE   P0M1=0xFF;P0M2=0xFF;P1M1=0xFF;P1M2=0xFF;P3M1=0xFF;P3M2=0xFF
+
+/*****************************************************************************/
+/*    For GPIO Schmitt Trig / TTL Type Seetting                              */ 
+/*****************************************************************************/
+#define    ENABLE_P00_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_ST_MODE        ENABLE_SFR_PAGE1;P0S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x02;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x04;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x08;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x10;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x20;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x40;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_ST_MODE        ENABLE_SFR_PAGE1;P1S|=0x80;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_ST_MODE        ENABLE_SFR_PAGE1;P2S|=0x01;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_ST_MODE        ENABLE_SFR_PAGE1;P3S|=0x01;ENABLE_SFR_PAGE0
+
+#define    ENABLE_P00_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P01_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P02_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P03_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P04_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P05_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P06_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P07_TTL_MODE       ENABLE_SFR_PAGE1;P0S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P10_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P11_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFD;ENABLE_SFR_PAGE0
+#define    ENABLE_P12_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xFB;ENABLE_SFR_PAGE0
+#define    ENABLE_P13_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xF7;ENABLE_SFR_PAGE0
+#define    ENABLE_P14_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xEF;ENABLE_SFR_PAGE0
+#define    ENABLE_P15_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xDF;ENABLE_SFR_PAGE0
+#define    ENABLE_P16_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0xBF;ENABLE_SFR_PAGE0
+#define    ENABLE_P17_TTL_MODE       ENABLE_SFR_PAGE1;P1S&=0x7F;ENABLE_SFR_PAGE0
+#define    ENABLE_P20_TTL_MODE       ENABLE_SFR_PAGE1;P2S&=0xFE;ENABLE_SFR_PAGE0
+#define    ENABLE_P30_TTL_MODE       ENABLE_SFR_PAGE1;P3S&=0xFE;ENABLE_SFR_PAGE0
+
+/*****************************************************************************/
+/*    Enable GPIO Pin Interrupt port 0~3                                     */ 
+/*****************************************************************************/
+#define    ENABLE_INT_PORT0               PICON &= 0xFB;
+#define    ENABLE_INT_PORT1               PICON |= 0x01;
+#define    ENABLE_INT_PORT2               PICON |= 0x02;
+#define    ENABLE_INT_PORT3               PICON |= 0x03;
+/*    Bit low level trig mode   */
+#define    ENABLE_BIT7_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_LOWLEVEL_TRIG      PICON&=0x7F;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_LOWLEVEL_TRIG      PICON&=0xBF;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_LOWLEVEL_TRIG      PICON&=0xDF;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_LOWLEVEL_TRIG      PICON&=0xEF;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_LOWLEVEL_TRIG      PICON&=0xF7;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_LOWLEVEL_TRIG      PICON&=0xFD;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit high level trig mode    */
+#define    ENABLE_BIT7_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_HIGHLEVEL_TRIG     PICON&=0x7F;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_HIGHLEVEL_TRIG     PICON&=0xBF;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_HIGHLEVEL_TRIG     PICON&=0xDF;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_HIGHLEVEL_TRIG     PICON&=0xEF;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_HIGHLEVEL_TRIG     PICON&=0xF7;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_HIGHLEVEL_TRIG     PICON&=0xFD;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit falling edge trig mode   */
+#define    ENABLE_BIT7_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x80;PIPEN&=0x7F
+#define    ENABLE_BIT6_FALLINGEDGE_TRIG   PICON|=0x80;PINEN|=0x40;PIPEN&=0xBF
+#define    ENABLE_BIT5_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x20;PIPEN&=0xDF
+#define    ENABLE_BIT4_FALLINGEDGE_TRIG   PICON|=0x40;PINEN|=0x10;PIPEN&=0xEF
+#define    ENABLE_BIT3_FALLINGEDGE_TRIG   PICON|=0x20;PINEN|=0x08;PIPEN&=0xF7
+#define    ENABLE_BIT2_FALLINGEDGE_TRIG   PICON|=0x10;PINEN|=0x04;PIPEN&=0xFB
+#define    ENABLE_BIT1_FALLINGEDGE_TRIG   PICON|=0x08;PINEN|=0x02;PIPEN&=0xFD
+#define    ENABLE_BIT0_FALLINGEDGE_TRIG   PICON|=0x04;PINEN|=0x01;PIPEN&=0xFE
+/*    Bit rising edge trig mode    */
+#define    ENABLE_BIT7_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0x7F;PIPEN|=0x80
+#define    ENABLE_BIT6_RISINGEDGE_TRIG    PICON|=0x80;PINEN&=0xBF;PIPEN|=0x40
+#define    ENABLE_BIT5_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xDF;PIPEN|=0x20
+#define    ENABLE_BIT4_RISINGEDGE_TRIG    PICON|=0x40;PINEN&=0xEF;PIPEN|=0x10
+#define    ENABLE_BIT3_RISINGEDGE_TRIG    PICON|=0x20;PINEN&=0xF7;PIPEN|=0x08
+#define    ENABLE_BIT2_RISINGEDGE_TRIG    PICON|=0x10;PINEN&=0xFB;PIPEN|=0x04
+#define    ENABLE_BIT1_RISINGEDGE_TRIG    PICON|=0x08;PINEN&=0xFD;PIPEN|=0x02
+#define    ENABLE_BIT0_RISINGEDGE_TRIG    PICON|=0x04;PINEN&=0xFE;PIPEN|=0x01
+/*    Bit both edge trig mode    */
+#define    ENABLE_BIT7_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x80;PIPEN|=0x80
+#define    ENABLE_BIT6_BOTHEDGE_TRIG      PICON|=0x80;PINEN|=0x40;PIPEN|=0x40
+#define    ENABLE_BIT5_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x20;PIPEN|=0x20
+#define    ENABLE_BIT4_BOTHEDGE_TRIG      PICON|=0x40;PINEN|=0x10;PIPEN|=0x10
+#define    ENABLE_BIT3_BOTHEDGE_TRIG      PICON|=0x20;PINEN|=0x08;PIPEN|=0x08
+#define    ENABLE_BIT2_BOTHEDGE_TRIG      PICON|=0x10;PINEN|=0x04;PIPEN|=0x04
+#define    ENABLE_BIT1_BOTHEDGE_TRIG      PICON|=0x08;PINEN|=0x02;PIPEN|=0x02
+#define    ENABLE_BIT0_BOTHEDGE_TRIG      PICON|=0x04;PINEN|=0x01;PIPEN|=0x01
+
+/*****************************************************************************/
+/*    TIMER Function Define                                                  */ 
+/*****************************************************************************/
+#define    ENABLE_CLOCK_OUT             set_CKCON_CLOEN;
+/*    Timer0 basic define  */
+#define    ENABLE_TIMER0_MODE0           TMOD&=0xF0
+#define    ENABLE_TIMER0_MODE1           TMOD&=0xF0;TMOD|=0x01
+#define    ENABLE_TIMER0_MODE2           TMOD&=0xF0;TMOD|=0x02
+#define    ENABLE_TIMER0_MODE3           TMOD&=0xF0;TMOD|=0x03
+#define    TIMER0_FSYS                   set_CKCON_T0M
+#define    TIMER0_FSYS_DIV12             clr_CKCON_T0M
+#define    TIMER0_MODE0_ENABLE           TMOD&=0xF0
+#define    TIMER0_MODE1_ENABLE           TMOD&=0xF0;TMOD|=0x01
+#define    TIMER0_MODE2_ENABLE           TMOD&=0xF0;TMOD|=0x02
+#define    TIMER0_MODE3_ENABLE           TMOD&=0xF0;TMOD|=0x03
+/*    Timer1 basic define  */
+#define    ENABLE_TIMER1_MODE0           TMOD&=0x0F
+#define    ENABLE_TIMER1_MODE1           TMOD&=0x0F;TMOD|=0x10
+#define    ENABLE_TIMER1_MODE2           TMOD&=0x0F;TMOD|=0x20
+#define    ENABLE_TIMER1_MODE3           TMOD&=0x0F;TMOD|=0x30
+#define    TIMER1_FSYS                   set_CKCON_T1M
+#define    TIMER1_FSYS_DIV12             clr_CKCON_T1M
+#define    TIMER1_MODE0_ENABLE           TMOD&=0x0F
+#define    TIMER1_MODE1_ENABLE           TMOD&=0x0F;TMOD|=0x10
+#define    TIMER1_MODE2_ENABLE           TMOD&=0x0F;TMOD|=0x20
+#define    TIMER1_MODE3_ENABLE           TMOD&=0x0F;TMOD|=0x30
+/*    Timer2 function define  */
+#define    TIMER2_DIV_4                  T2MOD|=0x10;T2MOD&=0x9F
+#define    TIMER2_DIV_16                 T2MOD|=0x20;T2MOD&=0xAF
+#define    TIMER2_DIV_32                 T2MOD|=0x30;T2MOD&=0xBF
+#define    TIMER2_DIV_64                 T2MOD|=0x40;T2MOD&=0xCF
+#define    TIMER2_DIV_128                T2MOD|=0x50;T2MOD&=0xDF
+#define    TIMER2_DIV_256                T2MOD|=0x60;T2MOD&=0xEF
+#define    TIMER2_DIV_512                T2MOD|=0x70
+#define    TIMER2_AUTO_RELOAD_DELAY_MODE T2CON&=0xFE;T2MOD|=0x80;T2MOD|=0x08
+#define    TIMER2_COMPARE_CAPTURE_MODE   T2CON|=0x01;T2MOD&=0x7F;T2MOD|=0x04
+#define    TIMER2_CAP0_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x89
+#define    TIMER2_CAP1_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8A
+#define    TIMER2_CAP2_CAPTURE_MODE      T2CON&=0xFE;T2MOD=0x8B
+#define    DISABLE_TIMER2_CAP0           CAPCON0&=0xBF
+#define    DISABLE_TIMER2_CAP1           CAPCON0&=0xDF
+#define    DISABLE_TIMER2_CAP2           CAPCON0&=0xEF
+
+/*    Timer2 Capture define  */
+#define    IC0_P12_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_FALLINGEDGE_CAPTURE    CAPCON1&=0xFC;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON0|=0x20
+#define    IC2_P10_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_FALLINGEDGE_CAPTURE    CAPCON1&=0xF3;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x10;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x20;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x30;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x40;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x50;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x60;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x70;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_FALLINGEDGE_CAPTURE    CAPCON1&=0x0F;CAPCON4&=0xF0;CAPCON4|=0x80;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_RISINGEDGE_CAPTURE     CAPCON1&=0xFC;CAPCON1|=0x01;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_RISINGEDGE_CAPTURE     CAPCON1&=0xF3;CAPCON1|=0x04;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_RISINGEDGE_CAPTURE     CAPCON1&=0x0F;CAPCON1|=0x10;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+#define    IC0_P12_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC1_P11_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x01;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC2_P10_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x02;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P00_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x03;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC3_P04_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x04;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC4_P01_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x05;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC5_P03_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x06;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC6_P05_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x07;CAPCON0|=0x10;CAPCON2|=0x10
+#define    IC7_P15_CAP0_BOTHEDGE_CAPTURE       CAPCON1&=0xFC;CAPCON1|=0x02;CAPCON3&=0xF0;CAPCON3|=0x08;CAPCON0|=0x10;CAPCON2|=0x10
+           
+#define    IC0_P12_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC1_P11_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x10;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC2_P10_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x20;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P00_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x30;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC3_P04_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x40;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC4_P01_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x50;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC5_P03_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x60;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC6_P05_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x70;CAPCON0|=0x20;CAPCON2|=0x20
+#define    IC7_P15_CAP1_BOTHEDGE_CAPTURE       CAPCON1&=0xF3;CAPCON1|=0x08;CAPCON3&=0x0F;CAPCON3|=0x80;CAPCON0|=0x20;CAPCON2|=0x20
+           
+#define    IC0_P12_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC1_P11_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x01;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC2_P10_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x02;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P00_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x03;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC3_P04_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x04;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC4_P01_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x05;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC5_P03_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x06;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC6_P05_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x07;CAPCON0|=0x40;CAPCON2|=0x40
+#define    IC7_P15_CAP2_BOTHEDGE_CAPTURE       CAPCON1&=0x0F;CAPCON1|=0x20;CAPCON4&=0xF0;CAPCON4|=0x08;CAPCON0|=0x40;CAPCON2|=0x40
+
+/*****************************************************************************/
+/*     For PWM setting                                                       */
+/*****************************************************************************/
+/*     PMW0 clock source select define    */
+#define    PWM0_CLOCK_FSYS                   CKCON&=0xBF
+#define    PWM0_CLOCK_TIMER1                 CKCON|=0x40
+/*     PWM type define    */
+#define    PWM0_EDGE_TYPE                    PWMCON1&=0xEF
+#define    PWM0_CENTER_TYPE                  PWMCON1|=0x10      
+/*      PWM mode define   */
+#define    PWM0_IMDEPENDENT_MODE             PWMCON1&=0x3F
+#define    PWM0_COMPLEMENTARY_MODE           PWMCON1&=0x3F;PWMCON1|=0x40 
+#define    PWM0_SYNCHRONIZED_MODE            PWMCON1&=0x3F;PWMCON1|=0x80 
+#define    PWM0_GP_MODE_ENABLE               PWMCON1|=0x20
+#define    PWM0_GP_MODE_DISABLE              PWMCON1&=0xDF
+/*      PWM0 clock devide define    */
+#define    PWM0_CLOCK_DIV_1                  PWMCON1&=0xF8;PWMCON1|=0x00
+#define    PWM0_CLOCK_DIV_2                  PWMCON1&=0xF8;PWMCON1|=0x01
+#define    PWM0_CLOCK_DIV_4                  PWMCON1&=0xF8;PWMCON1|=0x02
+#define    PWM0_CLOCK_DIV_8                  PWMCON1&=0xF8;PWMCON1|=0x03
+#define    PWM0_CLOCK_DIV_16                 PWMCON1&=0xF8;PWMCON1|=0x04
+#define    PWM0_CLOCK_DIV_32                 PWMCON1&=0xF8;PWMCON1|=0x05
+#define    PWM0_CLOCK_DIV_64                 PWMCON1&=0xF8;PWMCON1|=0x06
+#define    PWM0_CLOCK_DIV_128                PWMCON1&=0xF8;PWMCON1|=0x07
+/*      PWM0 I/O select define    */
+#define    ENABLE_PWM0_CH5_P15_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x20;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output enable 
+#define    ENABLE_PWM0_CH5_P03_OUTPUT        PIOCON0|=0x20                                                                                 //P0.3 as PWM5               
+#define    ENABLE_PWM0_CH4_P01_OUTPUT        PIOCON0|=0x10                                                                                 //P0.1 as PWM4 output enable 
+#define    ENABLE_PWM0_CH3_P04_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x08;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output enable 
+#define    ENABLE_PWM0_CH3_P00_OUTPUT        PIOCON0|=0x08                                                                                 //P0.0 as PWM3               
+#define    ENABLE_PWM0_CH2_P05_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x04;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output enable 
+#define    ENABLE_PWM0_CH2_P10_OUTPUT        PIOCON0|=0x04                                                                                 //P1.0 as PWM2               
+#define    ENABLE_PWM0_CH1_P14_OUTPUT        ENABLE_SFR_PAGE1;PIOCON1|=0x02;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output enable 
+#define    ENABLE_PWM0_CH1_P11_OUTPUT        PIOCON0|=0x02                                                                                 //P1.1 as PWM1               
+#define    ENABLE_PWM0_CH0_P12_OUTPUT        PIOCON0|=0x01                                                                                 //P1.2 as PWM0 output enable 
+#define    ENABLE_ALL_PWM0_OUTPUT            PIOCON0=0xFF;PIOCON1=0xFF
+
+#define    DISABLE_PWM0_CH5_P15_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xDF;ENABLE_SFR_PAGE0        //P1.5 as PWM5 output disable
+#define    DISABLE_PWM0_CH5_P03_OUTPUT       PIOCON0&=0xDF                                                                                 //P0.3 as PWM5               
+#define    DISABLE_PWM0_CH4_P01_OUTPUT       PIOCON0&=0xEF                                                                                 //P0.1 as PWM4 output disable
+#define    DISABLE_PWM0_CH3_P04_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xF7;ENABLE_SFR_PAGE0        //P0.4 as PWM3 output disable
+#define    DISABLE_PWM0_CH3_P00_OUTPUT       PIOCON0&=0xF7                                                                                 //P0.0 as PWM3               
+#define    DISABLE_PWM0_CH2_P05_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFB;ENABLE_SFR_PAGE0        //P1.0 as PWM2 output disable
+#define    DISABLE_PWM0_CH2_P10_OUTPUT       PIOCON0&=0xFB                                                                                 //P1.0 as PWM2               
+#define    DISABLE_PWM0_CH1_P14_OUTPUT       ENABLE_SFR_PAGE1;PIOCON1&=0xFD;ENABLE_SFR_PAGE0        //P1.4 as PWM1 output disable
+#define    DISABLE_PWM0_CH1_P11_OUTPUT       PIOCON0&=0xFD                                                                                 //P1.1 as PWM1               
+#define    DISABLE_PWM0_CH0_P12_OUTPUT       PIOCON0&=0xFE                                                                                 //P1.2 as PWM0 output disable
+#define    DISABLE_ALL_PWM0_OUTPUT           PIOCON0=0x00;PIOCON1=0x00
+/*       PWM0 I/O Polarity Control     */
+#define    PWM0_CH5_OUTPUT_INVERSE           PNP|=0x20
+#define    PWM0_CH4_OUTPUT_INVERSE           PNP|=0x10
+#define    PWM0_CH3_OUTPUT_INVERSE           PNP|=0x08
+#define    PWM0_CH2_OUTPUT_INVERSE           PNP|=0x04
+#define    PWM0_CH1_OUTPUT_INVERSE           PNP|=0x02
+#define    PWM0_CH0_OUTPUT_INVERSE           PNP|=0x01
+#define    PWM0_OUTPUT_ALL_INVERSE           PNP|=0xFF
+#define    PWM0_CH5_OUTPUT_NORMAL            PNP&=0xDF
+#define    PWM0_CH4_OUTPUT_NORMAL            PNP&=0xEF
+#define    PWM0_CH3_OUTPUT_NORMAL            PNP&=0xF7
+#define    PWM0_CH2_OUTPUT_NORMAL            PNP&=0xFB
+#define    PWM0_CH1_OUTPUT_NORMAL            PNP&=0xFD
+#define    PWM0_CH0_OUTPUT_NORMAL            PNP&=0xFE
+#define    PWM0_OUTPUT_ALL_NORMAL            PNP&=0x00
+/*      PMW0 interrupt setting     */
+#define    PWM0_FALLING_INT                  ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_RISING_INT                   ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x10;ENABLE_SFR_PAGE0
+#define    PWM0_CENTRAL_POINT_INT            ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x20;ENABLE_SFR_PAGE0
+#define    PWM0_PERIOD_END_INT               ENABLE_SFR_PAGE1;PWMINTC&=0xCF;PWMINTC|=0x30;ENABLE_SFR_PAGE0
+/*      PWM0 interrupt pin select    */
+#define    PWM0_INT_PWM0                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x00;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM1                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x01;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM2                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x02;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM3                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x03;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM4                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x04;ENABLE_SFR_PAGE0
+#define    PWM0_INT_PWM5                     ENABLE_SFR_PAGE1;PWMINTC&=0xF8;PWMINTC|=0x05;ENABLE_SFR_PAGE0
+/*      PWM0 Dead time setting     */
+#define    ENABLE_PWM0_CH45_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define    ENABLE_PWM0_CH23_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define    ENABLE_PWM0_CH01_DEADTIME         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+
+/*****************************************************************************/
+/*     For ADC INIT setting                                                  */
+/*****************************************************************************/
+#define    ENABLE_ADC                        set_ADCCON1_ADCEN
+#define    DISABLE_ADC                       clr_ADCCON1_ADCEN
+
+#define    ENABLE_ADC_BANDGAP                DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x08;ADCCON0&=0xF8;ENABLE_ADC  
+#define    ENABLE_ADC_AIN0                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_AIN1                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_AIN2                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_AIN3                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_AIN4                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC    //P05
+#define    ENABLE_ADC_AIN5                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_AIN6                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_AIN7                   DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+
+#define    ENABLE_ADC_CH0                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x00;P17_INPUT_MODE;AINDIDS=0;AINDIDS|=0x01;ENABLE_ADC    //P17
+#define    ENABLE_ADC_CH1                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x01;P30_INPUT_MODE;AINDIDS=0;AINDIDS|=0x02;ENABLE_ADC    //P30
+#define    ENABLE_ADC_CH2                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x02;P07_INPUT_MODE;AINDIDS=0;AINDIDS|=0x04;ENABLE_ADC    //P07
+#define    ENABLE_ADC_CH3                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x03;P06_INPUT_MODE;AINDIDS=0;AINDIDS|=0x08;ENABLE_ADC    //P06
+#define    ENABLE_ADC_CH4                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x04;P05_INPUT_MODE;AINDIDS=0;AINDIDS|=0x10;ENABLE_ADC   //P05
+#define    ENABLE_ADC_CH5                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x05;P04_INPUT_MODE;AINDIDS=0;AINDIDS|=0x20;ENABLE_ADC    //P04
+#define    ENABLE_ADC_CH6                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x06;P03_INPUT_MODE;AINDIDS=0;AINDIDS|=0x40;ENABLE_ADC    //P03
+#define    ENABLE_ADC_CH7                    DISABLE_ADC;ADCCON0&=0xF0;ADCCON0|=0x07;P11_INPUT_MODE;AINDIDS=0;AINDIDS|=0x80;ENABLE_ADC    //P11
+/*      GPIO trig ADC start define*/
+#define    P04_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P13_FALLINGEDGE_TRIG_ADC          ADCCON0|=0x30;ADCCON1|=0x40;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    P04_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xBF;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    P13_RISINGEDGE_TRIG_ADC           ADCCON0|=0x30;ADCCON1&=0xF7;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+/*      PWM trig ADC start define */ 
+#define    PWM0_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM2_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM4_FALLINGEDGE_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM2_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM4_RISINGEDGE_TRIG_ADC          ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM2_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM4_CENTRAL_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM2_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM4_END_TRIG_ADC                 ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+#define    PWM0_CH0_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH2_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x00;ADCCON1|=0x02
+#define    PWM0_CH4_FALLINGEDGE_TRIG_ADC     ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH0_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH2_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x04;ADCCON1|=0x02
+#define    PWM0_CH4_RISINGEDGE_TRIG_ADC      ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x06;ADCCON1|=0x02
+#define    PWM0_CH0_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH2_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH4_CENTRAL_TRIG_ADC         ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x08;ADCCON1|=0x02
+#define    PWM0_CH0_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x00;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH2_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x10;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+#define    PWM0_CH4_END_TRIG_ADC             ADCCON0&=0xCF;ADCCON0|=0x20;ADCCON1&=0xF3;ADCCON1|=0x0C;ADCCON1|=0x02
+
+/*****************************************************************************/
+/*     For SPI INIT setting                                                  */
+/*****************************************************************************/
+#define    SPICLK_FSYS_DIV2                  SPCR&=0xFC
+#define    SPICLK_FSYS_DIV4                  SPCR&=0xFC;SPCR|=0x01
+#define    SPICLK_FSYS_DIV8                  SPCR&=0xFC;SPCR|=0x02
+#define    SPICLK_FSYS_DIV16                 SPCR&=0xFC;SPCR|=0x03
+#define    SS    P15
+/*****************************************************************************/
+/*     For UART0 and UART1 and printf funcion                                */
+/*****************************************************************************/
+#define    ENABLE_UART0_PRINTF                set_SCON_TI;PRINTFG=1            //For printf function must setting TI = 1
+#define    DISABLE_UART0_PRINTF               clr_SCON_TI;PRINTFG=0
+#define    ENABLE_UART1_PRINTF                set_SCON_1_TI_1;PRINTFG=1
+#define    DISABLE_UART1_PRINTF               clr_SCON_1_TI_1;PRINTFG=0
+/*****************************************************************************/
+/*     INT0 setting                                                          */
+/*****************************************************************************/
+#define    INT0_FALLING_EDGE_TRIG             set_TCON_IT0
+#define    INT0_LOW_LEVEL_TRIG                clr_TCON_IT0
+/*****************************************************************************/
+/*     INT1 setting                                                          */
+/*****************************************************************************/
+#define    INT1_FALLING_EDGE_TRIG             set_TCON_IT1
+#define    INT1_LOW_LEVEL_TRIG                clr_TCON_IT1
+
+/*****************************************************************************/
+/*     WDT setting                                                           */
+/*****************************************************************************/
+#define    WDT_TIMEOUT_6MS                    TA=0xAA;TA=0x55;WDCON&=0xF8
+#define    WDT_TIMEOUT_25MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x01
+#define    WDT_TIMEOUT_50MS                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x02
+#define    WDT_TIMEOUT_100MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x03
+#define    WDT_TIMEOUT_200MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x04
+#define    WDT_TIMEOUT_400MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x05
+#define    WDT_TIMEOUT_800MS                  TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x06
+#define    WDT_TIMEOUT_1_6S                   TA=0xAA;TA=0x55;WDCON&=0xF8;WDCON|=0x07
+
+#define    WDT_RUN_IN_POWERDOWN_ENABLE        set_WDCON_WIDPD
+#define    WDT_RUN_IN_POWERDOWN_DISABLE       clr_WDCON_WIDPD
+#define    WDT_COUNTER_CLEAR                  set_WDCON_WDCLR
+#define    WDT_COUNTER_RUN                    set_WDCON_WDTR
+
+

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_iar.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_iar.h
@@ -1,0 +1,530 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  N76S003_iar.h                                                                       */
+/*  Header file of Nuvoton                                                              */
+/*  N76S003AT20 / N76S003AQ20                                                           */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76s003.h"
+
+/*  BYTE Registers  */
+/*  SFR page 0      */
+__sfr __no_init volatile union
+{
+  unsigned char P0; /* Port 0 */
+  struct /* Port 0 */
+  { 
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P0_bit;
+} @ 0x80;
+__sfr __no_init volatile unsigned char  SP          @ 0x81;
+__sfr __no_init volatile unsigned char  DPL         @ 0x82;
+__sfr __no_init volatile unsigned char  DPH         @ 0x83;
+__sfr __no_init volatile unsigned char  RCTRIM0     @ 0x84;
+__sfr __no_init volatile unsigned char  RCTRIM1     @ 0x85;  
+__sfr __no_init volatile unsigned char  RWK         @ 0x86;
+__sfr __no_init volatile unsigned char  PCON        @ 0x87;
+
+__sfr __no_init volatile union
+{
+  unsigned char TCON; /* Timer Control */
+  struct /* Timer Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } TCON_bit;
+} @ 0x88;                            
+__sfr __no_init volatile unsigned char  TMOD        @ 0x89;
+__sfr __no_init volatile unsigned char  TL0         @ 0x8A;
+__sfr __no_init volatile unsigned char  TL1         @ 0x8B;
+__sfr __no_init volatile unsigned char  TH0         @ 0x8C;
+__sfr __no_init volatile unsigned char  TH1         @ 0x8D;
+__sfr __no_init volatile unsigned char  CKCON       @ 0x8E;
+__sfr __no_init volatile unsigned char  WKCON       @ 0x8F;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char P1; /* Port 1 */
+  struct /* Port 1 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } P1_bit;
+} @ 0x90;
+__sfr __no_init volatile unsigned char SFRS        @ 0x91; //TA Protection
+__sfr __no_init volatile unsigned char CAPCON0     @ 0x92;
+__sfr __no_init volatile unsigned char CAPCON1     @ 0x93;
+__sfr __no_init volatile unsigned char CAPCON2     @ 0x94;
+__sfr __no_init volatile unsigned char CKDIV       @ 0x95;
+__sfr __no_init volatile unsigned char CKSWT       @ 0x96; //TA Protection
+__sfr __no_init volatile unsigned char CKEN        @ 0x97; //TA Protection
+
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON; /* Serial Control */
+  struct /* Serial Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_bit;
+} @ 0x98;
+__sfr __no_init volatile unsigned char SBUF        @ 0x99;
+__sfr __no_init volatile unsigned char SBUF_1      @ 0x9A;
+__sfr __no_init volatile unsigned char EIE         @ 0x9B;
+__sfr __no_init volatile unsigned char EIE1        @ 0x9C;
+__sfr __no_init volatile unsigned char CHPCON      @ 0x9F; //TA Protection
+   
+__sfr __no_init volatile union
+{
+  unsigned char P2; /* Port 2 */
+  struct /* Port 2 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P2_bit;
+} @ 0xA0;
+__sfr __no_init volatile unsigned char AUXR1       @ 0xA2;
+__sfr __no_init volatile unsigned char BODCON0     @ 0xA3; //TA Protection
+__sfr __no_init volatile unsigned char IAPTRG      @ 0xA4; //TA Protection
+__sfr __no_init volatile unsigned char IAPUEN      @ 0xA5;  //TA Protection
+__sfr __no_init volatile unsigned char IAPAL       @ 0xA6;
+__sfr __no_init volatile unsigned char IAPAH       @ 0xA7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IE; /* Interrupt Enable */
+  struct /* Interrupt Enable */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IE_bit;
+} @ 0xA8;
+__sfr __no_init volatile unsigned char SADDR       @ 0xA9;
+__sfr __no_init volatile unsigned char WDCON       @ 0xAA; //TA Protection
+__sfr __no_init volatile unsigned char BODCON1     @ 0xAB; //TA Protection
+__sfr __no_init volatile unsigned char P3M1        @ 0xAC;
+__sfr __no_init volatile unsigned char P3S         @ 0xAC; //Page1
+__sfr __no_init volatile unsigned char P3M2        @ 0xAD;
+__sfr __no_init volatile unsigned char P3SR        @ 0xAD; //Page1
+__sfr __no_init volatile unsigned char IAPFD       @ 0xAE;
+__sfr __no_init volatile unsigned char IAPCN       @ 0xAF;
+
+__sfr __no_init volatile union
+{
+  unsigned char P3; /* Port 3 */
+  struct /* Port 3 */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } P3_bit;
+} @ 0xB0;
+__sfr __no_init volatile unsigned char P0M1        @ 0xB1;
+__sfr __no_init volatile unsigned char P0S         @ 0xB1; //Page1
+__sfr __no_init volatile unsigned char P0M2        @ 0xB2;
+__sfr __no_init volatile unsigned char P0SR        @ 0xB2; //Page1
+__sfr __no_init volatile unsigned char P1M1        @ 0xB3;
+__sfr __no_init volatile unsigned char P1S         @ 0xB3; //Page1
+__sfr __no_init volatile unsigned char P1M2        @ 0xB4;
+__sfr __no_init volatile unsigned char P1SR        @ 0xB4; //Page1
+__sfr __no_init volatile unsigned char P2S         @ 0xB5; 
+__sfr __no_init volatile unsigned char IPH         @ 0xB7;
+__sfr __no_init volatile unsigned char PWMINTC     @ 0xB7;  //Page1
+
+
+__sfr __no_init volatile union
+{
+  unsigned char IP; /* IP  */
+  struct /* IP  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } IP_bit;
+} @ 0xB8;
+__sfr __no_init volatile unsigned char SADEN       @ 0xB9;
+__sfr __no_init volatile unsigned char SADEN_1     @ 0xBA;
+__sfr __no_init volatile unsigned char SADDR_1     @ 0xBB;
+__sfr __no_init volatile unsigned char I2DAT       @ 0xBC;
+__sfr __no_init volatile unsigned char I2STAT      @ 0xBD;
+__sfr __no_init volatile unsigned char I2CLK       @ 0xBE;
+__sfr __no_init volatile unsigned char I2TOC       @ 0xBF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char I2CON; /* I2CON  */
+  struct /* I2CON  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } I2CON_bit;
+} @ 0xC0;
+__sfr __no_init volatile unsigned char I2ADDR      @ 0xC1;
+__sfr __no_init volatile unsigned char ADCRL       @ 0xC2;
+__sfr __no_init volatile unsigned char ADCRH       @ 0xC3;
+__sfr __no_init volatile unsigned char T3CON       @ 0xC4;
+__sfr __no_init volatile unsigned char PWM4H       @ 0xC4; //Page1
+__sfr __no_init volatile unsigned char RL3         @ 0xC5;
+__sfr __no_init volatile unsigned char PWM5H       @ 0xC5;  //Page1
+__sfr __no_init volatile unsigned char RH3         @ 0xC6;
+__sfr __no_init volatile unsigned char PIOCON1     @ 0xC6; //Page1
+__sfr __no_init volatile unsigned char TA          @ 0xC7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char T2CON; /* Timer 2 Control */
+  struct /* Timer 2 Control */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } T2CON_bit;
+} @ 0xC8;
+__sfr __no_init volatile unsigned char T2MOD       @ 0xC9;
+__sfr __no_init volatile unsigned char RCMP2L      @ 0xCA;
+__sfr __no_init volatile unsigned char RCMP2H      @ 0xCB;
+__sfr __no_init volatile unsigned char TL2         @ 0xCC; 
+__sfr __no_init volatile unsigned char PWM4L       @ 0xCC; //Page1
+__sfr __no_init volatile unsigned char TH2         @ 0xCD;
+__sfr __no_init volatile unsigned char PWM5L       @ 0xCD; //Page1
+__sfr __no_init volatile unsigned char ADCMPL      @ 0xCE;
+__sfr __no_init volatile unsigned char ADCMPH      @ 0xCF;
+
+__sfr __no_init volatile union
+{
+  unsigned char PSW; /* Program Status Word */
+  struct /* Program Status Word */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PSW_bit;
+} @ 0xD0;
+__sfr __no_init volatile unsigned char PWMPH        @ 0xD1;
+__sfr __no_init volatile unsigned char PWM0H        @ 0xD2;
+__sfr __no_init volatile unsigned char PWM1H        @ 0xD3;
+__sfr __no_init volatile unsigned char PWM2H        @ 0xD4;
+__sfr __no_init volatile unsigned char PWM3H        @ 0xD5;
+__sfr __no_init volatile unsigned char PNP          @ 0xD6;
+__sfr __no_init volatile unsigned char FBD          @ 0xD7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char PWMCON0; /* PWMCON0  */
+  struct /* PWMCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } PWMCON0_bit;
+} @ 0xD8;
+__sfr __no_init volatile unsigned char PWMPL        @ 0xD9;
+__sfr __no_init volatile unsigned char PWM0L        @ 0xDA;
+__sfr __no_init volatile unsigned char PWM1L        @ 0xDB;
+__sfr __no_init volatile unsigned char PWM2L        @ 0xDC;
+__sfr __no_init volatile unsigned char PWM3L        @ 0xDD;
+__sfr __no_init volatile unsigned char PIOCON0      @ 0xDE;
+__sfr __no_init volatile unsigned char PWMCON1      @ 0xDF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ACC; /* Accumulator */
+  struct /* Accumulator */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;    
+  } ACC_bit;
+} @ 0xE0;
+__sfr __no_init volatile unsigned char ADCCON1     @ 0xE1;
+__sfr __no_init volatile unsigned char ADCCON2     @ 0xE2;
+__sfr __no_init volatile unsigned char ADCDLY      @ 0xE3;
+__sfr __no_init volatile unsigned char C0L         @ 0xE4;
+__sfr __no_init volatile unsigned char C0H         @ 0xE5;
+__sfr __no_init volatile unsigned char C1L         @ 0xE6;
+__sfr __no_init volatile unsigned char C1H         @ 0xE7;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char ADCCON0; /* ADCCON0  */
+  struct /* ADCCON0  */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } ADCCON0_bit;
+} @ 0xE8;
+__sfr __no_init volatile unsigned char PICON       @ 0xE9;
+__sfr __no_init volatile unsigned char PINEN       @ 0xEA;
+__sfr __no_init volatile unsigned char PIPEN       @ 0xEB;
+__sfr __no_init volatile unsigned char PIF         @ 0xEC;
+__sfr __no_init volatile unsigned char C2L         @ 0xED;
+__sfr __no_init volatile unsigned char C2H         @ 0xEE;
+__sfr __no_init volatile unsigned char EIP         @ 0xEF;
+
+
+__sfr __no_init volatile union
+{
+  unsigned char B; /* B Register */
+  struct /* B Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } B_bit;
+} @ 0xF0;
+__sfr __no_init volatile unsigned char CAPCON3      @ 0xF1;
+__sfr __no_init volatile unsigned char CAPCON4      @ 0xF2;
+__sfr __no_init volatile unsigned char SPCR         @ 0xF3;
+__sfr __no_init volatile unsigned char SPCR2        @ 0xF3; //Page1
+__sfr __no_init volatile unsigned char SPSR         @ 0xF4;
+__sfr __no_init volatile unsigned char SPDR         @ 0xF5;
+__sfr __no_init volatile unsigned char AINDIDS      @ 0xF6;
+__sfr __no_init volatile unsigned char EIPH         @ 0xF7;
+
+__sfr __no_init volatile union
+{
+  unsigned char SCON_1 ; /* SCON_1  Register */
+  struct /* SCON_1  Register */
+  {
+    unsigned char BIT0 : 1;
+    unsigned char BIT1 : 1;
+    unsigned char BIT2 : 1;
+    unsigned char BIT3 : 1;
+    unsigned char BIT4 : 1;
+    unsigned char BIT5 : 1;
+    unsigned char BIT6 : 1;
+    unsigned char BIT7 : 1;
+  } SCON_1_bit;
+} @ 0xF8;
+__sfr __no_init volatile unsigned char PDTEN       @ 0xF9; //TA Protection
+__sfr __no_init volatile unsigned char PDTCNT      @ 0xFA; //TA Protection
+__sfr __no_init volatile unsigned char PMEN        @ 0xFB;
+__sfr __no_init volatile unsigned char PMD         @ 0xFC;
+__sfr __no_init volatile unsigned char EIP1        @ 0xFE;
+__sfr __no_init volatile unsigned char EIPH1       @ 0xFF;
+
+/*  BIT Registers  */
+/*  BIT Registers  */
+/*  P0  */
+#define P07         P0_bit.BIT7
+#define P06         P0_bit.BIT6
+#define P05         P0_bit.BIT5
+#define P04         P0_bit.BIT4
+#define P03         P0_bit.BIT3
+#define P02         P0_bit.BIT2
+#define P01         P0_bit.BIT1
+#define P00         P0_bit.BIT0
+
+/*  TCON  */
+#define TF1         TCON_bit.BIT7
+#define TR1         TCON_bit.BIT6
+#define TF0         TCON_bit.BIT5
+#define TR0         TCON_bit.BIT4
+#define IE1         TCON_bit.BIT3
+#define IT1         TCON_bit.BIT2
+#define IE0         TCON_bit.BIT1
+#define IT0         TCON_bit.BIT0
+                    
+/*  P1  */
+#define P17         P1_bit.BIT7
+#define P16         P1_bit.BIT6
+#define P15         P1_bit.BIT5
+#define P14         P1_bit.BIT4
+#define P13         P1_bit.BIT3
+#define P12         P1_bit.BIT2
+#define P11         P1_bit.BIT1
+#define P10         P1_bit.BIT0
+
+/*  SCON  */
+#define SM0         SCON_bit.BIT7 
+#define FE          SCON_bit.BIT7 
+#define SM1         SCON_bit.BIT6 
+#define SM2         SCON_bit.BIT5 
+#define REN         SCON_bit.BIT4 
+#define TB8         SCON_bit.BIT3 
+#define RB8         SCON_bit.BIT2 
+#define TI          SCON_bit.BIT1 
+#define RI          SCON_bit.BIT0 
+
+/*  P2  */ 
+#define P20         P2_bit.BIT0
+
+/*  IE  */
+#define EA          IE_bit.BIT7
+#define EADC        IE_bit.BIT6
+#define EBOD        IE_bit.BIT5
+#define ES          IE_bit.BIT4
+#define ET1         IE_bit.BIT3
+#define EX1         IE_bit.BIT2
+#define ET0         IE_bit.BIT1
+#define EX0         IE_bit.BIT0
+
+/*  P3  */  
+#define P30	    P3_bit.BIT0
+
+/*  IP  */
+#define PADC        IP_bit.BIT6
+#define PBOD        IP_bit.BIT5
+#define PS          IP_bit.BIT4
+#define PT1         IP_bit.BIT3
+#define PX1         IP_bit.BIT2
+#define PT0         IP_bit.BIT1
+#define PX0         IP_bit.BIT0
+
+/*  I2CON  */
+#define I2CEN       I2CON_bit.BIT6
+#define STA         I2CON_bit.BIT5
+#define STO         I2CON_bit.BIT4
+#define SI          I2CON_bit.BIT3
+#define AA          I2CON_bit.BIT2
+#define I2CPX	    I2CON_bit.BIT0
+
+/*  T2CON  */
+#define TF2         T2CON_bit.BIT7
+#define TR2         T2CON_bit.BIT2
+#define CM_RL2      T2CON_bit.BIT0
+
+/*  PSW */
+#define CY          PSW.BIT7
+#define AC          PSW.BIT6
+#define F0          PSW.BIT5
+#define RS1         PSW.BIT4
+#define RS0         PSW.BIT3
+#define OV          PSW.BIT2
+#define P           PSW.BIT0
+
+/*  PWMCON0  */
+#define PWMRUN      PWMCON0_bit.BIT7
+#define LOAD        PWMCON0_bit.BIT6
+#define PWMF        PWMCON0_bit.BIT5
+#define CLRPWM      PWMCON0_bit.BIT4
+
+/*  ADCCON0  */
+#define ADCF        ADCCON0_bit.BIT7
+#define ADCS        ADCCON0_bit.BIT6
+#define ETGSEL1     ADCCON0_bit.BIT5
+#define ETGSEL0     ADCCON0_bit.BIT4
+#define ADCHS3      ADCCON0_bit.BIT3
+#define ADCHS2      ADCCON0_bit.BIT2
+#define ADCHS1      ADCCON0_bit.BIT1
+#define ADCHS0      ADCCON0_bit.BIT0
+
+/*  SCON_1  */
+#define SM0_1       SCON_1_bit.BIT7
+#define FE_1        SCON_1_bit.BIT7 
+#define SM1_1       SCON_1_bit.BIT6 
+#define SM2_1       SCON_1_bit.BIT5 
+#define REN_1       SCON_1_bit.BIT4 
+#define TB8_1       SCON_1_bit.BIT3 
+#define RB8_1       SCON_1_bit.BIT2 
+#define TI_1        SCON_1_bit.BIT1 
+#define RI_1        SCON_1_bit.BIT0
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_keil.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_keil.h
@@ -1,0 +1,305 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  N76S003_keil.h                                                                      */
+/*  Header file of Nuvoton                                                              */
+/*  N76S003AT20 / N76S003AQ20 / N76S003BQ20                                             */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76s003.h"
+
+
+sfr P0          = 0x80;
+sfr SP          = 0x81;
+sfr DPL         = 0x82;
+sfr DPH         = 0x83;
+sfr RCTRIM0     = 0x84;
+sfr RCTRIM1     = 0x85;  
+sfr RWK         = 0x86;
+sfr PCON        = 0x87;
+
+sfr TCON        = 0x88;
+sfr TMOD        = 0x89;
+sfr TL0         = 0x8A;
+sfr TL1         = 0x8B;
+sfr TH0         = 0x8C;
+sfr TH1         = 0x8D;
+sfr CKCON       = 0x8E;
+sfr WKCON       = 0x8F;
+
+sfr P1          = 0x90;
+sfr SFRS        = 0x91; //TA Protection
+sfr CAPCON0     = 0x92;
+sfr CAPCON1     = 0x93;
+sfr CAPCON2     = 0x94;
+sfr CKDIV       = 0x95;
+sfr CKSWT       = 0x96; //TA Protection
+sfr CKEN        = 0x97; //TA Protection
+
+sfr SCON        = 0x98;
+sfr SBUF        = 0x99;
+sfr SBUF_1      = 0x9A;
+sfr EIE         = 0x9B;
+sfr EIE1        = 0x9C;
+sfr CHPCON      = 0x9F; //TA Protection
+
+sfr P2          = 0xA0;
+sfr AUXR1       = 0xA2;
+sfr BODCON0     = 0xA3; //TA Protection
+sfr IAPTRG      = 0xA4; //TA Protection
+sfr IAPUEN      = 0xA5;  //TA Protection
+sfr IAPAL       = 0xA6;
+sfr IAPAH       = 0xA7;
+
+sfr IE          = 0xA8;
+sfr SADDR       = 0xA9;
+sfr WDCON       = 0xAA; //TA Protection
+sfr BODCON1     = 0xAB; //TA Protection
+sfr P3M1        = 0xAC;
+sfr P3S         = 0xAC; //Page1
+sfr P3M2        = 0xAD;
+sfr P3SR        = 0xAD; //Page1
+sfr IAPFD       = 0xAE;
+sfr IAPCN       = 0xAF;
+
+sfr P3          = 0xB0;
+sfr P0M1        = 0xB1;
+sfr P0S         = 0xB1; //Page1
+sfr P0M2        = 0xB2;
+sfr P0SR        = 0xB2; //Page1
+sfr P1M1        = 0xB3;
+sfr P1S         = 0xB3; //Page1
+sfr P1M2        = 0xB4;
+sfr P1SR        = 0xB4; //Page1
+sfr P2S         = 0xB5; 
+sfr IPH         = 0xB7;
+sfr PWMINTC     = 0xB7; //Page1
+
+sfr IP          = 0xB8;
+sfr SADEN       = 0xB9;
+sfr SADEN_1     = 0xBA;
+sfr SADDR_1     = 0xBB;
+sfr I2DAT       = 0xBC;
+sfr I2STAT      = 0xBD;
+sfr I2CLK       = 0xBE;
+sfr I2TOC       = 0xBF;
+
+sfr I2CON       = 0xC0;
+sfr I2ADDR      = 0xC1;
+sfr ADCRL       = 0xC2;
+sfr ADCRH       = 0xC3;
+sfr T3CON       = 0xC4;
+sfr PWM4H       = 0xC4; //Page1
+sfr RL3         = 0xC5;
+sfr PWM5H       = 0xC5; //Page1
+sfr RH3         = 0xC6;
+sfr PIOCON1     = 0xC6; //Page1
+sfr TA          = 0xC7;
+
+sfr T2CON       = 0xC8;
+sfr T2MOD       = 0xC9;
+sfr RCMP2L      = 0xCA;
+sfr RCMP2H      = 0xCB;
+sfr TL2         = 0xCC; 
+sfr PWM4L       = 0xCC; //Page1
+sfr TH2         = 0xCD;
+sfr PWM5L       = 0xCD; //Page1
+sfr ADCMPL      = 0xCE;
+sfr ADCMPH      = 0xCF;
+
+sfr PSW         = 0xD0;
+sfr PWMPH       = 0xD1;
+sfr PWM0H       = 0xD2;
+sfr PWM1H       = 0xD3;
+sfr PWM2H       = 0xD4;
+sfr PWM3H       = 0xD5;
+sfr PNP         = 0xD6;
+sfr FBD         = 0xD7;
+
+sfr PWMCON0     = 0xD8;
+sfr PWMPL       = 0xD9;
+sfr PWM0L       = 0xDA;
+sfr PWM1L       = 0xDB;
+sfr PWM2L       = 0xDC;
+sfr PWM3L       = 0xDD;
+sfr PIOCON0     = 0xDE;
+sfr PWMCON1     = 0xDF;
+
+sfr ACC         = 0xE0;
+sfr ADCCON1     = 0xE1;
+sfr ADCCON2     = 0xE2;
+sfr ADCDLY      = 0xE3;
+sfr C0L         = 0xE4;
+sfr C0H         = 0xE5;
+sfr C1L         = 0xE6;
+sfr C1H         = 0xE7;
+
+sfr ADCCON0     = 0xE8;
+sfr PICON       = 0xE9;
+sfr PINEN       = 0xEA;
+sfr PIPEN       = 0xEB;
+sfr PIF         = 0xEC;
+sfr C2L         = 0xED;
+sfr C2H         = 0xEE;
+sfr EIP         = 0xEF;
+
+sfr B           = 0xF0;
+sfr CAPCON3     = 0xF1;
+sfr CAPCON4     = 0xF2;
+sfr SPCR        = 0xF3;
+sfr SPCR2       = 0xF3; //Page1
+sfr SPSR        = 0xF4;
+sfr SPDR        = 0xF5;
+sfr AINDIDS     = 0xF6;
+sfr EIPH        = 0xF7;
+
+sfr SCON_1      = 0xF8;
+sfr PDTEN       = 0xF9; //TA Protection
+sfr PDTCNT      = 0xFA; //TA Protection
+sfr PMEN        = 0xFB;
+sfr PMD         = 0xFC;
+sfr EIP1        = 0xFE;
+sfr EIPH1       = 0xFF;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+sbit SM0_1      = SCON_1^7;
+sbit FE_1       = SCON_1^7; 
+sbit SM1_1      = SCON_1^6; 
+sbit SM2_1      = SCON_1^5; 
+sbit REN_1      = SCON_1^4; 
+sbit TB8_1      = SCON_1^3; 
+sbit RB8_1      = SCON_1^2; 
+sbit TI_1       = SCON_1^1; 
+sbit RI_1       = SCON_1^0; 
+
+/*  ADCCON0  */
+sbit ADCF       = ADCCON0^7;
+sbit ADCS       = ADCCON0^6;
+sbit ETGSEL1    = ADCCON0^5;
+sbit ETGSEL0    = ADCCON0^4;
+sbit ADCHS3     = ADCCON0^3;
+sbit ADCHS2     = ADCCON0^2;
+sbit ADCHS1     = ADCCON0^1;
+sbit ADCHS0     = ADCCON0^0;
+
+/*  PWMCON0  */
+sbit PWMRUN     = PWMCON0^7;
+sbit LOAD       = PWMCON0^6;
+sbit PWMF       = PWMCON0^5;
+sbit CLRPWM     = PWMCON0^4;
+
+
+/*  PSW */
+sbit CY         = PSW^7;
+sbit AC         = PSW^6;
+sbit F0         = PSW^5;
+sbit RS1        = PSW^4;
+sbit RS0        = PSW^3;
+sbit OV         = PSW^2;
+sbit P          = PSW^0;
+
+/*  T2CON  */
+sbit TF2        = T2CON^7;
+sbit TR2        = T2CON^2;
+sbit CM_RL2     = T2CON^0;
+ 
+/*  I2CON  */
+sbit I2CEN      = I2CON^6;
+sbit STA        = I2CON^5;
+sbit STO        = I2CON^4;
+sbit SI         = I2CON^3;
+sbit AA         = I2CON^2;
+sbit I2CPX      = I2CON^0;
+
+/*  IP  */  
+sbit PADC       = IP^6;
+sbit PBOD       = IP^5;
+sbit PS         = IP^4;
+sbit PT1        = IP^3;
+sbit PX1        = IP^2;
+sbit PT0        = IP^1;
+sbit PX0        = IP^0;
+
+/*  P3  */  
+sbit P30        = P3^0;
+
+
+/*  IE  */
+sbit EA         = IE^7;
+sbit EADC       = IE^6;
+sbit EBOD       = IE^5;
+sbit ES         = IE^4;
+sbit ET1        = IE^3;
+sbit EX1        = IE^2;
+sbit ET0        = IE^1;
+sbit EX0        = IE^0;
+
+/*  P2  */ 
+sbit P20        = P2^0;
+
+/*  SCON  */
+sbit SM0        = SCON^7;
+sbit FE         = SCON^7; 
+sbit SM1        = SCON^6; 
+sbit SM2        = SCON^5; 
+sbit REN        = SCON^4; 
+sbit TB8        = SCON^3; 
+sbit RB8        = SCON^2; 
+sbit TI         = SCON^1; 
+sbit RI         = SCON^0; 
+
+/*  P1  */     
+sbit P17        = P1^7;
+sbit P16        = P1^6;
+sbit TXD_1      = P1^6; 
+sbit P15        = P1^5;
+sbit P14        = P1^4;
+sbit SDA        = P1^4;    
+sbit P13        = P1^3;
+sbit SCL        = P1^3;  
+sbit P12        = P1^2; 
+sbit P11        = P1^1;
+sbit P10        = P1^0;
+
+/*  TCON  */
+sbit TF1        = TCON^7;
+sbit TR1        = TCON^6;
+sbit TF0        = TCON^5;
+sbit TR0        = TCON^4;
+sbit IE1        = TCON^3;
+sbit IT1        = TCON^2;
+sbit IE0        = TCON^1;
+sbit IT0        = TCON^0;
+
+/*  P0  */  
+
+sbit P07        = P0^7;
+sbit RXD        = P0^7;
+sbit P06        = P0^6;
+sbit TXD        = P0^6;
+sbit P05        = P0^5;
+sbit P04        = P0^4;
+sbit STADC      = P0^4;
+sbit P03        = P0^3;
+sbit P02        = P0^2;
+sbit RXD_1      = P0^2;
+sbit P01        = P0^1;
+sbit MISO       = P0^1;
+sbit P00        = P0^0;
+sbit MOSI       = P0^0;
+
+
+
+
+
+
+
+
+
+
+
+

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_sdcc.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/n76s003_sdcc.h
@@ -1,0 +1,296 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  N76S003_sdcc.h                                                                      */
+/*  Header file of Nuvoton                                                              */
+/*  N76S003AT20 / N76S003AQ20 / N76S003BQ20                                             */
+/*--------------------------------------------------------------------------------------*/
+#include "sfr_macro_n76s003.h"
+
+/******************************************************************************/
+/*                         Macro define header files                          */
+/******************************************************************************/
+__sfr __at   (0x80) P0        ;
+__sfr __at   (0x81) SP        ;
+__sfr __at   (0x82) DPL       ;
+__sfr __at   (0x83) DPH       ;
+__sfr __at   (0x84) RCTRIM0   ;
+__sfr __at   (0x85) RCTRIM1   ;
+__sfr __at   (0x86) RWK       ;
+__sfr __at   (0x87) PCON      ;
+
+__sfr  __at  (0x88)TCON       ;
+__sfr  __at  (0x89)TMOD       ;
+__sfr  __at  (0x8A)TL0        ;
+__sfr  __at  (0x8B)TL1        ;
+__sfr  __at  (0x8C)TH0        ;
+__sfr  __at  (0x8D)TH1        ;
+__sfr  __at  (0x8E)CKCON      ;
+__sfr  __at  (0x8F)WKCON      ;
+
+__sfr  __at  (0x90)P1         ;
+__sfr  __at  (0x91)SFRS       ; //TA Protection
+__sfr  __at  (0x92)CAPCON0    ;
+__sfr  __at  (0x93)CAPCON1    ;
+__sfr  __at  (0x94)CAPCON2    ;
+__sfr  __at  (0x95)CKDIV      ;
+__sfr  __at  (0x96)CKSWT      ; //TA Protection
+__sfr  __at  (0x97)CKEN       ; //TA Protection
+
+__sfr  __at  (0x98) SCON      ;
+__sfr  __at  (0x99) SBUF      ;
+__sfr  __at  (0x9A) SBUF_1    ;
+__sfr  __at  (0x9B) EIE       ;
+__sfr  __at  (0x9C) EIE1      ;
+__sfr  __at  (0x9F) CHPCON    ; //TA Protection
+
+__sfr  __at  (0xA0) P2        ;
+__sfr  __at  (0xA2) AUXR1     ;
+__sfr  __at  (0xA3) BODCON0   ; //TA Protection
+__sfr  __at  (0xA4) IAPTRG    ; //TA Protection
+__sfr  __at  (0xA5) IAPUEN    ; //TA Protection
+__sfr  __at  (0xA6) IAPAL     ;
+__sfr  __at  (0xA7) IAPAH     ;
+
+__sfr  __at  (0xA8) IE        ;
+__sfr  __at  (0xA9) SADDR     ;
+__sfr  __at  (0xAA) WDCON     ; //TA Protection
+__sfr  __at  (0xAB) BODCON1   ; //TA Protection
+__sfr  __at  (0xAC) P3M1      ;
+__sfr  __at  (0xAC) P3S       ; //Page1
+__sfr  __at  (0xAD) P3M2      ;
+__sfr  __at  (0xAD) P3SR      ; //Page1
+__sfr  __at  (0xAE) IAPFD     ;
+__sfr  __at  (0xAF) IAPCN     ;
+
+__sfr  __at  (0xB0) P3        ;
+__sfr  __at  (0xB1) P0M1      ;
+__sfr  __at  (0xB1) P0S       ; //Page1
+__sfr  __at  (0xB2) P0M2      ;
+__sfr  __at  (0xB2) P0SR      ; //Page1
+__sfr  __at  (0xB3) P1M1      ;
+__sfr  __at  (0xB3) P1S       ; //Page1
+__sfr  __at  (0xB4) P1M2      ;
+__sfr  __at  (0xB4) P1SR      ; //Page1
+__sfr  __at  (0xB5) P2S       ; 
+__sfr  __at  (0xB7) IPH       ;
+__sfr  __at  (0xB7) PWMINTC   ;  //Page1
+
+__sfr  __at  (0xB8) IP        ;
+__sfr  __at  (0xB9) SADEN     ;
+__sfr  __at  (0xBA) SADEN_1   ;
+__sfr  __at  (0xBB) SADDR_1   ;
+__sfr  __at  (0xBC) I2DAT     ;
+__sfr  __at  (0xBD) I2STAT    ;
+__sfr  __at  (0xBE) I2CLK     ;
+__sfr  __at  (0xBF) I2TOC     ;
+
+__sfr  __at  (0xC0) I2CON     ;
+__sfr  __at  (0xC1) I2ADDR    ;
+__sfr  __at  (0xC2) ADCRL     ;
+__sfr  __at  (0xC3) ADCRH     ;
+__sfr  __at  (0xC4) T3CON     ;
+__sfr  __at  (0xC4) PWM4H     ; //Page1
+__sfr  __at  (0xC5) RL3       ;
+__sfr  __at  (0xC5) PWM5H     ;  //Page1
+__sfr  __at  (0xC6) RH3       ;
+__sfr  __at  (0xC6) PIOCON1   ; //Page1
+__sfr  __at  (0xC7) TA        ;
+
+__sfr  __at  (0xC8) T2CON     ;
+__sfr  __at  (0xC9) T2MOD     ;
+__sfr  __at  (0xCA) RCMP2L    ;
+__sfr  __at  (0xCB) RCMP2H    ;
+__sfr  __at  (0xCC) TL2       ; 
+__sfr  __at  (0xCC) PWM4L     ; //Page1
+__sfr  __at  (0xCD) TH2       ;
+__sfr  __at  (0xCD) PWM5L     ; //Page1
+__sfr  __at  (0xCE) ADCMPL    ;
+__sfr  __at  (0xCF) ADCMPH    ;
+
+__sfr  __at  (0xD0) PSW       ;
+__sfr  __at  (0xD1) PWMPH     ;
+__sfr  __at  (0xD2) PWM0H     ;
+__sfr  __at  (0xD3) PWM1H     ;
+__sfr  __at  (0xD4) PWM2H     ;
+__sfr  __at  (0xD5) PWM3H     ;
+__sfr  __at  (0xD6) PNP       ;
+__sfr  __at  (0xD7) FBD       ;
+
+__sfr  __at  (0xD8) PWMCON0   ;
+__sfr  __at  (0xD9) PWMPL     ;
+__sfr  __at  (0xDA) PWM0L     ;
+__sfr  __at  (0xDB) PWM1L     ;
+__sfr  __at  (0xDC) PWM2L     ;
+__sfr  __at  (0xDD) PWM3L     ;
+__sfr  __at  (0xDE) PIOCON0   ;
+__sfr  __at  (0xDF) PWMCON1   ;
+
+__sfr  __at  (0xE0) ACC       ;
+__sfr  __at  (0xE1) ADCCON1   ;
+__sfr  __at  (0xE2) ADCCON2   ;
+__sfr  __at  (0xE3) ADCDLY    ;
+__sfr  __at  (0xE4) C0L       ;
+__sfr  __at  (0xE5) C0H       ;
+__sfr  __at  (0xE6) C1L       ;
+__sfr  __at  (0xE7) C1H       ;
+
+__sfr  __at  (0xE8) ADCCON0   ;
+__sfr  __at  (0xE9) PICON     ;
+__sfr  __at  (0xEA) PINEN     ;
+__sfr  __at  (0xEB) PIPEN     ;
+__sfr  __at  (0xEC) PIF       ;
+__sfr  __at  (0xED) C2L       ;
+__sfr  __at  (0xEE) C2H       ;
+__sfr  __at  (0xEF) EIP       ;
+
+__sfr  __at  (0xF0) B         ;
+__sfr  __at  (0xF1) CAPCON3   ;
+__sfr  __at  (0xF2) CAPCON4   ;
+__sfr  __at  (0xF3) SPCR      ;
+__sfr  __at  (0xF3) SPCR2     ; //Page1
+__sfr  __at  (0xF4) SPSR      ;
+__sfr  __at  (0xF5) SPDR      ;
+__sfr  __at  (0xF6) AINDIDS   ;
+__sfr  __at  (0xF7) EIPH      ;
+
+__sfr  __at  (0xF8) SCON_1    ;
+__sfr  __at  (0xF9) PDTEN     ; //TA Protection
+__sfr  __at  (0xFA) PDTCNT    ; //TA Protection
+__sfr  __at  (0xFB) PMEN      ;
+__sfr  __at  (0xFC) PMD       ;
+__sfr  __at  (0xFD) PORDIS    ;
+__sfr  __at  (0xFE) EIP1      ;
+__sfr  __at  (0xFF) EIPH1     ;
+
+/*  BIT Registers  */
+/*  SCON_1  */
+__sbit  __at (0xF8+7) SM0_1   ; //SCON_1^7;
+__sbit  __at (0xF8+7) FE_1    ; //SCON_1^7
+__sbit  __at (0xF8+6) SM1_1   ; //SCON_1^6
+__sbit  __at (0xF8+5) SM2_1   ; //SCON_1^5
+__sbit  __at (0xF8+4) REN_1   ; //SCON_1^4
+__sbit  __at (0xF8+3) TB8_1   ; //SCON_1^3
+__sbit  __at (0xF8+2) RB8_1   ; //SCON_1^2
+__sbit  __at (0xF8+1) TI_1    ; //SCON_1^1
+__sbit  __at (0xF8+0) RI_1    ; //SCON_1^0
+
+/*  ADCCON0  */
+__sbit  __at (0xE8+7) ADCF    ; //ADCCON0^7
+__sbit  __at (0xE8+6) ADCS    ; //ADCCON0^6
+__sbit  __at (0xE8+5) ETGSEL1 ; //ADCCON0^5
+__sbit  __at (0xE8+4) ETGSEL0 ; //ADCCON0^4
+__sbit  __at (0xE8+3) ADCHS3  ; //ADCCON0^3
+__sbit  __at (0xE8+2) ADCHS2  ; //ADCCON0^2
+__sbit  __at (0xE8+1) ADCHS1  ; //ADCCON0^1
+__sbit  __at (0xE8+0) ADCHS0  ; //ADCCON0^0
+
+/*  PWMCON0  */
+__sbit  __at (0xD8+7) PWMRUN  ; //PWMCON0^7
+__sbit  __at (0xD8+6) LOAD    ; //PWMCON0^6
+__sbit  __at (0xD8+5) PWMF    ; //PWMCON0^5
+__sbit  __at (0xD8+4) CLRPWM  ; //PWMCON0^4
+
+
+/*  PSW */
+__sbit  __at (0xD0+7) CY       ; //PSW^7
+__sbit  __at (0xD0+6) AC       ; //PSW^6
+__sbit  __at (0xD0+5) F0       ; //PSW^5
+__sbit  __at (0xD0+4) RS1      ; //PSW^4
+__sbit  __at (0xD0+3) RS0      ; //PSW^3
+__sbit  __at (0xD0+2) OV       ; //PSW^2
+__sbit  __at (0xD0+0) P        ; //PSW^0
+
+/*  T2CON  */
+__sbit  __at (0xC8+7) TF2      ; //T2CON^7
+__sbit  __at (0xC8+2) TR2      ; //T2CON^2
+__sbit  __at (0xC8+0) CM_RL2   ; //T2CON^0
+ 
+/*  I2CON  */
+__sbit  __at (0xC0+6) I2CEN    ; //I2CON^6
+__sbit  __at (0xC0+5) STA      ; //I2CON^5
+__sbit  __at (0xC0+4) STO      ; //I2CON^4
+__sbit  __at (0xC0+3) SI       ; //I2CON^3
+__sbit  __at (0xC0+2) AA       ; //I2CON^2
+__sbit  __at (0xC0+0) I2CPX    ; //I2CON^0
+
+/*  IP  */  
+__sbit  __at (0xB8+6) PADC     ; //IP^6
+__sbit  __at (0xB8+5) PBOD     ; //IP^5
+__sbit  __at (0xB8+4) PS       ; //IP^4
+__sbit  __at (0xB8+3) PT1      ; //IP^3
+__sbit  __at (0xB8+2) PX1      ; //IP^2
+__sbit  __at (0xB8+1) PT0      ; //IP^1
+__sbit  __at (0xB8+0) PX0      ; //IP^0
+
+/*  P3  */  
+__sbit  __at (0xB0+0) P30      ; //P3^0
+
+
+/*  IE  */
+__sbit  __at (0xA8+7) EA       ; //IE^7
+__sbit  __at (0xA8+6) EADC     ; //IE^6
+__sbit  __at (0xA8+5) EBOD     ; //IE^5
+__sbit  __at (0xA8+4) ES       ; //IE^4
+__sbit  __at (0xA8+3) ET1      ; //IE^3
+__sbit  __at (0xA8+2) EX1      ; //IE^2
+__sbit  __at (0xA8+1) ET0      ; //IE^1
+__sbit  __at (0xA8+0) EX0      ; //IE^0
+
+/*  P2  */ 
+__sbit  __at (0xA0+0) P20      ; //P2^0
+
+/*  SCON  */
+__sbit  __at (0x98+7) SM0      ; //SCON^7
+__sbit  __at (0x98+7) FE       ; //SCON^7
+__sbit  __at (0x98+6) SM1      ; //SCON^6
+__sbit  __at (0x98+5) SM2      ; //SCON^5
+__sbit  __at (0x98+4) REN      ; //SCON^4
+__sbit  __at (0x98+3) TB8      ; //SCON^3
+__sbit  __at (0x98+2) RB8      ; //SCON^2
+__sbit  __at (0x98+1) TI       ; //SCON^1
+__sbit  __at (0x98+0) RI       ; //SCON^0
+
+/*  P1  */     
+__sbit  __at (0x90+7) P17      ; //P1^7
+__sbit  __at (0x90+6) P16      ; //P1^6
+__sbit  __at (0x90+6) TXD_1    ; //P1^6
+__sbit  __at (0x90+5) P15      ; //P1^5
+__sbit  __at (0x90+4) P14      ; //P1^4
+__sbit  __at (0x90+4) SDA      ; //P1^4
+__sbit  __at (0x90+3) P13      ; //P1^3
+__sbit  __at (0x90+3) SCL      ; //P1^3
+__sbit  __at (0x90+2) P12      ; //P1^2
+__sbit  __at (0x90+1) P11      ; //P1^1
+__sbit  __at (0x90+0) P10      ; //P1^0
+
+/*  TCON  */
+__sbit  __at (0x88+7) TF1      ; //TCON^7
+__sbit  __at (0x88+6) TR1      ; //TCON^6
+__sbit  __at (0x88+5) TF0      ; //TCON^5
+__sbit  __at (0x88+4) TR0      ; //TCON^4
+__sbit  __at (0x88+3) IE1      ; //TCON^3
+__sbit  __at (0x88+2) IT1      ; //TCON^2
+__sbit  __at (0x88+1) IE0      ; //TCON^1
+__sbit  __at (0x88+0) IT0      ; //TCON^0
+
+/*  P0  */  
+__sbit  __at (0x80+7) P07      ; //P0^7
+__sbit  __at (0x80+7) RXD      ; //P0^7
+__sbit  __at (0x80+6) P06      ; //P0^6
+__sbit  __at (0x80+6) TXD      ; //P0^6
+__sbit  __at (0x80+5) P05      ; //P0^5
+__sbit  __at (0x80+4) P04      ; //P0^4
+__sbit  __at (0x80+4) STADC    ; //P0^4
+__sbit  __at (0x80+3) P03      ; //P0^3
+__sbit  __at (0x80+2) P02      ; //P0^2
+__sbit  __at (0x80+2) RXD_1    ; //P0^2
+__sbit  __at (0x80+1) P01      ; //P0^1
+__sbit  __at (0x80+1) MISO     ; //P0^1
+__sbit  __at (0x80+0) P00      ; //P0^0
+__sbit  __at (0x80+0) MOSI     ; //P0^0
+

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/numicro_8051.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/numicro_8051.h
@@ -1,0 +1,14 @@
+
+/* for Keil */
+#if defined __C51__
+#include "n76s003_keil.h"
+
+/* for IAR */
+#elif defined __ICC8051__
+#include "n76s003_iar.h"
+
+/* for SDCC */
+#elif defined __SDCC__
+#include "n76s003_sdcc.h"
+
+#endif

--- a/hardware/victims/firmware/numicro8051/inc/N76S003/sfr_macro_n76s003.h
+++ b/hardware/victims/firmware/numicro8051/inc/N76S003/sfr_macro_n76s003.h
@@ -1,0 +1,2268 @@
+/*---------------------------------------------------------------------------------------------------------*/
+/*                                                                                                         */
+/* SPDX-License-Identifier: Apache-2.0                                                                     */
+/* Copyright(c) 2023 Nuvoton Technology Corp. All rights reserved.                                         */
+/*                                                                                                         */
+/*---------------------------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/*  sfr_macro_N76S003.h                                                            */
+/*  SFR Macro define for Nuvoton                                                        */
+/*  N76S003AT20 / N76S003AQ20                                                           */
+/*--------------------------------------------------------------------------------------*/
+#if defined __C51__
+#include <stdio.h>
+#include <string.h>
+#include <absacc.h>
+#include <intrins.h>
+
+#elif defined __ICC8051__
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+
+#elif defined __SDCC__
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <float.h>
+
+#endif
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "function_define_n76s003.h"
+
+#ifdef INC_STD_DRIVER
+#include "adc.h"
+#include "bod.h"
+#include "capture.h"
+#include "common.h"
+#include "delay.h"
+#include "eeprom_sprom.h"
+#include "eeprom.h"
+#include "i2c.h"
+#include "iap_sprom.h"
+#include "iap.h"
+#include "isr.h"
+#include "pwm.h"
+#include "spi.h"
+#include "sys.h"
+#include "timer.h"
+#include "uart.h"
+#include "wdt.h"
+#include "wkt.h"
+#endif
+/********************************************************************/
+/*  <Macro define                                                   */
+/********************************************************************/
+
+/**** SP   81H ****/
+/**** DPH  82H ****/
+/**** DPL  83H ****/
+/**** RWK  86H ****/
+
+/**** PCON  87H ****/
+#define set_PCON_SMOD            PCON|=0x80
+#define set_PCON_SMOD0           PCON|=0x40
+#define set_PCON_POF             PCON|=0x10
+#define set_PCON_GF1             PCON|=0x08
+#define set_PCON_GF0             PCON|=0x04 
+#define set_PCON_PD              PCON|=0x02
+#define set_PCON_IDLE            PCON|=0x01
+                                    
+#define clr_PCON_SMOD            PCON&=0x7F
+#define clr_PCON_SMOD0           PCON&=0xBF
+#define clr_PCON_POF             PCON&=0xEF
+#define clr_PCON_GF1             PCON&=0xF7
+#define clr_PCON_GF0             PCON&=0xFB 
+#define clr_PCON_PD              PCON&=0xFD
+#define clr_PCON_IDLE            PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TCON_TF1             TF1=1
+#define set_TCON_TR1             TR1=1
+#define set_TCON_TF0             TF0=1
+#define set_TCON_TR0             TR0=1
+#define set_TCON_IE1             IE1=1
+#define set_TCON_IT1             IT1=1
+#define set_TCON_IE0             IE0=1
+#define set_TCON_IT0             IT0=1
+                                 
+#define clr_TCON_TF1             TF1=0
+#define clr_TCON_TR1             TR1=0
+#define clr_TCON_TF0             TF0=0
+#define clr_TCON_TR0             TR0=0
+#define clr_TCON_IE1             IE1=0
+#define clr_TCON_IT1             IT1=0
+#define clr_TCON_IE0             IE0=0
+#define clr_TCON_IT0             IT0=0
+
+/**** TMOD    89H ****/
+#define set_TMOD_GATE_T1         TMOD|=0x80
+#define set_TMOD_CT_T1           TMOD|=0x40
+#define set_TMOD_M1_T1           TMOD|=0x20
+#define set_TMOD_M0_T1           TMOD|=0x10
+#define set_TMOD_GATE_T0         TMOD|=0x08
+#define set_TMOD_CT_T0           TMOD|=0x04
+#define set_TMOD_M1_T0           TMOD|=0x02
+#define set_TMOD_M0_T0           TMOD|=0x01
+                                  
+#define clr_TMOD_GATE_T1         TMOD&=0x7F
+#define clr_TMOD_CT_T1           TMOD&=0xBF
+#define clr_TMOD_M1_T1           TMOD&=0xDF
+#define clr_TMOD_M0_T1           TMOD&=0xEF
+#define clr_TMOD_GATE_T0         TMOD&=0xF7
+#define clr_TMOD_CT_T0           TMOD&=0xFB
+#define clr_TMOD_M1_T0           TMOD&=0xFD
+#define clr_TMOD_M0_T0           TMOD&=0xFE
+
+/**** TH1    8AH ****/
+/**** TH0    8BH ****/
+/**** TL1    8CH  ****/ 
+/**** TL0    8DH ****/
+
+/**** CKCON  8EH ****/
+#define set_CKCON_PWMCKS         CKCON|=0x40
+#define set_CKCON_T1M            CKCON|=0x10
+#define set_CKCON_T0M            CKCON|=0x08
+#define set_CKCON_CLOEN          CKCON|=0x02
+                                   
+#define clr_CKCON_PWMCKS         CKCON&=0xBF
+#define clr_CKCON_T1M            CKCON&=0xEF
+#define clr_CKCON_T0M            CKCON&=0xF7
+#define clr_CKCON_CLOEN          CKCON&=0xFD
+                                 
+/**** WKCON  8FH ****/          
+#define set_WKCON_WKTCK          WKCON|=0x20
+#define set_WKCON_WKTF           WKCON|=0x10
+#define set_WKCON_WKTR           WKCON|=0x08
+#define set_WKCON_WKPS2          WKCON|=0x04
+#define set_WKCON_WKPS1          WKCON|=0x02
+#define set_WKCON_WKPS0          WKCON|=0x01
+                                   
+#define clr_WKCON_WKTCK          WKCON&=0xDF
+#define clr_WKCON_WKTF           WKCON&=0xEF
+#define clr_WKCON_WKTR           WKCON&=0xF7
+#define clr_WKCON_WKPS2          WKCON&=0xFB
+#define clr_WKCON_WKPS1          WKCON&=0xFD
+#define clr_WKCON_WKPS0          WKCON&= 0xFE
+
+/****SFRS    91H ****/
+#define set_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRS_SFRPAGE         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPCON0_CAPEN2       CAPCON0|=0x40
+#define set_CAPCON0_CAPEN1       CAPCON0|=0x20
+#define set_CAPCON0_CAPEN0       CAPCON0|=0x10
+#define set_CAPCON0_CAPF2        CAPCON0|=0x04
+#define set_CAPCON0_CAPF1        CAPCON0|=0x02
+#define set_CAPCON0_CAPF0        CAPCON0|=0x01
+                                 
+#define clr_CAPCON0_CAPEN2       CAPCON0&=0xBF
+#define clr_CAPCON0_CAPEN1       CAPCON0&=0xDF
+#define clr_CAPCON0_CAPEN0       CAPCON0&=0xEF
+#define clr_CAPCON0_CAPF2        CAPCON0&=0xFB
+#define clr_CAPCON0_CAPF1        CAPCON0&=0xFD
+#define clr_CAPCON0_CAPF0        CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAPCON1_CAP2LS1      CAPCON1|=0x20
+#define set_CAPCON1_CAP2LS0      CAPCON1|=0x10
+#define set_CAPCON1_CAP1LS1      CAPCON1|=0x08
+#define set_CAPCON1_CAP1LS0      CAPCON1|=0x04
+#define set_CAPCON1_CAP0LS1      CAPCON1|=0x02
+#define set_CAPCON1_CAP0LS0      CAPCON1|=0x01
+                                 
+#define clr_CAPCON1_CAP2LS1      CAPCON1&=0xDF
+#define clr_CAPCON1_CAP2LS0      CAPCON1&=0xEF
+#define clr_CAPCON1_CAP1LS1      CAPCON1&=0xF7
+#define clr_CAPCON1_CAP1LS0      CAPCON1&=0xFB
+#define clr_CAPCON1_CAP0LS1      CAPCON1&=0xFD
+#define clr_CAPCON1_CAP0LS0      CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_CAPCON2_ENF2         CAPCON2|=0x40
+#define set_CAPCON2_ENF1         CAPCON2|=0x20
+#define set_CAPCON2_ENF0         CAPCON2|=0x10
+                                   
+#define clr_CAPCON2_ENF2         CAPCON2&=0xBF
+#define clr_CAPCON2_ENF1         CAPCON2&=0xDF
+#define clr_CAPCON2_ENF0         CAPCON2&=0xEF
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H   TA protect register ****/
+#define set_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+
+#define clr_CKSWT_HIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_CKSWT_LIRCST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_CKSWT_ECLKST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_CKSWT_OSC1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_CKSWT_OSC0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/ 
+#define set_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+
+#define clr_CKEN_EXTEN1          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_CKEN_EXTEN0          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_CKEN_HIRCEN          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKEN_CKSWTF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_SCON_FE              FE =1
+#define set_SCON_SM1             SM1=1
+#define set_SCON_SM2             SM2=1
+#define set_SCON_REN             REN=1
+#define set_SCON_TB8             TB8=1
+#define set_SCON_RB8             RB8=1
+#define set_SCON_TI              TI =1
+#define set_SCON_RI              RI =1
+                                 
+#define clr_SCON_FE              FE =0
+#define clr_SCON_SM1             SM1=0
+#define clr_SCON_SM2             SM2=0
+#define clr_SCON_REN             REN=0
+#define clr_SCON_TB8             TB8=0
+#define clr_SCON_RB8             RB8=0
+#define clr_SCON_TI              TI =0
+#define clr_SCON_RI              RI =0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                     
+#define set_EIE_ET2              EIE|=0x80
+#define set_EIE_ESPI             EIE|=0x40
+#define set_EIE_EFB              EIE|=0x20
+#define set_EIE_EWDT             EIE|=0x10
+#define set_EIE_EPWM             EIE|=0x08
+#define set_EIE_ECAP             EIE|=0x04
+#define set_EIE_EPI              EIE|=0x02
+#define set_EIE_EI2C             EIE|=0x01
+                                    
+#define clr_EIE_ET2              EIE&=0x7F
+#define clr_EIE_ESPI             EIE&=0xBF
+#define clr_EIE_EFB              EIE&=0xDF
+#define clr_EIE_EWDT             EIE&=0xEF
+#define clr_EIE_EPWM             EIE&=0xF7
+#define clr_EIE_ECAP             EIE&=0xFB
+#define clr_EIE_EPI              EIE&=0xFD
+#define clr_EIE_EI2C             EIE&=0xFE
+
+/**** EIE1    9CH ****/                     
+#define set_EIE1_EWKT            EIE1|=0x04
+#define set_EIE1_ET3             EIE1|=0x02
+#define set_EIE1_ES_1            EIE1|=0x01
+                                    
+#define clr_EIE1_EWKT            EIE1&=0xFB
+#define clr_EIE1_ET3             EIE1&=0xFD
+#define clr_EIE1_ES_1            EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register  ****/
+#define set_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_CHPCON_SWRST         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_CHPCON_IAPFF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_CHPCON_BS            BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_CHPCON_IAPEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_AUXR1_SWRF           AUXR1|=0x80
+#define set_AUXR1_RSTPINF        AUXR1|=0x40
+#define set_AUXR1_HARDF          AUXR1|=0x20
+#define set_AUXR1_GF2            AUXR1|=0x08
+#define set_AUXR1_UART0PX        AUXR1|=0x04
+#define set_AUXR1_DPS            AUXR1|=0x01
+                                   
+#define clr_AUXR1_SWRF           AUXR1&=0x7F
+#define clr_AUXR1_RSTPINF        AUXR1&=0xBF
+#define clr_AUXR1_HARDF          AUXR1&=0xDF
+#define clr_AUXR1_GF2            AUXR1&=0xF7
+#define clr_AUXR1_UART0PX        AUXR1&=0xFB
+#define clr_AUXR1_DPS            AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON0_BODEN        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BODCON0_BOV2         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BODCON0_BOV1         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BODCON0_BOV0         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BODCON0_BOF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BODCON0_BORST        BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BODCON0_BORF         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BODCON0_BOS          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define set_IAPTRG_IAPGO_WDCLR   BIT_TMP=EA;EA=0;set_WDCON_WDCLR;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+#define clr_IAPTRG_IAPGO         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG&=0xFE;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/ 
+#define set_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x10;EA=BIT_TMP
+#define set_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x08;EA=BIT_TMP
+#define set_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                 
+#define clr_IAPUEN_SPMEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xEF;EA=BIT_TMP
+#define clr_IAPUEN_SPUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xF7;EA=BIT_TMP
+#define clr_IAPUEN_CFUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_IAPUEN_LDUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_IAPUEN_APUEN         BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_IE_EA                EA  =1
+#define set_IE_EADC              EADC=1
+#define set_IE_EBOD              EBOD=1
+#define set_IE_ES                ES  =1
+#define set_IE_ET1               ET1 =1
+#define set_IE_EX1               EX1 =1
+#define set_IE_ET0               ET0 =1
+#define set_IE_EX0               EX0 =1
+                                 
+#define clr_IE_EA                EA  =0
+#define clr_IE_EADC              EADC=0
+#define clr_IE_EBOD              EBOD=0
+#define clr_IE_ES                ES  =0
+#define clr_IE_ET1               ET1 =0
+#define clr_IE_EX1               EX1 =0
+#define clr_IE_ET0               ET0 =0
+#define clr_IE_EX0               EX0 =0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WDCON_WIDPD          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                 
+#define clr_WDCON_WDTR           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCON_WDCLR          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDCON_WDTF           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDCON_WDTRF          BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WDCON_WPS2           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WDCON_WPS1           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WDCON_WPS0           BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                 
+#define clr_BODCON1_LPBOD1       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_BODCON1_LPBOD0       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODCON1_BODFLT       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_IAPCN_FOEN           IAPN|=0x20
+#define set_IAPCN_FCEN           IAPN|=0x10
+#define set_IAPCN_FCTRL3         IAPN|=0x08
+#define set_IAPCN_FCTRL2         IAPN|=0x04
+#define set_IAPCN_FCTRL1         IAPN|=0x02
+#define set_IAPCN_FCTRL0         IAPN|=0x01
+                                   
+#define clr_IAPCN_FOEN           IAPN&=0xDF
+#define clr_IAPCN_FCEN           IAPN&=0xEF
+#define clr_IAPCN_FCTRL3         IAPN&=0xF7
+#define clr_IAPCN_FCTRL2         IAPN&=0xFB
+#define clr_IAPCN_FCTRL1         IAPN&=0xFD
+#define clr_IAPCN_FCTRL0         IAPN&=0xFE
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7               clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6               clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5               clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4               clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3               clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2               clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1               clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0               clr_SFRS_SFRPAGE;P0M1|=0x01
+                                 
+#define clr_P0M1_7               clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6               clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5               clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4               clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3               clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2               clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1               clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0               clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/
+#define set_P0S_7                set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6                set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5                set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4                set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3                set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2                set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1                set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0                set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7                set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6                set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5                set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4                set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3                set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2                set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1                set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0                set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7               clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6               clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5               clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4               clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3               clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2               clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1               clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0               clr_SFRS_SFRPAGE;P0M2|=0x01
+                                 
+#define clr_P0M2_7               clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6               clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5               clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4               clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3               clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2               clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1               clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0               clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7               set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6               set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5               set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4               set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3               set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2               set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1               set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0               set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7               set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6               set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5               set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4               set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3               set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2               set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1               set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0               set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7                set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6                set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5                set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4                set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3                set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2                set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1                set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0                set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1S_7                set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6                set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5                set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4                set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3                set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2                set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1                set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0                set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7               set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6               set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5               set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4               set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3               set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2               set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1               set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0               set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                 
+#define clr_P1SR_7               set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6               set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5               set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4               set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3               set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2               set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1               set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0               set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_P20UP            P2S|=0x80
+#define set_P2S_T1OE             P2S|=0x08
+#define set_P2S_T0OE             P2S|=0x04
+#define set_P2S_P2S0             P2S|=0x01
+                                 
+#define clr_P2S_P20UP            P2S&=0x7F
+#define clr_P2S_T1OE             P2S&=0xF7
+#define clr_P2S_T0OE             P2S&=0xFB
+#define clr_P2S_P2S0             P2S&=0xFE
+                                 
+/**** IPH    B7H PAGE0 ****/                     
+#define set_IPH_PADCH            clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_IPH_PBODH            clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_IPH_PSH              clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_IPH_PT1H             clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_IPH_PX1H             clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_IPH_PT0H             clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_IPH_PX0H             clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_IPH_PADCH            clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_IPH_PBODH            clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_IPH_PSH              clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_IPH_PT1H             clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_IPH_PX1H             clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_IPH_PT0H             clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_IPH_PX0H             clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/ 
+#define set_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+                                
+#define clr_PWMINTC_INTTYP1      set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTTYP0      set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL2      set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL1      set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_PWMINTC_INTSEL0      set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_IP_PADC              PADC=1
+#define set_IP_PBOD              PBOD=1
+#define set_IP_PS                PS  =1
+#define set_IP_PT1               PT1 =1
+#define set_IP_PX1               PX1 =1
+#define set_IP_PT0               PT0 =1
+#define set_IP_PX0               PX0 =1
+                                 
+#define clr_IP_PADC              PADC=0
+#define clr_IP_PBOD              PBOD=0
+#define clr_IP_PS                PS  =0
+#define clr_IP_PT1               PT1 =0
+#define clr_IP_PX1               PX1 =0
+#define clr_IP_PT0               PT0 =0
+#define clr_IP_PX0               PX0 =0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOC_I2TOCEN       I2TOC|=0x04
+#define set_I2TOC_DIV           I2TOC|=0x02
+#define set_I2TOC_I2TOF         I2TOC|=0x01
+                                
+#define clr_I2TOC_I2TOCEN       I2TOC&=0xFB
+#define clr_I2TOC_DIV           I2TOC&=0xFD
+#define clr_I2TOC_I2TOF         I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CON_I2CEN         I2CEN    = 1
+#define set_I2CON_STA           STA      = 1
+#define set_I2CON_STO           STO      = 1
+#define set_I2CON_SI            SI       = 1
+#define set_I2CON_AA            AA       = 1
+#define set_I2CON_I2CPX         I2CPX    = 1
+            
+#define clr_I2CON_I2CEN         I2CEN    = 0
+#define clr_I2CON_STA           STA      = 0
+#define clr_I2CON_STO           STO      = 0
+#define clr_I2CON_SI            SI       = 0
+#define clr_I2CON_AA            AA       = 0
+#define clr_I2CON_I2CPX         I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_I2ADDR_GC           I2ADDR|= 0x01
+#define clr_I2ADDR_GC           I2ADDR&= 0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON|=0x01
+
+#define clr_T3CON_SMOD_1        clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_T3CON_SMOD0_1       clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_T3CON_BRCK          clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_T3CON_TF3           clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_T3CON_TR3           clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3CON_T3PS2         clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3CON_T3PS1         clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3CON_T3PS0         clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIOCON1_PIO15       set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO13       set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO12       set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIOCON1_PIO11       set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_T2CON_TF2           TF2      = 1
+#define set_T2CON_TR2           TR2      = 1
+#define set_T2CON_CMRL2         CM_RL2   = 1
+                                
+#define clr_T2CON_TF2           TF2      = 0
+#define clr_T2CON_TR2           TR2      = 0
+#define clr_T2CON_CMRL2         CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_T2MOD_LDEN          T2MOD|=0x80
+#define set_T2MOD_T2DIV2        T2MOD|=0x40
+#define set_T2MOD_T2DIV1        T2MOD|=0x20
+#define set_T2MOD_T2DIV0        T2MOD|=0x10
+#define set_T2MOD_CAPCR         T2MOD|=0x08
+#define set_T2MOD_CMPCR         T2MOD|=0x04
+#define set_T2MOD_LDTS1         T2MOD|=0x02
+#define set_T2MOD_LDTS0         T2MOD|=0x01
+                                       
+#define clr_T2MOD_LDEN          T2MOD&=0x7F
+#define clr_T2MOD_T2DIV2        T2MOD&=0xBF
+#define clr_T2MOD_T2DIV1        T2MOD&=0xDF
+#define clr_T2MOD_T2DIV0        T2MOD&=0xEF
+#define clr_T2MOD_CAPCR         T2MOD&=0xF7
+#define clr_T2MOD_CMPCR         T2MOD&=0xFB
+#define clr_T2MOD_LDTS1         T2MOD&=0xFD
+#define clr_T2MOD_LDTS0         T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L  CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_PSW_CY              CY  = 1
+#define set_PSW_AC              AC  = 1
+#define set_PSW_F0              F0  = 1 
+#define set_PSW_RS1             RS1 = 1
+#define set_PSW_RS0             RS0 = 1
+#define set_PSW_OV              OV   = 1
+#define set_PSW_P               P    = 1
+                                
+#define clr_PSW_CY              CY  = 0
+#define clr_PSW_AC              AC  = 0
+#define clr_PSW_F0              F0  = 0 
+#define clr_PSW_RS1             RS1 = 0
+#define clr_PSW_RS0             RS0 = 0
+#define clr_PSW_OV              OV   = 0
+#define clr_PSW_P               P    = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** FBD    D7H ****/
+#define set_FBD_FBF             FBD|=0x80
+#define set_FBD_FBINLS          FBD|=0x40
+#define set_FBD_FBD5            FBD|=0x20
+#define set_FBD_FBD4            FBD|=0x10
+#define set_FBD_FBD3            FBD|=0x08
+#define set_FBD_FBD2            FBD|=0x04
+#define set_FBD_FBD1            FBD|=0x02
+#define set_FBD_FBD0            FBD|=0x01
+                                
+#define clr_FBD_FBF             FBD&=0x7F
+#define clr_FBD_FBINLS          FBD&=0xBF
+#define clr_FBD_FBD5            FBD&=0xDF
+#define clr_FBD_FBD4            FBD&=0xEF
+#define clr_FBD_FBD3            FBD&=0xF7
+#define clr_FBD_FBD2            FBD&=0xFB
+#define clr_FBD_FBD1            FBD&=0xFD
+#define clr_FBD_FBD0            FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMCON0_PWMRUN      PWMRUN   = 1
+#define set_PWMCON0_LOAD        LOAD     = 1
+#define set_PWMCON0_PWMF        PWMF     = 1
+#define set_PWMCON0_CLRPWM      CLRPWM   = 1
+                                
+#define clr_PWMCON0_PWMRUN      PWMRUN   = 0
+#define clr_PWMCON0_LOAD        LOAD     = 0
+#define clr_PWMCON0_PWMF        PWMF     = 0 
+#define clr_PWMCON0_CLRPWM      CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIOCON0_PIO05       PIOCON0|=0x20
+#define set_PIOCON0_PIO04       PIOCON0|=0x10
+#define set_PIOCON0_PIO03       PIOCON0|=0x08
+#define set_PIOCON0_PIO02       PIOCON0|=0x04
+#define set_PIOCON0_PIO01       PIOCON0|=0x02
+#define set_PIOCON0_PIO00       PIOCON0|=0x01
+                                
+#define clr_PIOCON0_PIO05       PIOCON0&=0xDF
+#define clr_PIOCON0_PIO04       PIOCON0&=0xEF
+#define clr_PIOCON0_PIO03       PIOCON0&=0xF7
+#define clr_PIOCON0_PIO02       PIOCON0&=0xFB
+#define clr_PIOCON0_PIO01       PIOCON0&=0xFD
+#define clr_PIOCON0_PIO00       PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMCON1_PWMMOD1     PWMCON1|=0x80
+#define set_PWMCON1_PWMMOD0     PWMCON1|=0x40
+#define set_PWMCON1_GP          PWMCON1|=0x20
+#define set_PWMCON1_PWMTYP      PWMCON1|=0x10
+#define set_PWMCON1_FBINEN      PWMCON1|=0x08
+#define set_PWMCON1_PWMDIV2     PWMCON1|=0x04 
+#define set_PWMCON1_PWMDIV1     PWMCON1|=0x02
+#define set_PWMCON1_PWMDIV0     PWMCON1|=0x01
+                                
+#define clr_PWMCON1_PWMMOD1     PWMCON1&=0x7F
+#define clr_PWMCON1_PWMMOD0     PWMCON1&=0xBF
+#define clr_PWMCON1_GP          PWMCON1&=0xDF
+#define clr_PWMCON1_PWMTYP      PWMCON1&=0xEF
+#define clr_PWMCON1_FBINEN      PWMCON1&=0xF7
+#define clr_PWMCON1_PWMDIV2     PWMCON1&=0xFB 
+#define clr_PWMCON1_PWMDIV1     PWMCON1&=0xFD
+#define clr_PWMCON1_PWMDIV0     PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1|=0x40
+#define set_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1|=0x08
+#define set_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1|=0x04
+#define set_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1|=0x02
+#define set_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1|=0x01
+
+#define clr_ADCCON1_STADCPX     clr_SFRS_SFRPAGE;ADCCON1&=0xBF
+#define clr_ADCCON1_ETGTYP1     clr_SFRS_SFRPAGE;ADCCON1&=0xF7
+#define clr_ADCCON1_ETGTYP0     clr_SFRS_SFRPAGE;ADCCON1&=0xFB                                                   
+#define clr_ADCCON1_ADCEX       clr_SFRS_SFRPAGE;ADCCON1&=0xFD
+#define clr_ADCCON1_ADCEN       clr_SFRS_SFRPAGE;ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/                    
+#define set_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2|=0x80
+#define set_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2|=0x40
+#define set_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2|=0x20
+#define set_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2|=0x10
+
+#define clr_ADCCON2_ADFBEN      clr_SFRS_SFRPAGE;ADCCON2&=0x7F
+#define clr_ADCCON2_ADCMPOP     clr_SFRS_SFRPAGE;ADCCON2&=0xBF
+#define clr_ADCCON2_ADCMPEN     clr_SFRS_SFRPAGE;ADCCON2&=0xDF
+#define clr_ADCCON2_ADCMPO      clr_SFRS_SFRPAGE;ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=1
+#define set_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=1
+#define set_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=1
+#define set_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=1
+#define set_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=1
+#define set_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=1
+#define set_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=1
+#define set_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=1
+
+#define clr_ADCCON0_ADCF        clr_SFRS_SFRPAGE;ADCF=0
+#define clr_ADCCON0_ADCS        clr_SFRS_SFRPAGE;ADCS=0
+#define clr_ADCCON0_ETGSEL1     clr_SFRS_SFRPAGE;ETGSEL1=0
+#define clr_ADCCON0_ETGSEL0     clr_SFRS_SFRPAGE;ETGSEL0=0
+#define clr_ADCCON0_ADCHS3      clr_SFRS_SFRPAGE;ADCHS3=0
+#define clr_ADCCON0_ADCHS2      clr_SFRS_SFRPAGE;ADCHS2=0
+#define clr_ADCCON0_ADCHS1      clr_SFRS_SFRPAGE;ADCHS1=0
+#define clr_ADCCON0_ADCHS0      clr_SFRS_SFRPAGE;ADCHS0=0
+
+/**** PICON  E9H ****/
+#define set_PICON_PIT67         PICON|=0x80
+#define set_PICON_PIT45         PICON|=0x40
+#define set_PICON_PIT3          PICON|=0x20
+#define set_PICON_PIT2          PICON|=0x10
+#define set_PICON_PIT1          PICON|=0x08
+#define set_PICON_PIT0          PICON|=0x04
+#define set_PICON_PIPS1         PICON|=0x02
+#define set_PICON_PIPS0         PICON|=0x01
+                                  
+#define clr_PICON_PIT67         PICON&=0x7F
+#define clr_PICON_PIT45         PICON&=0xBF
+#define clr_PICON_PIT3          PICON&=0xDF
+#define clr_PICON_PIT2          PICON&=0xEF
+#define clr_PICON_PIT1          PICON&=0xF7
+#define clr_PICON_PIT0          PICON&=0xFB
+#define clr_PICON_PIPS1         PICON&=0xFD
+#define clr_PICON_PIPS0         PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN_PINEN7        PINEN|=0x80
+#define set_PINEN_PINEN6        PINEN|=0x40
+#define set_PINEN_PINEN5        PINEN|=0x20
+#define set_PINEN_PINEN4        PINEN|=0x10
+#define set_PINEN_PINEN3        PINEN|=0x08
+#define set_PINEN_PINEN2        PINEN|=0x04
+#define set_PINEN_PINEN1        PINEN|=0x02
+#define set_PINEN_PINEN0        PINEN|=0x01
+                                  
+#define clr_PINEN_PINEN7        PINEN&=0x7F
+#define clr_PINEN_PINEN6        PINEN&=0xBF
+#define clr_PINEN_PINEN5        PINEN&=0xDF
+#define clr_PINEN_PINEN4        PINEN&=0xEF
+#define clr_PINEN_PINEN3        PINEN&=0xF7
+#define clr_PINEN_PINEN2        PINEN&=0xFB
+#define clr_PINEN_PINEN1        PINEN&=0xFD
+#define clr_PINEN_PINEN0        PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN_PIPEN7        PIPEN|=0x80
+#define set_PIPEN_PIPEN6        PIPEN|=0x40
+#define set_PIPEN_PIPEN5        PIPEN|=0x20
+#define set_PIPEN_PIPEN4        PIPEN|=0x10
+#define set_PIPEN_PIPEN3        PIPEN|=0x08
+#define set_PIPEN_PIPEN2        PIPEN|=0x04
+#define set_PIPEN_PIPEN1        PIPEN|=0x02
+#define set_PIPEN_PIPEN0        PIPEN|=0x01
+                                  
+#define clr_PIPEN_PIPEN7        PIPEN&=0x7F
+#define clr_PIPEN_PIPEN6        PIPEN&=0xBF
+#define clr_PIPEN_PIPEN5        PIPEN&=0xDF
+#define clr_PIPEN_PIPEN4        PIPEN&=0xEF
+#define clr_PIPEN_PIPEN3        PIPEN&=0xF7
+#define clr_PIPEN_PIPEN2        PIPEN&=0xFB
+#define clr_PIPEN_PIPEN1        PIPEN&=0xFD
+#define clr_PIPEN_PIPEN0        PIPEN&=0xFE
+
+/**** PIF ECH ****/
+#define set_PIF_PIF7             PIF|=0x80
+#define set_PIF_PIF6             PIF|=0x40
+#define set_PIF_PIF5             PIF|=0x20
+#define set_PIF_PIF4             PIF|=0x10
+#define set_PIF_PIF3             PIF|=0x08
+#define set_PIF_PIF2             PIF|=0x04
+#define set_PIF_PIF1             PIF|=0x02
+#define set_PIF_PIF0             PIF|=0x01
+                                 
+#define clr_PIF_PIF7             PIF&=0x7F
+#define clr_PIF_PIF6             PIF&=0xBF
+#define clr_PIF_PIF5             PIF&=0xDF
+#define clr_PIF_PIF4             PIF&=0xEF
+#define clr_PIF_PIF3             PIF&=0xF7
+#define clr_PIF_PIF2             PIF&=0xFB
+#define clr_PIF_PIF1             PIF&=0xFD
+#define clr_PIF_PIF0             PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_EIP_PT2             EIP|=0x80
+#define set_EIP_PSPI            EIP|=0x40
+#define set_EIP_PFB             EIP|=0x20
+#define set_EIP_PWDT            EIP|=0x10
+#define set_EIP_PPWM            EIP|=0x08
+#define set_EIP_PCAP            EIP|=0x04
+#define set_EIP_PPI             EIP|=0x02
+#define set_EIP_PI2C            EIP|=0x01
+                                   
+#define clr_EIP_PT2             EIP&=0x7F
+#define clr_EIP_PSPI            EIP&=0xBF
+#define clr_EIP_PFB             EIP&=0xDF
+#define clr_EIP_PWDT            EIP&=0xEF
+#define clr_EIP_PPWM            EIP&=0xF7
+#define clr_EIP_PCAP            EIP&=0xFB
+#define clr_EIP_PPI             EIP&=0xFD
+#define clr_EIP_PI2C            EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAPCON3_CAP13       CAPCON3|=0x80
+#define set_CAPCON3_CAP12       CAPCON3|=0x40
+#define set_CAPCON3_CAP11       CAPCON3|=0x20
+#define set_CAPCON3_CAP10       CAPCON3|=0x10
+#define set_CAPCON3_CAP03       CAPCON3|=0x08
+#define set_CAPCON3_CAP02       CAPCON3|=0x04
+#define set_CAPCON3_CAP01       CAPCON3|=0x02
+#define set_CAPCON3_CAP00       CAPCON3|=0x01
+                                
+#define clr_CAPCON3_CAP13       CAPCON3&=0x7F
+#define clr_CAPCON3_CAP12       CAPCON3&=0xBF
+#define clr_CAPCON3_CAP11       CAPCON3&=0xDF
+#define clr_CAPCON3_CAP10       CAPCON3&=0xEF
+#define clr_CAPCON3_CAP03       CAPCON3&=0xF7
+#define clr_CAPCON3_CAP02       CAPCON3&=0xFB
+#define clr_CAPCON3_CAP01       CAPCON3&=0xFD
+#define clr_CAPCON3_CAP00       CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAPCON4_CAP23       CAPCON4|=0x08
+#define set_CAPCON4_CAP22       CAPCON4|=0x04
+#define set_CAPCON4_CAP21       CAPCON4|=0x02
+#define set_CAPCON4_CAP20       CAPCON4|=0x01
+                                
+#define clr_CAPCON4_CAP23       CAPCON4&=0xF7
+#define clr_CAPCON4_CAP22       CAPCON4&=0xFB
+#define clr_CAPCON4_CAP21       CAPCON4&=0xFD
+#define clr_CAPCON4_CAP20       CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR|=0x01
+                                
+#define clr_SPCR_SSOE           clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPCR_SPIEN          clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_SPCR_LSBFE          clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_SPCR_MSTR           clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_SPCR_CPOL           clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_SPCR_CPHA           clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPCR_SPR1           clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPCR_SPR0           clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPCR2_SPIS1         set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPCR2_SPIS0         set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPSR_SPIF           SPSR|=0x80
+#define set_SPSR_WCOL           SPSR|=0x40
+#define set_SPSR_SPIOVF         SPSR|=0x20
+#define set_SPSR_MODF           SPSR|=0x10
+#define set_SPSR_DISMODF        SPSR|=0x08
+                                   
+#define clr_SPSR_SPIF           SPSR&=0x7F
+#define clr_SPSR_WCOL           SPSR&=0xBF
+#define clr_SPSR_SPIOVF         SPSR&=0xDF
+#define clr_SPSR_MODF           SPSR&=0xEF
+#define clr_SPSR_DISMODF        SPSR&=0xF7
+
+/**** SPDR    F5H PAGE0 ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                
+#define clr_AINDIDS_P11DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_AINDIDS_P03DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_AINDIDS_P04DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_AINDIDS_P05DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_AINDIDS_P06DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_AINDIDS_P07DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_AINDIDS_P30DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_AINDIDS_P17DIDS     clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH|=0x01
+                                   
+#define clr_EIPH_PT2H           clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_EIPH_PSPIH          clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_EIPH_PFBH           clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_EIPH_PWDTH          clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_EIPH_PPWMH          clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_EIPH_PCAPH          clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_EIPH_PPIH           clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_EIPH_PI2CH          clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_SCON_1_FE_1         FE_1  = 1
+#define set_SCON_1_SM1_1        SM1_1 = 1
+#define set_SCON_1_SM2_1        SM2_1 = 1
+#define set_SCON_1_REN_1        REN_1 = 1
+#define set_SCON_1_TB8_1        TB8_1 = 1
+#define set_SCON_1_RB8_1        RB8_1 = 1
+#define set_SCON_1_TI_1         TI_1  = 1
+#define set_SCON_1_RI_1         RI_1  = 1
+                                
+#define clr_SCON_1_FE_1         FE_1  = 0
+#define clr_SCON_1_SM1_1        SM1_1 = 0
+#define clr_SCON_1_SM2_1        SM2_1 = 0
+#define clr_SCON_1_REN_1        REN_1 = 0
+#define clr_SCON_1_TB8_1        TB8_1 = 0
+#define clr_SCON_1_RB8_1        RB8_1 = 0
+#define clr_SCON_1_TI_1         TI_1  = 0
+#define clr_SCON_1_RI_1         RI_1  = 0
+
+/**** PDTEN    F9H ****/
+#define set_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDTEN_PDT45EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDTEN_PDT23EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDTEN_PDT01EN       BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN_5               PMEN|=0x20
+#define set_PMEN_4               PMEN|=0x10
+#define set_PMEN_3               PMEN|=0x08
+#define set_PMEN_2               PMEN|=0x04
+#define set_PMEN_1               PMEN|=0x02
+#define set_PMEN_0               PMEN|=0x01
+                                    
+#define clr_PMEN_5               PMEN&=0xDF
+#define clr_PMEN_4               PMEN&=0xEF
+#define clr_PMEN_3               PMEN&=0xF7
+#define clr_PMEN_2               PMEN&=0xFB
+#define clr_PMEN_1               PMEN&=0xFD
+#define clr_PMEN_0               PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD_7                PMD|=0x80
+#define set_PMD_6                PMD|=0x40
+#define set_PMD_5                PMD|=0x20
+#define set_PMD_4                PMD|=0x10
+#define set_PMD_3                PMD|=0x08
+#define set_PMD_2                PMD|=0x04
+#define set_PMD_1                PMD|=0x02
+#define set_PMD_0                PMD|=0x01
+                                   
+#define clr_PMD_7                PMD&=0x7F
+#define clr_PMD_6                PMD&=0xBF
+#define clr_PMD_5                PMD&=0xDF
+#define clr_PMD_4                PMD&=0xEF
+#define clr_PMD_3                PMD&=0xF7
+#define clr_PMD_2                PMD&=0xFB
+#define clr_PMD_1                PMD&=0xFD
+#define clr_PMD_0                PMD&=0xFE
+
+/****  EIP1     FEH PAGE0 ****/                   
+#define set_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1|=0x01
+                                   
+#define clr_EIP1_PWKT           clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_EIP1_PT3            clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_EIP1_PS_1           clr_SFRS_SFRPAGE;EIP1&=0xFE
+
+/**** EIPH1    FFH ****/                
+#define set_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                  
+#define clr_EIPH1_PWKTH         clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_EIPH1_PT3H          clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_EIPH1_PSH_1         clr_SFRS_SFRPAGE;EIPH1&=0xFE
+
+ /********************************************************/
+/*  <Define rule II> "set or clr _ register bit name     */
+/*********************************************************/
+/**** P0    80H ****/
+#define set_P00                 P00=1
+#define set_P01                 P01=1
+#define set_P02                 P02=1
+#define set_P03                 P03=1
+#define set_P04                 P04=1
+#define set_P05                 P05=1
+#define set_P06                 P06=1
+#define set_P07                 P07=1
+                                
+#define clr_P00                 P00=0
+#define clr_P01                 P01=0
+#define clr_P02                 P02=0
+#define clr_P03                 P03=0
+#define clr_P04                 P04=0
+#define clr_P05                 P05=0
+#define clr_P06                 P06=0
+#define clr_P07                 P07=0
+
+/**** SP    81H ****/ 
+/**** DPH  82H ****/ 
+/**** DPL  83H ****/ 
+/**** RWK  86H ****/ 
+
+/**** PCON  87H ****/
+#define set_SMOD                PCON|=0x80
+#define set_SMOD0               PCON|=0x40
+#define set_POF                 PCON|=0x10
+#define set_GF1                 PCON|=0x08
+#define set_GF0                 PCON|=0x04 
+#define set_PD                  PCON|=0x02
+#define set_IDL                 PCON|=0x01
+                                    
+#define clr_SMOD                PCON&=0x7F
+#define clr_SMOD0               PCON&=0xBF
+#define clr_POF                 PCON&=0xEF
+#define clr_GF1                 PCON&=0xF7
+#define clr_GF0                 PCON&=0xFB 
+#define clr_PD                  PCON&=0xFD
+#define clr_IDL                 PCON&=0xFE
+
+/**** TCON    88H ****/
+#define set_TF1                 TF1=1
+#define set_TR1                 TR1=1
+#define set_TF0                 TF0=1
+#define set_TR0                 TR0=1
+#define set_IE1                 IE1=1
+#define set_IT1                 IT1=1
+#define set_IE0                 IE0=1
+#define set_IT0                 IT0=1
+                                
+#define clr_TF1                 TF1=0
+#define clr_TR1                 TR1=0
+#define clr_TF0                 TF0=0
+#define clr_TR0                 TR0=0
+#define clr_IE1                 IE1=0
+#define clr_IT1                 IT1=0
+#define clr_IE0                 IE0=0
+#define clr_IT0                 IT0=0
+
+/**** TMOD    89H ****/ 
+#define set_GATE_T1             TMOD|=0x80
+#define set_CT_T1               TMOD|=0x40
+#define set_M1_T1               TMOD|=0x20
+#define set_M0_T1               TMOD|=0x10
+#define set_GATE_T0             TMOD|=0x08
+#define set_CT_T0               TMOD|=0x04
+#define set_M1_T0               TMOD|=0x02
+#define set_M0_T0               TMOD|=0x01
+                                    
+#define clr_GATE_T1             TMOD&=0x7F
+#define clr_CT_T1               TMOD&=0xBF
+#define clr_M1_T1               TMOD&=0xDF
+#define clr_M0_T1               TMOD&=0xEF
+#define clr_GATE_T0             TMOD&=0xF7
+#define clr_CT_T0               TMOD&=0xFB
+#define clr_M1_T0               TMOD&=0xFD
+#define clr_M0_T0               TMOD&=0xFE
+
+/**** TH1    8AH ****/ 
+/**** TH0    8BH ****/ 
+/**** TL1    8CH ****/
+/**** TL0    8DH ****/ 
+
+/**** CKCON  8EH ****/
+#define set_PWMCKS              CKCON|=0x40
+#define set_T1M                 CKCON|=0x10
+#define set_T0M                 CKCON|=0x08
+#define set_CLOEN               CKCON|=0x02
+                                     
+#define clr_PWMCKS              CKCON&=0xBF
+#define clr_T1M                 CKCON&=0xEF
+#define clr_T0M                 CKCON&=0xF7
+#define clr_CLOEN               CKCON&=0xFD
+
+/**** WKCON  8FH ****/
+#define set_WKTCK               WKCON|=0x20
+#define set_WKTF                WKCON|=0x10
+#define set_WKTR                WKCON|=0x08
+#define set_WKPS2               WKCON|=0x04
+#define set_WKPS1               WKCON|=0x02
+#define set_WKPS0               WKCON|=0x01
+                                     
+#define clr_WKTCK               WKCON&=0xDF
+#define clr_WKTF                WKCON&=0xEF
+#define clr_WKTR                WKCON&=0xF7
+#define clr_WKPS2               WKCON&=0xFB
+#define clr_WKPS1               WKCON&=0xFD
+#define clr_WKPS0               WKCON&=0xFE
+
+/**** P1    90H ****/
+#define set_P10                 P10=1
+#define set_P11                 P11=1
+#define set_P12                 P12=1
+#define set_P13                 P13=1
+#define set_P14                 P14=1
+#define set_P15                 P15=1
+#define set_P16                 P16=1
+#define set_P17                 P17=1
+                                
+#define clr_P10                 P10=0
+#define clr_P11                 P11=0
+#define clr_P12                 P12=0
+#define clr_P13                 P13=0
+#define clr_P14                 P14=0
+#define clr_P15                 P15=0
+#define clr_P16                 P16=0
+#define clr_P17                 P17=0
+
+/****SFRS    91H ****/
+#define set_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=1;EA=BIT_TMP
+#define clr_SFRPAGE             BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;SFRS=0;EA=BIT_TMP
+
+/****CAPCON0  92H ****/
+#define set_CAPEN2              CAPCON0|=0x40
+#define set_CAPEN1              CAPCON0|=0x20
+#define set_CAPEN0              CAPCON0|=0x10
+#define set_CAPF2               CAPCON0|=0x04
+#define set_CAPF1               CAPCON0|=0x02
+#define set_CAPF0               CAPCON0|=0x01
+                                
+#define clr_CAPEN2              CAPCON0&=0xBF
+#define clr_CAPEN1              CAPCON0&=0xDF
+#define clr_CAPEN0              CAPCON0&=0xEF
+#define clr_CAPF2               CAPCON0&=0xFB
+#define clr_CAPF1               CAPCON0&=0xFD
+#define clr_CAPF0               CAPCON0&=0xFE
+
+/**** CAPCON1  93H ****/
+#define set_CAP2LS1             CAPCON1|=0x20
+#define set_CAP2LS0             CAPCON1|=0x10
+#define set_CAP1LS1             CAPCON1|=0x08
+#define set_CAP1LS0             CAPCON1|=0x04
+#define set_CAP0LS1             CAPCON1|=0x02
+#define set_CAP0LS0             CAPCON1|=0x01
+                                
+#define clr_CAP2LS1             CAPCON1&=0xDF
+#define clr_CAP2LS0             CAPCON1&=0xEF
+#define clr_CAP1LS1             CAPCON1&=0xF7
+#define clr_CAP1LS0             CAPCON1&=0xFB
+#define clr_CAP0LS1             CAPCON1&=0xFD
+#define clr_CAP0LS0             CAPCON1&=0xFE
+
+/**** CAPCON2    94H ****/
+#define set_ENF2                CAPCON2|=0x40
+#define set_ENF1                CAPCON2|=0x20
+#define set_ENF0                CAPCON2|=0x10
+                                       
+#define clr_ENF2                CAPCON2&=0xBF
+#define clr_ENF1                CAPCON2&=0xDF
+#define clr_ENF0                CAPCON2&=0xEF
+
+/**** CKDIV    95H ****/
+
+/**** CKSWT    96H ****/
+#define set_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x20;EA=BIT_TMP
+#define set_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x10;EA=BIT_TMP
+#define set_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x08;EA=BIT_TMP
+#define set_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x04;EA=BIT_TMP
+#define set_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT|=0x02;EA=BIT_TMP
+                                
+#define clr_HIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xDF;EA=BIT_TMP
+#define clr_LIRCST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xEF;EA=BIT_TMP
+#define clr_ECLKST              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xF7;EA=BIT_TMP
+#define clr_OSC1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFB;EA=BIT_TMP
+#define clr_OSC0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKSWT&=0xFD;EA=BIT_TMP
+
+/**** CKEN   97H **** TA protect register ****/
+#define set_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x80;EA=BIT_TMP
+#define set_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x40;EA=BIT_TMP
+#define set_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x20;EA=BIT_TMP
+#define set_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN|=0x01;EA=BIT_TMP
+                                
+#define clr_EXTEN1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0x7F;EA=BIT_TMP
+#define clr_EXTEN0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xBF;EA=BIT_TMP
+#define clr_HIRCEN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xDF;EA=BIT_TMP
+#define clr_CKSWTF              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CKEN&=0xFE;EA=BIT_TMP
+
+/**** SCON    98H ****/
+#define set_FE                  FE    = 1
+#define set_SM1                 SM1   = 1
+#define set_SM2                 SM2   = 1
+#define set_REN                 REN   = 1
+#define set_TB8                 TB8   = 1
+#define set_RB8                 RB8   = 1
+#define set_TI                  TI    = 1
+#define set_RI                  RI    = 1
+                                
+#define clr_FE                  FE    = 0
+#define clr_SM1                 SM1   = 0
+#define clr_SM2                 SM2   = 0
+#define clr_REN                 REN   = 0
+#define clr_TB8                 TB8   = 0
+#define clr_RB8                 RB8   = 0
+#define clr_TI                  TI    = 0
+#define clr_RI                  RI    = 0
+
+/**** SBUF    99H ****/
+/**** SBUF_1  9AH ****/
+
+/**** EIE    9BH ****/                      
+#define set_ET2                 EIE|=0x80
+#define set_ESPI                EIE|=0x40
+#define set_EFB                 EIE|=0x20
+#define set_EWDT                EIE|=0x10
+#define set_EPWM                EIE|=0x08
+#define set_ECAP                EIE|=0x04
+#define set_EPI                 EIE|=0x02
+#define set_EI2C                EIE|=0x01
+                                   
+#define clr_ET2                 EIE&=0x7F
+#define clr_ESPI                EIE&=0xBF
+#define clr_EFB                 EIE&=0xDF
+#define clr_EWDT                EIE&=0xEF
+#define clr_EPWM                EIE&=0xF7
+#define clr_ECAP                EIE&=0xFB
+#define clr_EPI                 EIE&=0xFD
+#define clr_EI2C                EIE&=0xFE
+
+/**** EIE1    9CH ****/                      
+#define set_EWKT                EIE1|=0x04
+#define set_ET3                 EIE1|=0x02
+#define set_ES_1                EIE1|=0x01
+                                    
+#define clr_EWKT                EIE1&=0xFB
+#define clr_ET3                 EIE1&=0xFD
+#define clr_ES_1                EIE1&=0xFE
+                            
+/**** CHPCON    9DH ****  TA protect register ****/
+#define set_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x80;EA=BIT_TMP
+#define set_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x40;EA=BIT_TMP
+#define set_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x02;EA=BIT_TMP
+#define set_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON|=0x01;EA=BIT_TMP
+                                
+#define clr_SWRST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0x7F;EA=BIT_TMP
+#define clr_IAPFF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xBF;EA=BIT_TMP
+#define clr_BS                  BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFD;EA=BIT_TMP
+#define clr_IAPEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;CHPCON&=0xFE;EA=BIT_TMP
+
+/**** P2    A0H ****/
+
+/**** AUXR1  A2H ****/
+#define set_SWRF                AUXR1|=0x80
+#define set_RSTPINF             AUXR1|=0x40
+#define set_HARDF               AUXR1|=0x20
+#define set_GF2                 AUXR1|=0x08
+#define set_UART0PX             AUXR1|=0x04
+#define set_DPS                 AUXR1|=0x01
+                                     
+#define clr_SWRF                AUXR1&=0x7F
+#define clr_RSTPINF             AUXR1&=0xBF
+#define clr_HARDF               AUXR1&=0xDF
+#define clr_GF2                 AUXR1&=0xF7
+#define clr_UART0PX             AUXR1&=0xFB
+#define clr_DPS                 AUXR1&=0xFE
+
+/**** BODCON0  A3H ****  TA protect register ****/
+#define set_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x80;EA=BIT_TMP
+#define set_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x20;EA=BIT_TMP
+#define set_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x10;EA=BIT_TMP
+#define set_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x08;EA=BIT_TMP
+#define set_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x04;EA=BIT_TMP
+#define set_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x02;EA=BIT_TMP
+#define set_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0|=0x01;EA=BIT_TMP
+                                
+#define clr_BODEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0x7F;EA=BIT_TMP
+#define clr_BOV2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xBF;EA=BIT_TMP
+#define clr_BOV1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xDF;EA=BIT_TMP
+#define clr_BOV0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xEF;EA=BIT_TMP
+#define clr_BOF                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xF7;EA=BIT_TMP
+#define clr_BORST               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFB;EA=BIT_TMP
+#define clr_BORF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFD;EA=BIT_TMP
+#define clr_BOS                 BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON0&=0xFE;EA=BIT_TMP
+
+/**** IAPTRG    A4H  ****  TA protect register ****/
+#define set_IAPGO               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPTRG|=0x01;EA=BIT_TMP
+
+/**** IAPUEN    A5H **** TA protect register ****/
+#define set_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x04;EA=BIT_TMP
+#define set_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x02;EA=BIT_TMP
+#define set_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN|=0x01;EA=BIT_TMP
+                                
+#define clr_CFUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFB;EA=BIT_TMP
+#define clr_LDUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFD;EA=BIT_TMP
+#define clr_APUEN               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;IAPUEN&=0xFE;EA=BIT_TMP
+
+/**** IAPAL  A6H ****/
+/**** IAPAH  A7H ****/
+
+/**** IE      A8H ****/
+#define set_EA                  EA       = 1
+#define set_EADC                EADC     = 1
+#define set_EBOD                EBOD     = 1
+#define set_ES                  ES       = 1
+#define set_ET1                 ET1      = 1
+#define set_EX1                 EX1      = 1
+#define set_ET0                 ET0      = 1
+#define set_EX0                 EX0      = 1
+                                
+#define clr_EA                  EA       = 0
+#define clr_EADC                EADC     = 0
+#define clr_EBOD                EBOD     = 0
+#define clr_ES                  ES       = 0
+#define clr_ET1                 ET1      = 0
+#define clr_EX1                 EX1      = 0
+#define clr_ET0                 ET0      = 0
+#define clr_EX0                 EX0      = 0
+
+/**** SADDR    A9H ****/
+
+/**** WDCON    AAH **** TA protect register ****/
+#define set_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x80;EA=BIT_TMP
+#define set_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x40;EA=BIT_TMP
+#define set_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x20;EA=BIT_TMP
+#define set_WIDPD               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x10;EA=BIT_TMP
+#define set_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x08;EA=BIT_TMP
+#define set_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x04;EA=BIT_TMP
+#define set_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x02;EA=BIT_TMP
+#define set_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON|=0x01;EA=BIT_TMP
+                                
+#define clr_WDTR                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0x7F;EA=BIT_TMP
+#define clr_WDCLR               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xBF;EA=BIT_TMP
+#define clr_WDTF                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xDF;EA=BIT_TMP
+#define clr_WDTRF               BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xF7;EA=BIT_TMP
+#define clr_WPS2                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFB;EA=BIT_TMP
+#define clr_WPS1                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFD;EA=BIT_TMP
+#define clr_WPS0                BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;WDCON&=0xFE;EA=BIT_TMP
+
+/**** BODCON1 ABH **** TA protect register ****/
+#define set_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x04;EA=BIT_TMP
+#define set_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x02;EA=BIT_TMP
+#define set_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1|=0x01;EA=BIT_TMP
+                                
+#define clr_LPBOD1              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFB;EA=BIT_TMP
+#define clr_LPBOD0              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFD;EA=BIT_TMP
+#define clr_BODFLT              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;BODCON1&=0xFE;EA=BIT_TMP
+
+/**** P3M1    ACH PAGE0 ****/
+#define set_P3M1_0              clr_SFRS_SFRPAGE;P3M1|=0x01
+#define clr_P3M1_0              clr_SFRS_SFRPAGE;P3M1&=0xFE
+
+/**** P3S    ACH PAGE1 ****/ 
+#define set_P3S_0               set_SFRS_SFRPAGE;P3S|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3S_0               set_SFRS_SFRPAGE;P3S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P3M2    ADH PAGE0 ****/
+#define set_P3M2_0              clr_SFRS_SFRPAGE;P3M2|=0x01
+#define clr_P3M2_0              clr_SFRS_SFRPAGE;P3M2&=0xFE
+
+/**** P3SR    ADH PAGE1 ****/ 
+#define set_P3SR_0              set_SFRS_SFRPAGE;P3SR|=0x01;clr_SFRS_SFRPAGE
+#define clr_P3SR_0              set_SFRS_SFRPAGE;P3SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IAPFD  AEH ****/
+
+/**** IAPCN  AFH ****/
+#define set_FOEN                IAPN|=0x20
+#define set_FCEN                IAPN|=0x10
+#define set_FCTRL3              IAPN|=0x08
+#define set_FCTRL2              IAPN|=0x04
+#define set_FCTRL1              IAPN|=0x02
+#define set_FCTRL0              IAPN|=0x01
+                                      
+#define clr_FOEN                IAPN&=0xDF
+#define clr_FCEN                IAPN&=0xEF
+#define clr_FCTRL3              IAPN&=0xF7
+#define clr_FCTRL2              IAPN&=0xFB
+#define clr_FCTRL1              IAPN&=0xFD
+#define clr_FCTRL0              IAPN&=0xFE
+
+/**** P3    B0H ****/
+#define set_P30                 P30= 1
+#define clr_P30                 P30= 0
+
+/**** P0M1  B1H PAGE0 ****/
+#define set_P0M1_7              clr_SFRS_SFRPAGE;P0M1|=0x80
+#define set_P0M1_6              clr_SFRS_SFRPAGE;P0M1|=0x40
+#define set_P0M1_5              clr_SFRS_SFRPAGE;P0M1|=0x20 
+#define set_P0M1_4              clr_SFRS_SFRPAGE;P0M1|=0x10
+#define set_P0M1_3              clr_SFRS_SFRPAGE;P0M1|=0x08
+#define set_P0M1_2              clr_SFRS_SFRPAGE;P0M1|=0x04
+#define set_P0M1_1              clr_SFRS_SFRPAGE;P0M1|=0x02
+#define set_P0M1_0              clr_SFRS_SFRPAGE;P0M1|=0x01
+                                
+#define clr_P0M1_7              clr_SFRS_SFRPAGE;P0M1&=0x7F
+#define clr_P0M1_6              clr_SFRS_SFRPAGE;P0M1&=0xBF
+#define clr_P0M1_5              clr_SFRS_SFRPAGE;P0M1&=0xDF
+#define clr_P0M1_4              clr_SFRS_SFRPAGE;P0M1&=0xEF
+#define clr_P0M1_3              clr_SFRS_SFRPAGE;P0M1&=0xF7
+#define clr_P0M1_2              clr_SFRS_SFRPAGE;P0M1&=0xFB
+#define clr_P0M1_1              clr_SFRS_SFRPAGE;P0M1&=0xFD
+#define clr_P0M1_0              clr_SFRS_SFRPAGE;P0M1&=0xFE
+
+/**** P0S  B2H PAGE1 ****/ 
+#define set_P0S_7               set_SFRS_SFRPAGE;P0S|=0x80;clr_SFRS_SFRPAGE
+#define set_P0S_6               set_SFRS_SFRPAGE;P0S|=0x40;clr_SFRS_SFRPAGE
+#define set_P0S_5               set_SFRS_SFRPAGE;P0S|=0x20;clr_SFRS_SFRPAGE
+#define set_P0S_4               set_SFRS_SFRPAGE;P0S|=0x10;clr_SFRS_SFRPAGE
+#define set_P0S_3               set_SFRS_SFRPAGE;P0S|=0x08;clr_SFRS_SFRPAGE
+#define set_P0S_2               set_SFRS_SFRPAGE;P0S|=0x04;clr_SFRS_SFRPAGE
+#define set_P0S_1               set_SFRS_SFRPAGE;P0S|=0x02;clr_SFRS_SFRPAGE
+#define set_P0S_0               set_SFRS_SFRPAGE;P0S|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0S_7               set_SFRS_SFRPAGE;P0S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0S_6               set_SFRS_SFRPAGE;P0S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0S_5               set_SFRS_SFRPAGE;P0S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0S_4               set_SFRS_SFRPAGE;P0S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0S_3               set_SFRS_SFRPAGE;P0S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0S_2               set_SFRS_SFRPAGE;P0S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0S_1               set_SFRS_SFRPAGE;P0S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0S_0               set_SFRS_SFRPAGE;P0S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P0M2    B2H PAGE0 ****/
+#define set_P0M2_7              clr_SFRS_SFRPAGE;P0M2|=0x80
+#define set_P0M2_6              clr_SFRS_SFRPAGE;P0M2|=0x40
+#define set_P0M2_5              clr_SFRS_SFRPAGE;P0M2|=0x20 
+#define set_P0M2_4              clr_SFRS_SFRPAGE;P0M2|=0x10
+#define set_P0M2_3              clr_SFRS_SFRPAGE;P0M2|=0x08
+#define set_P0M2_2              clr_SFRS_SFRPAGE;P0M2|=0x04
+#define set_P0M2_1              clr_SFRS_SFRPAGE;P0M2|=0x02
+#define set_P0M2_0              clr_SFRS_SFRPAGE;P0M2|=0x01
+                                
+#define clr_P0M2_7              clr_SFRS_SFRPAGE;P0M2&=0x7F
+#define clr_P0M2_6              clr_SFRS_SFRPAGE;P0M2&=0xBF
+#define clr_P0M2_5              clr_SFRS_SFRPAGE;P0M2&=0xDF
+#define clr_P0M2_4              clr_SFRS_SFRPAGE;P0M2&=0xEF
+#define clr_P0M2_3              clr_SFRS_SFRPAGE;P0M2&=0xF7
+#define clr_P0M2_2              clr_SFRS_SFRPAGE;P0M2&=0xFB
+#define clr_P0M2_1              clr_SFRS_SFRPAGE;P0M2&=0xFD
+#define clr_P0M2_0              clr_SFRS_SFRPAGE;P0M2&=0xFE
+
+/**** P0SR    B0H PAGE1 ****/ 
+#define set_P0SR_7              set_SFRS_SFRPAGE;P0SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P0SR_6              set_SFRS_SFRPAGE;P0SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P0SR_5              set_SFRS_SFRPAGE;P0SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P0SR_4              set_SFRS_SFRPAGE;P0SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P0SR_3              set_SFRS_SFRPAGE;P0SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P0SR_2              set_SFRS_SFRPAGE;P0SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P0SR_1              set_SFRS_SFRPAGE;P0SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P0SR_0              set_SFRS_SFRPAGE;P0SR|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_P0SR_7              set_SFRS_SFRPAGE;P0SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P0SR_6              set_SFRS_SFRPAGE;P0SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P0SR_5              set_SFRS_SFRPAGE;P0SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P0SR_4              set_SFRS_SFRPAGE;P0SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P0SR_3              set_SFRS_SFRPAGE;P0SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P0SR_2              set_SFRS_SFRPAGE;P0SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P0SR_1              set_SFRS_SFRPAGE;P0SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P0SR_0              set_SFRS_SFRPAGE;P0SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M1  B3H PAGE0 ****/
+#define set_P1M1_7              clr_SFRS_SFRPAGE;P1M1|=0x80
+#define set_P1M1_6              clr_SFRS_SFRPAGE;P1M1|=0x40
+#define set_P1M1_5              clr_SFRS_SFRPAGE;P1M1|=0x20 
+#define set_P1M1_4              clr_SFRS_SFRPAGE;P1M1|=0x10
+#define set_P1M1_3              clr_SFRS_SFRPAGE;P1M1|=0x08
+#define set_P1M1_2              clr_SFRS_SFRPAGE;P1M1|=0x04
+#define set_P1M1_1              clr_SFRS_SFRPAGE;P1M1|=0x02
+#define set_P1M1_0              clr_SFRS_SFRPAGE;P1M1|=0x01
+                                
+#define clr_P1M1_7              clr_SFRS_SFRPAGE;P1M1&=0x7F
+#define clr_P1M1_6              clr_SFRS_SFRPAGE;P1M1&=0xBF
+#define clr_P1M1_5              clr_SFRS_SFRPAGE;P1M1&=0xDF
+#define clr_P1M1_4              clr_SFRS_SFRPAGE;P1M1&=0xEF
+#define clr_P1M1_3              clr_SFRS_SFRPAGE;P1M1&=0xF7
+#define clr_P1M1_2              clr_SFRS_SFRPAGE;P1M1&=0xFB
+#define clr_P1M1_1              clr_SFRS_SFRPAGE;P1M1&=0xFD
+#define clr_P1M1_0              clr_SFRS_SFRPAGE;P1M1&=0xFE
+
+/**** P1S B3H PAGE1 ****/ 
+#define set_P1S_7               set_SFRS_SFRPAGE;P1S|=0x80;clr_SFRS_SFRPAGE
+#define set_P1S_6               set_SFRS_SFRPAGE;P1S|=0x40;clr_SFRS_SFRPAGE
+#define set_P1S_5               set_SFRS_SFRPAGE;P1S|=0x20;clr_SFRS_SFRPAGE
+#define set_P1S_4               set_SFRS_SFRPAGE;P1S|=0x10;clr_SFRS_SFRPAGE
+#define set_P1S_3               set_SFRS_SFRPAGE;P1S|=0x08;clr_SFRS_SFRPAGE
+#define set_P1S_2               set_SFRS_SFRPAGE;P1S|=0x04;clr_SFRS_SFRPAGE
+#define set_P1S_1               set_SFRS_SFRPAGE;P1S|=0x02;clr_SFRS_SFRPAGE
+#define set_P1S_0               set_SFRS_SFRPAGE;P1S|=0x01;clr_SFRS_SFRPAGE
+         
+#define clr_P1S_7               set_SFRS_SFRPAGE;P1S&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1S_6               set_SFRS_SFRPAGE;P1S&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1S_5               set_SFRS_SFRPAGE;P1S&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1S_4               set_SFRS_SFRPAGE;P1S&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1S_3               set_SFRS_SFRPAGE;P1S&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1S_2               set_SFRS_SFRPAGE;P1S&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1S_1               set_SFRS_SFRPAGE;P1S&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1S_0               set_SFRS_SFRPAGE;P1S&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P1M2    B4H PAGE0 ****/                      
+#define set_P12UP               clr_SFRS_SFRPAGE;P1M2|=0x04
+#define set_P1M2_1              clr_SFRS_SFRPAGE;P1M2|=0x02
+#define set_P1M2_0              clr_SFRS_SFRPAGE;P1M2|=0x01
+                                    
+#define clr_P12UP               clr_SFRS_SFRPAGE;P1M2&=0xFB
+#define clr_P1M2_1              clr_SFRS_SFRPAGE;P1M2&=0xFD
+#define clr_P1M2_0              clr_SFRS_SFRPAGE;P1M2&=0xFE
+
+/**** P1SR    B4H PAGE1 ****/ 
+#define set_P1SR_7              set_SFRS_SFRPAGE;P1SR|=0x80;clr_SFRS_SFRPAGE
+#define set_P1SR_6              set_SFRS_SFRPAGE;P1SR|=0x40;clr_SFRS_SFRPAGE
+#define set_P1SR_5              set_SFRS_SFRPAGE;P1SR|=0x20;clr_SFRS_SFRPAGE
+#define set_P1SR_4              set_SFRS_SFRPAGE;P1SR|=0x10;clr_SFRS_SFRPAGE
+#define set_P1SR_3              set_SFRS_SFRPAGE;P1SR|=0x08;clr_SFRS_SFRPAGE
+#define set_P1SR_2              set_SFRS_SFRPAGE;P1SR|=0x04;clr_SFRS_SFRPAGE
+#define set_P1SR_1              set_SFRS_SFRPAGE;P1SR|=0x02;clr_SFRS_SFRPAGE
+#define set_P1SR_0              set_SFRS_SFRPAGE;P1SR|=0x01;clr_SFRS_SFRPAGE
+                                                                            
+#define clr_P1SR_7              set_SFRS_SFRPAGE;P1SR&=0x7F;clr_SFRS_SFRPAGE
+#define clr_P1SR_6              set_SFRS_SFRPAGE;P1SR&=0xBF;clr_SFRS_SFRPAGE
+#define clr_P1SR_5              set_SFRS_SFRPAGE;P1SR&=0xDF;clr_SFRS_SFRPAGE
+#define clr_P1SR_4              set_SFRS_SFRPAGE;P1SR&=0xEF;clr_SFRS_SFRPAGE
+#define clr_P1SR_3              set_SFRS_SFRPAGE;P1SR&=0xF7;clr_SFRS_SFRPAGE
+#define clr_P1SR_2              set_SFRS_SFRPAGE;P1SR&=0xFB;clr_SFRS_SFRPAGE
+#define clr_P1SR_1              set_SFRS_SFRPAGE;P1SR&=0xFD;clr_SFRS_SFRPAGE
+#define clr_P1SR_0              set_SFRS_SFRPAGE;P1SR&=0xFE;clr_SFRS_SFRPAGE
+
+/**** P2S    B5H ****/
+#define set_P2S_0               P2S|= 0x01
+#define clr_P2S_0               P2S&= 0xFE
+
+/**** IPH    B7H PAGE0 ****/                    
+#define set_PADCH               clr_SFRS_SFRPAGE;IPH|=0x40
+#define set_PBODH               clr_SFRS_SFRPAGE;IPH|=0x20
+#define set_PSH                 clr_SFRS_SFRPAGE;IPH|=0x10
+#define set_PT1H                clr_SFRS_SFRPAGE;IPH|=0x08
+#define set_PX11                clr_SFRS_SFRPAGE;IPH|=0x04
+#define set_PT0H                clr_SFRS_SFRPAGE;IPH|=0x02
+#define set_PX0H                clr_SFRS_SFRPAGE;IPH|=0x01
+                                    
+#define clr_PADCH               clr_SFRS_SFRPAGE;IPH&=0xBF
+#define clr_PBODH               clr_SFRS_SFRPAGE;IPH&=0xDF
+#define clr_PSH                 clr_SFRS_SFRPAGE;IPH&=0xEF
+#define clr_PT1H                clr_SFRS_SFRPAGE;IPH&=0xF7
+#define clr_PX11                clr_SFRS_SFRPAGE;IPH&=0xFB
+#define clr_PT0H                clr_SFRS_SFRPAGE;IPH&=0xFD
+#define clr_PX0H                clr_SFRS_SFRPAGE;IPH&=0xFE
+
+/**** PWMINTC B7H PAGE1 ****/  
+#define set_INTTYP1             set_SFRS_SFRPAGE;PWMINTC|=0x20;clr_SFRS_SFRPAGE
+#define set_INTTYP0             set_SFRS_SFRPAGE;PWMINTC|=0x10;clr_SFRS_SFRPAGE
+#define set_INTSEL2             set_SFRS_SFRPAGE;PWMINTC|=0x04;clr_SFRS_SFRPAGE
+#define set_INTSEL1             set_SFRS_SFRPAGE;PWMINTC|=0x02;clr_SFRS_SFRPAGE
+#define set_INTSEL0             set_SFRS_SFRPAGE;PWMINTC|=0x01;clr_SFRS_SFRPAGE
+
+#define clr_INTTYP1             set_SFRS_SFRPAGE;PWMINTC&=0xDF;clr_SFRS_SFRPAGE
+#define clr_INTTYP0             set_SFRS_SFRPAGE;PWMINTC&=0xEF;clr_SFRS_SFRPAGE
+#define clr_INTSEL2             set_SFRS_SFRPAGE;PWMINTC&=0xFB;clr_SFRS_SFRPAGE
+#define clr_INTSEL1             set_SFRS_SFRPAGE;PWMINTC&=0xFD;clr_SFRS_SFRPAGE
+#define clr_INTSEL0             set_SFRS_SFRPAGE;PWMINTC&=0xFE;clr_SFRS_SFRPAGE
+
+/**** IP    B8H ****/
+#define set_PADC                PADC     = 1
+#define set_PBOD                PBOD     = 1
+#define set_PS                  PS       = 1
+#define set_PT1                 PT1      = 1
+#define set_PX1                 PX1      = 1
+#define set_PT0                 PT0      = 1
+#define set_PX0                 PX0      = 1
+                                
+#define clr_PADC                PADC     = 0
+#define clr_PBOD                PBOD     = 0
+#define clr_PS                  PS       = 0
+#define clr_PT1                 PT1      = 0
+#define clr_PX1                 PX1      = 0
+#define clr_PT0                 PT0      = 0
+#define clr_PX0                 PX0      = 0
+
+/**** SADEN    B9H ****/
+/**** SADEN_1  8AH ****/
+/**** SADDR_1  BBH ****/
+/**** I2DAT    BCH ****/
+/**** I2STAT    BDH ****/
+/**** I2CLK    BEH ****/
+
+/**** I2TOC    BFH ****/
+#define set_I2TOCEN             I2TOC|=0x04
+#define set_DIV                 I2TOC|=0x02
+#define set_I2TOF               I2TOC|=0x01
+                                
+#define clr_I2TOCEN             I2TOC&=0xFB
+#define clr_DIV                 I2TOC&=0xFD
+#define clr_I2TOF               I2TOC&=0xFE
+
+/**** I2CON  C0H ****/ 
+#define set_I2CEN               I2CEN    = 1
+#define set_STA                 STA      = 1
+#define set_STO                 STO      = 1
+#define set_SI                  SI       = 1
+#define set_AA                  AA       = 1
+#define set_I2CPX               I2CPX    = 1
+
+#define clr_I2CEN               I2CEN    = 0
+#define clr_STA                 STA      = 0
+#define clr_STO                 STO      = 0
+#define clr_SI                  SI       = 0
+#define clr_AA                  AA       = 0
+#define clr_I2CPX               I2CPX    = 0 
+
+/**** I2ADDR    C1H ****/
+#define set_GC                  I2ADDR|=0x01
+#define clr_GC                  I2ADDR&=0xFE
+
+/**** ADCRL    C2H ****/
+/**** ADCRH    C3H ****/
+
+/**** T3CON    C4H  PAGE0 ****/                     
+#define set_SMOD_1              clr_SFRS_SFRPAGE;T3CON|=0x80
+#define set_SMOD0_1             clr_SFRS_SFRPAGE;T3CON|=0x40
+#define set_BRCK                clr_SFRS_SFRPAGE;T3CON|=0x20
+#define set_TF3                 clr_SFRS_SFRPAGE;T3CON|=0x10
+#define set_TR3                 clr_SFRS_SFRPAGE;T3CON|=0x08
+#define set_T3PS2               clr_SFRS_SFRPAGE;T3CON|=0x04
+#define set_T3PS1               clr_SFRS_SFRPAGE;T3CON|=0x02
+#define set_T3PS0               clr_SFRS_SFRPAGE;T3CON|=0x01
+                                     
+#define clr_SMOD_1              clr_SFRS_SFRPAGE;T3CON&=0x7F
+#define clr_SMOD0_1             clr_SFRS_SFRPAGE;T3CON&=0xBF
+#define clr_BRCK                clr_SFRS_SFRPAGE;T3CON&=0xDF
+#define clr_TF3                 clr_SFRS_SFRPAGE;T3CON&=0xEF
+#define clr_TR3                 clr_SFRS_SFRPAGE;T3CON&=0xF7
+#define clr_T3PS2               clr_SFRS_SFRPAGE;T3CON&=0xFB
+#define clr_T3PS1               clr_SFRS_SFRPAGE;T3CON&=0xFD
+#define clr_T3PS0               clr_SFRS_SFRPAGE;T3CON&=0xFE
+
+/**** PWM4H  C4H  PAGE1 ****/ 
+/**** RL3    C5H PAGE0 ****/
+/**** PWM5H  C5H PAGE1 ****/ 
+/**** RH3    C6H PAGE0 ****/
+
+/**** PIOCON1 C6H PAGE1 ****/ 
+#define set_PIO15               set_SFRS_SFRPAGE;PIOCON1|=0x20;clr_SFRS_SFRPAGE
+#define set_PIO13               set_SFRS_SFRPAGE;PIOCON1|=0x08;clr_SFRS_SFRPAGE
+#define set_PIO12               set_SFRS_SFRPAGE;PIOCON1|=0x04;clr_SFRS_SFRPAGE
+#define set_PIO11               set_SFRS_SFRPAGE;PIOCON1|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_PIO15               set_SFRS_SFRPAGE;PIOCON1&=0xDF;clr_SFRS_SFRPAGE
+#define clr_PIO13               set_SFRS_SFRPAGE;PIOCON1&=0xF7;clr_SFRS_SFRPAGE
+#define clr_PIO12               set_SFRS_SFRPAGE;PIOCON1&=0xFB;clr_SFRS_SFRPAGE
+#define clr_PIO11               set_SFRS_SFRPAGE;PIOCON1&=0xFD;clr_SFRS_SFRPAGE
+
+/**** T2CON  C8H ****/
+#define set_TF2                 TF2      = 1
+#define set_TR2                 TR2      = 1
+#define set_CMRL2               CM_RL2   = 1
+                                
+#define clr_TF2                 TF2      = 0
+#define clr_TR2                 TR2      = 0
+#define clr_CMRL2               CM_RL2   = 0
+
+/**** T2MOD  C9H ****/                     
+#define set_LDEN                T2MOD|=0x80
+#define set_T2DIV2              T2MOD|=0x40
+#define set_T2DIV1              T2MOD|=0x20
+#define set_T2DIV0              T2MOD|=0x10
+#define set_CAPCR               T2MOD|=0x08
+#define set_CMPCR               T2MOD|=0x04
+#define set_LDTS1               T2MOD|=0x02
+#define set_LDTS0               T2MOD|=0x01
+                                     
+#define clr_LDEN                T2MOD&=0x7F
+#define clr_T2DIV2              T2MOD&=0xBF
+#define clr_T2DIV1              T2MOD&=0xDF
+#define clr_T2DIV0              T2MOD&=0xEF
+#define clr_CAPCR               T2MOD&=0xF7
+#define clr_CMPCR               T2MOD&=0xFB
+#define clr_LDTS1               T2MOD&=0xFD
+#define clr_LDTS0               T2MOD&=0xFE
+
+/**** RCMP2H CAH ****/
+/**** RCMP2L CBH ****/
+/**** TL2    CCH PAGE0 ****/
+/**** PWM4L   CCH PAGE1 ****/ 
+/**** TH2    CDH PAGE0 ****/
+/**** PWM5L  CDH PAGE1 ****/ 
+/**** ADCMPL  CEH ****/ 
+/**** ADCMPH  CFH ****/
+
+/****  PSW     D0H ****/
+#define set_CY                   CY  = 1
+#define set_AC                   AC  = 1
+#define set_F0                   F0  = 1 
+#define set_RS1                  RS1 = 1
+#define set_RS0                  RS0 = 1
+#define set_OV                   OV  = 1
+#define set_P                    P   = 1
+                                 
+#define clr_CY                   CY  = 0
+#define clr_AC                   AC  = 0
+#define clr_F0                   F0  = 0 
+#define clr_RS1                  RS1 = 0
+#define clr_RS0                  RS0 = 0
+#define clr_OV                   OV  = 0
+#define clr_P                    P   = 0
+
+/**** PWMPH    D1H ****/
+/**** PWM0H    D2H ****/
+/**** PWM1H    D3H ****/
+/**** PWM2H    D4H ****/
+/**** PWM3H    D5H ****/
+
+/**** PNP      D6H ****/
+#define set_PNP5                 PNP|=0x20
+#define set_PNP4                 PNP|=0x10
+#define set_PNP3                 PNP|=0x08
+#define set_PNP2                 PNP|=0x04
+#define set_PNP1                 PNP|=0x02
+#define set_PNP0                 PNP|=0x01
+                                 
+#define clr_PNP5                 PNP&=0xDF
+#define clr_PNP4                 PNP&=0xEF
+#define clr_PNP3                 PNP&=0xF7
+#define clr_PNP2                 PNP&=0xFB
+#define clr_PNP1                 PNP&=0xFD
+#define clr_PNP0                 PNP&=0xFE
+
+/**** FBD    D7H ****/
+#define set_FBF                  FBD|=0x80
+#define set_FBINLS               FBD|=0x40
+#define set_FBD5                 FBD|=0x20
+#define set_FBD4                 FBD|=0x10
+#define set_FBD3                 FBD|=0x08
+#define set_FBD2                 FBD|=0x04
+#define set_FBD1                 FBD|=0x02
+#define set_FBD0                 FBD|=0x01
+                                 
+#define clr_FBF                  FBD&=0x7F
+#define clr_FBINLS               FBD&=0xBF
+#define clr_FBD5                 FBD&=0xDF
+#define clr_FBD4                 FBD&=0xEF
+#define clr_FBD3                 FBD&=0xF7
+#define clr_FBD2                 FBD&=0xFB
+#define clr_FBD1                 FBD&=0xFD
+#define clr_FBD0                 FBD&=0xFE
+
+/**** PWMCON0      D8H ****/
+#define set_PWMRUN               PWMRUN   = 1
+#define set_LOAD                 LOAD     = 1
+#define set_PWMF                 PWMF     = 1
+#define set_CLRPWM               CLRPWM   = 1
+                                 
+#define clr_PWMRUN               PWMRUN   = 0
+#define clr_LOAD                 LOAD     = 0
+#define clr_PWMF                 PWMF     = 0 
+#define clr_CLRPWM               CLRPWM   = 0
+
+/**** PWMPL    D9H ****/
+/**** PWM0L    DAH ****/
+/**** PWM1L    DBH ****/
+/**** PWM2L    DCH ****/
+/**** PWM3L    DDH ****/
+
+/**** PIOCON0  DEH ****/
+#define set_PIO05                PIOCON0|=0x20
+#define set_PIO04                PIOCON0|=0x10
+#define set_PIO03                PIOCON0|=0x08
+#define set_PIO02                PIOCON0|=0x04
+#define set_PIO01                PIOCON0|=0x02
+#define set_PIO00                PIOCON0|=0x01
+                                 
+#define clr_PIO05                PIOCON0&=0xDF
+#define clr_PIO04                PIOCON0&=0xEF
+#define clr_PIO03                PIOCON0&=0xF7
+#define clr_PIO02                PIOCON0&=0xFB
+#define clr_PIO01                PIOCON0&=0xFD
+#define clr_PIO00                PIOCON0&=0xFE
+
+/**** PWMCON1  DFH ****/
+#define set_PWMMOD1              PWMCON1|=0x80
+#define set_PWMMOD0              PWMCON1|=0x40
+#define set_GP                   PWMCON1|=0x20
+#define set_PWMTYP               PWMCON1|=0x10
+#define set_FBINEN               PWMCON1|=0x08
+#define set_PWMDIV2              PWMCON1|=0x04 
+#define set_PWMDIV1              PWMCON1|=0x02
+#define set_PWMDIV0              PWMCON1|=0x01
+                                      
+#define clr_PWMMOD1              PWMCON1&=0x7F
+#define clr_PWMMOD0              PWMCON1&=0xBF
+#define clr_GP                   PWMCON1&=0xDF
+#define clr_PWMTYP               PWMCON1&=0xEF
+#define clr_FBINEN               PWMCON1&=0xF7
+#define clr_PWMDIV2              PWMCON1&=0xFB 
+#define clr_PWMDIV1              PWMCON1&=0xFD
+#define clr_PWMDIV0              PWMCON1&=0xFE
+
+/**** ACC  E0H ****/
+
+/**** ADCCON1  E1H ****/
+#define set_STADCPX              ADCCON1|=0x40
+#define set_ETGTYP1              ADCCON1|=0x08
+#define set_ETGTYP0              ADCCON1|=0x04
+#define set_ADCEX                ADCCON1|=0x02
+#define set_ADCEN                ADCCON1|=0x01
+                                 
+#define clr_STADCPX              ADCCON1&=0xBF
+#define clr_ETGTYP1              ADCCON1&=0xF7
+#define clr_ETGTYP0              ADCCON1&=0xFB
+#define clr_ADCEX                ADCCON1&=0xFD
+#define clr_ADCEN                ADCCON1&=0xFE
+
+/**** ADCON2    E2H ****/
+#define set_ADFBEN               ADCCON2|=0x80
+#define set_ADCMPOP              ADCCON2|=0x40
+#define set_ADCMPEN              ADCCON2|=0x20
+#define set_ADCMPO               ADCCON2|=0x10
+                                 
+#define clr_ADFBEN               ADCCON2&=0x7F
+#define clr_ADCMPOP              ADCCON2&=0xBF
+#define clr_ADCMPEN              ADCCON2&=0xDF
+#define clr_ADCMPO               ADCCON2&=0xEF
+
+/**** ADCDLY    E3H ****/
+/**** C0L      E4H ****/
+/**** C0H      E5H ****/
+/**** C1L      E6H ****/
+/**** C1H      E7H ****/
+
+/**** ADCCON0  EAH ****/
+#define set_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 1
+#define set_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 1
+#define set_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 1
+#define set_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 1
+#define set_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 1
+#define set_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 1
+#define set_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 1
+#define set_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 1
+                                 
+#define clr_ADCF                 clr_SFRS_SFRPAGE;ADCF     = 0
+#define clr_ADCS                 clr_SFRS_SFRPAGE;ADCS     = 0
+#define clr_ETGSEL1              clr_SFRS_SFRPAGE;ETGSEL1  = 0
+#define clr_ETGSEL0              clr_SFRS_SFRPAGE;ETGSEL0  = 0
+#define clr_ADCHS3               clr_SFRS_SFRPAGE;ADCHS3   = 0
+#define clr_ADCHS2               clr_SFRS_SFRPAGE;ADCHS2   = 0
+#define clr_ADCHS1               clr_SFRS_SFRPAGE;ADCHS1   = 0
+#define clr_ADCHS0               clr_SFRS_SFRPAGE;ADCHS0   = 0
+
+/**** PICON  E9H ****/
+#define set_PIT67                PICON|=0x80
+#define set_PIT45                PICON|=0x40
+#define set_PIT3                 PICON|=0x20
+#define set_PIT2                 PICON|=0x10
+#define set_PIT1                 PICON|=0x08
+#define set_PIT0                 PICON|=0x04
+#define set_PIPS1                PICON|=0x02
+#define set_PIPS0                PICON|=0x01
+                                      
+#define clr_PIT67                PICON&=0x7F
+#define clr_PIT45                PICON&=0xBF
+#define clr_PIT3                 PICON&=0xDF
+#define clr_PIT2                 PICON&=0xEF
+#define clr_PIT1                 PICON&=0xF7
+#define clr_PIT0                 PICON&=0xFB
+#define clr_PIPS1                PICON&=0xFD
+#define clr_PIPS0                PICON&=0xFE
+
+/**** PINEN    EAH ****/ 
+#define set_PINEN7               PINEN|=0x80
+#define set_PINEN6               PINEN|=0x40
+#define set_PINEN5               PINEN|=0x20
+#define set_PINEN4               PINEN|=0x10
+#define set_PINEN3               PINEN|=0x08
+#define set_PINEN2               PINEN|=0x04
+#define set_PINEN1               PINEN|=0x02
+#define set_PINEN0               PINEN|=0x01
+                                      
+#define clr_PINEN7               PINEN&=0x7F
+#define clr_PINEN6               PINEN&=0xBF
+#define clr_PINEN5               PINEN&=0xDF
+#define clr_PINEN4               PINEN&=0xEF
+#define clr_PINEN3               PINEN&=0xF7
+#define clr_PINEN2               PINEN&=0xFB
+#define clr_PINEN1               PINEN&=0xFD
+#define clr_PINEN0               PINEN&=0xFE
+                            
+/**** PIPEN     EBH ****/
+#define set_PIPEN7               PIPEN|=0x80
+#define set_PIPEN6               PIPEN|=0x40
+#define set_PIPEN5               PIPEN|=0x20
+#define set_PIPEN4               PIPEN|=0x10
+#define set_PIPEN3               PIPEN|=0x08
+#define set_PIPEN2               PIPEN|=0x04
+#define set_PIPEN1               PIPEN|=0x02
+#define set_PIPEN0               PIPEN|=0x01
+                                      
+#define clr_PIPEN7               PIPEN&=0x7F
+#define clr_PIPEN6               PIPEN&=0xBF
+#define clr_PIPEN5               PIPEN&=0xDF
+#define clr_PIPEN4               PIPEN&=0xEF
+#define clr_PIPEN3               PIPEN&=0xF7
+#define clr_PIPEN2               PIPEN&=0xFB
+#define clr_PIPEN1               PIPEN&=0xFD
+#define clr_PIPEN0               PIPEN&=0xFE
+   
+/**** PIF  ECH ****/
+#define set_PIF7                 PIF|=0x80
+#define set_PIF6                 PIF|=0x40
+#define set_PIF5                 PIF|=0x20
+#define set_PIF4                 PIF|=0x10
+#define set_PIF3                 PIF|=0x08
+#define set_PIF2                 PIF|=0x04
+#define set_PIF1                 PIF|=0x02
+#define set_PIF0                 PIF|=0x01
+                                 
+#define clr_PIF7                 PIF&=0x7F
+#define clr_PIF6                 PIF&=0xBF
+#define clr_PIF5                 PIF&=0xDF
+#define clr_PIF4                 PIF&=0xEF
+#define clr_PIF3                 PIF&=0xF7
+#define clr_PIF2                 PIF&=0xFB
+#define clr_PIF1                 PIF&=0xFD
+#define clr_PIF0                 PIF&=0xFE
+
+/**** C2L  EDH ****/  
+/**** C2H  EEH ****/
+
+/**** EIP  EFH ****/                      
+#define set_PT2                  clr_SFRS_SFRPAGE;EIP|=0x80
+#define set_PSPI                 clr_SFRS_SFRPAGE;EIP|=0x40
+#define set_PFB                  clr_SFRS_SFRPAGE;EIP|=0x20
+#define set_PWDT                 clr_SFRS_SFRPAGE;EIP|=0x10
+#define set_PPWM                 clr_SFRS_SFRPAGE;EIP|=0x08
+#define set_PCAP                 clr_SFRS_SFRPAGE;EIP|=0x04
+#define set_PPI                  clr_SFRS_SFRPAGE;EIP|=0x02
+#define set_PI2C                 clr_SFRS_SFRPAGE;EIP|=0x01
+                                    
+#define clr_PT2                  clr_SFRS_SFRPAGE;EIP&=0x7F
+#define clr_PSPI                 clr_SFRS_SFRPAGE;EIP&=0xBF
+#define clr_PFB                  clr_SFRS_SFRPAGE;EIP&=0xDF
+#define clr_PWDT                 clr_SFRS_SFRPAGE;EIP&=0xEF
+#define clr_PPWM                 clr_SFRS_SFRPAGE;EIP&=0xF7
+#define clr_PCAP                 clr_SFRS_SFRPAGE;EIP&=0xFB
+#define clr_PPI                  clr_SFRS_SFRPAGE;EIP&=0xFD
+#define clr_PI2C                 clr_SFRS_SFRPAGE;EIP&=0xFE
+
+/**** B  F0H ****/
+
+/**** CAPCON3    F1H ****/
+#define set_CAP13                CAPCON3|=0x80
+#define set_CAP12                CAPCON3|=0x40
+#define set_CAP11                CAPCON3|=0x20
+#define set_CAP10                CAPCON3|=0x10
+#define set_CAP03                CAPCON3|=0x08
+#define set_CAP02                CAPCON3|=0x04
+#define set_CAP01                CAPCON3|=0x02
+#define set_CAP00                CAPCON3|=0x01
+                                 
+#define clr_CAP13                CAPCON3&=0x7F
+#define clr_CAP12                CAPCON3&=0xBF
+#define clr_CAP11                CAPCON3&=0xDF
+#define clr_CAP10                CAPCON3&=0xEF
+#define clr_CAP03                CAPCON3&=0xF7
+#define clr_CAP02                CAPCON3&=0xFB
+#define clr_CAP01                CAPCON3&=0xFD
+#define clr_CAP00                CAPCON3&=0xFE
+
+/**** CAPCON4    F2H ****/
+#define set_CAP23                CAPCON4|=0x08
+#define set_CAP22                CAPCON4|=0x04
+#define set_CAP21                CAPCON4|=0x02
+#define set_CAP20                CAPCON4|=0x01
+                                 
+#define clr_CAP23                CAPCON4&=0xF7
+#define clr_CAP22                CAPCON4&=0xFB
+#define clr_CAP21                CAPCON4&=0xFD
+#define clr_CAP20                CAPCON4&=0xFE
+
+/**** SPCR    F3H PAGE0 ****/
+#define set_SSOE                 clr_SFRS_SFRPAGE;SPCR|=0x80
+#define set_SPIEN                clr_SFRS_SFRPAGE;SPCR|=0x40
+#define set_LSBFE                clr_SFRS_SFRPAGE;SPCR|=0x20
+#define set_MSTR                 clr_SFRS_SFRPAGE;SPCR|=0x10
+#define set_CPOL                 clr_SFRS_SFRPAGE;SPCR|=0x08
+#define set_CPHA                 clr_SFRS_SFRPAGE;SPCR|=0x04
+#define set_SPR1                 clr_SFRS_SFRPAGE;SPCR|=0x02
+#define set_SPR0                 clr_SFRS_SFRPAGE;SPCR|=0x01
+                                 
+#define clr_SSOE                 clr_SFRS_SFRPAGE;SPCR&=0x7F
+#define clr_SPIEN                clr_SFRS_SFRPAGE;SPCR&=0xBF
+#define clr_LSBFE                clr_SFRS_SFRPAGE;SPCR&=0xDF
+#define clr_MSTR                 clr_SFRS_SFRPAGE;SPCR&=0xEF
+#define clr_CPOL                 clr_SFRS_SFRPAGE;SPCR&=0xF7
+#define clr_CPHA                 clr_SFRS_SFRPAGE;SPCR&=0xFB
+#define clr_SPR1                 clr_SFRS_SFRPAGE;SPCR&=0xFD
+#define clr_SPR0                 clr_SFRS_SFRPAGE;SPCR&=0xFE
+
+/**** SPCR2    F3H PAGE1 ****/ 
+#define set_SPIS1                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+#define set_SPIS0                set_SFRS_SFRPAGE;SPCR2|=0x02;clr_SFRS_SFRPAGE
+
+#define clr_SPIS1                set_SFRS_SFRPAGE;SPCR2&=0xFD;clr_SFRS_SFRPAGE
+#define clr_SPIS0                set_SFRS_SFRPAGE;SPCR2&=0xFE;clr_SFRS_SFRPAGE
+
+/**** SPSR      F4H ****/
+#define set_SPIF                 SPSR|=0x80
+#define set_WCOL                 SPSR|=0x40
+#define set_SPIOVF               SPSR|=0x20
+#define set_MODF                 SPSR|=0x10
+#define set_DISMODF              SPSR|=0x08
+                                     
+#define clr_SPIF                 SPSR&=0x7F
+#define clr_WCOL                 SPSR&=0xBF
+#define clr_SPIOVF               SPSR&=0xDF
+#define clr_MODF                 SPSR&=0xEF
+#define clr_DISMODF              SPSR&=0xF7
+
+/**** SPDR    F5H ****/
+
+/**** AINDIDS  F6H PAGE0 ****/
+#define set_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x80
+#define set_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x40
+#define set_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x20
+#define set_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x10
+#define set_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x08
+#define set_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x04
+#define set_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x02
+#define set_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS|=0x01
+                                 
+#define clr_P11DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0x7F
+#define clr_P03DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xBF
+#define clr_P04DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xDF
+#define clr_P05DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xEF
+#define clr_P06DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xF7
+#define clr_P07DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFB
+#define clr_P30DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFD
+#define clr_P17DIDS              clr_SFRS_SFRPAGE;AINDIDS&=0xFE
+
+/**** EIPH      F7H ****/
+#define set_PT2H                 clr_SFRS_SFRPAGE;EIPH|=0x80
+#define set_PSPIH                clr_SFRS_SFRPAGE;EIPH|=0x40
+#define set_PFBH                 clr_SFRS_SFRPAGE;EIPH|=0x20
+#define set_PWDTH                clr_SFRS_SFRPAGE;EIPH|=0x10
+#define set_PPWMH                clr_SFRS_SFRPAGE;EIPH|=0x08
+#define set_PCAPH                clr_SFRS_SFRPAGE;EIPH|=0x04
+#define set_PPIH                 clr_SFRS_SFRPAGE;EIPH|=0x02
+#define set_PI2CH                clr_SFRS_SFRPAGE;EIPH|=0x01
+                                     
+#define clr_PT2H                 clr_SFRS_SFRPAGE;EIPH&=0x7F
+#define clr_PSPIH                clr_SFRS_SFRPAGE;EIPH&=0xBF
+#define clr_PFBH                 clr_SFRS_SFRPAGE;EIPH&=0xDF
+#define clr_PWDTH                clr_SFRS_SFRPAGE;EIPH&=0xEF
+#define clr_PPWMH                clr_SFRS_SFRPAGE;EIPH&=0xF7
+#define clr_PCAPH                clr_SFRS_SFRPAGE;EIPH&=0xFB
+#define clr_PPIH                 clr_SFRS_SFRPAGE;EIPH&=0xFD
+#define clr_PI2CH                clr_SFRS_SFRPAGE;EIPH&=0xFE
+
+/**** SCON_1    F8H ****/
+#define set_FE_1                 FE_1  = 1
+#define set_SM1_1                SM1_1 = 1
+#define set_SM2_1                SM2_1 = 1
+#define set_REN_1                REN_1 = 1
+#define set_TB8_1                TB8_1 = 1
+#define set_RB8_1                RB8_1 = 1
+#define set_TI_1                 TI_1  = 1
+#define set_RI_1                 RI_1  = 1
+                                 
+#define clr_FE_1                 FE_1  = 0
+#define clr_SM1_1                SM1_1 = 0
+#define clr_SM2_1                SM2_1 = 0
+#define clr_REN_1                REN_1 = 0
+#define clr_TB8_1                TB8_1 = 0
+#define clr_RB8_1                RB8_1 = 0
+#define clr_TI_1                 TI_1  = 0
+#define clr_RI_1                 RI_1  = 0
+
+/**** PDTEN    F9H ****TA Protect ***/
+#define set_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x04;EA=BIT_TMP
+#define set_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x02;EA=BIT_TMP
+#define set_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN|=0x01;EA=BIT_TMP
+                                
+#define clr_PDT45EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFB;EA=BIT_TMP
+#define clr_PDT23EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFD;EA=BIT_TMP
+#define clr_PDT01EN              BIT_TMP=EA;EA=0;TA=0xAA;TA=0x55;PDTEN&=0xFE;EA=BIT_TMP
+
+/**** PDTCNT    FAH ****/
+
+/**** PMEN     FBH ****/                   
+#define set_PMEN5                PMEN|=0x20
+#define set_PMEN4                PMEN|=0x10
+#define set_PMEN3                PMEN|=0x08
+#define set_PMEN2                PMEN|=0x04
+#define set_PMEN1                PMEN|=0x02
+#define set_PMEN0                PMEN|=0x01
+                                     
+#define clr_PMEN5                PMEN&=0xDF
+#define clr_PMEN4                PMEN&=0xEF
+#define clr_PMEN3                PMEN&=0xF7
+#define clr_PMEN2                PMEN&=0xFB
+#define clr_PMEN1                PMEN&=0xFD
+#define clr_PMEN0                PMEN&=0xFE
+                            
+/**** PMD    FCH ****/                       
+#define set_PMD7                 PMD|=0x80
+#define set_PMD6                 PMD|=0x40
+#define set_PMD5                 PMD|=0x20
+#define set_PMD4                 PMD|=0x10
+#define set_PMD3                 PMD|=0x08
+#define set_PMD2                 PMD|=0x04
+#define set_PMD1                 PMD|=0x02
+#define set_PMD0                 PMD|=0x01
+                                    
+#define clr_PMD7                 PMD&=0x7F
+#define clr_PMD6                 PMD&=0xBF
+#define clr_PMD5                 PMD&=0xDF
+#define clr_PMD4                 PMD&=0xEF
+#define clr_PMD3                 PMD&=0xF7
+#define clr_PMD2                 PMD&=0xFB
+#define clr_PMD1                 PMD&=0xFD
+#define clr_PMD0                 PMD&=0xFE
+
+/****  PORDIS   FDH PAGE0 ****/
+/****  EIP1     FEH PAGE0 ****/                     
+#define set_PWKT                 clr_SFRS_SFRPAGE;EIP1|=0x04
+#define set_PT3                  clr_SFRS_SFRPAGE;EIP1|=0x02
+#define set_PS_1                 clr_SFRS_SFRPAGE;EIP1|=0x01
+                                     
+#define clr_PWKT                 clr_SFRS_SFRPAGE;EIP1&=0xFB
+#define clr_PT3                  clr_SFRS_SFRPAGE;EIP1&=0xFD
+#define clr_PS_1                 clr_SFRS_SFRPAGE;EIP1&=0xFE
+                                 
+/**** EIPH1    FFH PAGE0 ****/                
+#define set_PWKTH                clr_SFRS_SFRPAGE;EIPH1|=0x04
+#define set_PT3H                 clr_SFRS_SFRPAGE;EIPH1|=0x02
+#define set_PSH_1                clr_SFRS_SFRPAGE;EIPH1|=0x01
+                                      
+#define clr_PWKTH                clr_SFRS_SFRPAGE;EIPH1&=0xFB
+#define clr_PT3H                 clr_SFRS_SFRPAGE;EIPH1&=0xFD
+#define clr_PSH_1                clr_SFRS_SFRPAGE;EIPH1&=0xFE

--- a/hardware/victims/firmware/numicro8051/inc/README.md
+++ b/hardware/victims/firmware/numicro8051/inc/README.md
@@ -1,0 +1,1 @@
+Headers taken from https://github.com/OpenNuvoton/NuMicro-8051-Family, lightly edited to remove dependency on stddriver headers.

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes-bootloader/bootloader.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes-bootloader/bootloader.c
@@ -1,0 +1,138 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2017 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aes-independant.h"
+#include "hal.h"
+#include "simpleserial.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#undef DEFAULT_KEY
+#define DEFAULT_KEY 0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c
+#define HASH_KEY 0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6
+
+static uint8_t __data cipher_buf[0x08 + 0x10 + 0x01] = {HASH_KEY};
+static uint8_t key[] = {DEFAULT_KEY};
+static uint8_t IV[16] = {0};
+static uint8_t plaintext[16] = {0};
+static uint32_t mem_addr = 0;
+static uint8_t initialized = 0;
+
+// HASH(key, ciphertext) = MAC
+// buf[:16] = ciphertext
+// buf[16] = MAC
+void AES128_ECB_decrypt(uint8_t* input, uint8_t* key, uint8_t *output);
+uint8_t ss_crc(uint8_t *, uint8_t);
+
+//basically just getting IV
+uint8_t init_bootloader(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t * buf) __reentrant
+{
+    if (initialized) {
+        return 0x12;
+    }
+
+    if (len != 16) {
+        return SS_ERR_LEN;
+    }
+
+    for (uint8_t i = 0; i < 16; i++) {
+        IV[i] = buf[i];
+    }
+    initialized = 1;
+    return 0;
+}
+
+uint8_t set_addr(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf) __reentrant
+{
+    if (len != 4) {
+        return SS_ERR_LEN;
+    }
+    mem_addr = buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24);
+    return 0;
+}
+
+uint8_t read_mem(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf) __reentrant
+{
+    return 0x20; //permission error
+}
+
+uint8_t write_plaintext(uint8_t len, uint8_t *plaintext)
+{
+    mem_addr += len;
+    return 0;
+}
+
+uint8_t bootloader_recv(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf) __reentrant
+{
+    if (!initialized) {
+        return 0x12;
+    }
+
+    if (len != 0x11) {
+        return SS_ERR_LEN;
+    }
+
+    for (int i = 0; i < 16; i++) {
+        cipher_buf[0x08 + i] = buf[i];
+    }
+
+    //calculate MAC
+    trigger_high();
+    uint8_t crc = ss_crc(cipher_buf, 0x08 + 0x10);
+
+    // check that MAC is correct
+    if (crc != buf[16]) {
+        trigger_low();
+        return 0x11;
+    }
+    trigger_low();
+
+    //decrypt
+    AES128_ECB_decrypt(buf, key, plaintext);
+
+    //and do CBC
+    for (int i = 0; i < 16; i++) {
+        plaintext[i] ^= IV[i];
+        IV[i] = buf[i];
+    }
+
+    write_plaintext(16, plaintext);
+    return 0x00;
+}
+
+
+int main(void)
+{
+	static uint8_t tmp[KEY_LENGTH] = {DEFAULT_KEY};
+
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+	aes_indep_init();
+	aes_indep_key(tmp);
+
+	simpleserial_init();
+
+    simpleserial_addcmd(0x00, 0x10, init_bootloader);
+    simpleserial_addcmd(0x01, 0x11, bootloader_recv);
+    simpleserial_addcmd(0x02, 0x04, set_addr);
+    simpleserial_addcmd(0x03, 0x01, read_mem);
+    while(1)
+        simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes-bootloader/makefile
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes-bootloader/makefile
@@ -1,0 +1,52 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = simpleserial-bootloader
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += bootloader.c
+
+#CRYPTO_TARGET = NONE
+#CRYPTO_OPTIONS = NONE
+
+# -----------------------------------------------------------------------------
+ifeq ($(CRYPTO_OPTIONS),)
+CRYPTO_OPTIONS = AES128C
+endif
+
+#Add simpleserial project to build
+include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes/Makefile.platform
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes/Makefile.platform
@@ -1,0 +1,18 @@
+#Multi-Target Board, AVR Device (ATMega328P)
+#PLATFORM = CW301_AVR
+
+#Multi-Target Board, XMEGA Device
+#PLATFORM = CW301_XMEGA
+#Optional - use hardware crypto
+#CDEFS += -DHWCRYPTO=1
+
+#CW-Lite XMEGA Target Device (XMEGA128D4)
+#PLATFORM = CW303
+
+#NOTDUINO Kit (ATMega328P)
+#PLATFORM = CW304
+
+#802.15.4 Attack Platform (ATMega128RFA1)
+#PLATFORM = CW308_MEGARF
+#F_CPU = 16000000
+#CDEFS += -DHWCRYPTO=1

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes/makefile
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes/makefile
@@ -1,0 +1,57 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the base name of the compiled .hex file.
+TARGET = simpleserial-aes
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+#CPPSRC += simpleserial-aes.cpp
+SRC += simpleserial-aes.c
+
+# -----------------------------------------------------------------------------
+EXTRA_OPTS = NO_EXTRA_OPTS
+CFLAGS += -D$(EXTRA_OPTS)
+
+
+ifeq ($(CRYPTO_TARGET),)
+  ${info No CRYPTO_TARGET passed - defaulting to TINYAES128C}
+  CRYPTO_TARGET = TINYAES128C
+endif
+
+${info Building for platform ${PLATFORM} with CRYPTO_TARGET=$(CRYPTO_TARGET)}
+
+#Add simpleserial project to build
+include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes/simpleserial-aes.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes/simpleserial-aes.c
@@ -1,0 +1,166 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2017 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aes-independant.h"
+#include "hal.h"
+#include "simpleserial.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+uint8_t get_mask(uint8_t* m, uint8_t len) __reentrant
+{
+  aes_indep_mask(m, len);
+  return 0x00;
+}
+
+uint8_t get_key(uint8_t* k, uint8_t len) __reentrant
+{
+	aes_indep_key(k);
+	return 0x00;
+}
+
+uint8_t get_pt(uint8_t* pt, uint8_t len) __reentrant
+{
+    aes_indep_enc_pretrigger(pt);
+
+	trigger_high();
+
+  #ifdef ADD_JITTER
+  for (volatile uint8_t k = 0; k < (*pt & 0x0F); k++);
+  #endif
+
+	aes_indep_enc(pt); /* encrypting the data block */
+	trigger_low();
+
+    aes_indep_enc_posttrigger(pt);
+
+	simpleserial_put('r', 16, pt);
+	return 0x00;
+}
+
+uint8_t reset(uint8_t* x, uint8_t len) __reentrant
+{
+    // Reset key here if needed
+	return 0x00;
+}
+
+static uint16_t num_encryption_rounds = 10;
+
+uint8_t enc_multi_getpt(uint8_t* pt, uint8_t len) __reentrant
+{
+    aes_indep_enc_pretrigger(pt);
+
+    for(unsigned int i = 0; i < num_encryption_rounds; i++){
+        trigger_high();
+        aes_indep_enc(pt);
+        trigger_low();
+    }
+
+    aes_indep_enc_posttrigger(pt);
+	simpleserial_put('r', 16, pt);
+    return 0;
+}
+
+uint8_t enc_multi_setnum(uint8_t* t, uint8_t len) __reentrant
+{
+    //Assumes user entered a number like [0, 200] to mean "200"
+    //which is most sane looking for humans I think
+    num_encryption_rounds = t[1];
+    num_encryption_rounds |= t[0] << 8;
+    return 0;
+}
+#if SS_VER == SS_VER_2_1
+uint8_t aes(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf) __reentrant
+{
+    uint8_t req_len = 0;
+    uint8_t err = 0;
+    uint8_t mask_len = 0;
+    if (scmd & 0x04) {
+        // Mask has variable length. First byte encodes the length
+        mask_len = buf[req_len];
+        req_len += 1 + mask_len;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_mask(buf + req_len - mask_len, mask_len);
+        if (err)
+            return err;
+    }
+
+    if (scmd & 0x02) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_key(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+    if (scmd & 0x01) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_pt(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+
+    if (len != req_len) {
+        return SS_ERR_LEN;
+    }
+
+    return 0x00;
+
+}
+#endif
+
+int main(void)
+{
+	static uint8_t tmp[KEY_LENGTH] = {DEFAULT_KEY};
+
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+	aes_indep_init();
+	aes_indep_key(tmp);
+
+    /* Uncomment this to get a HELLO message for debug */
+
+    // putch('h');
+    // putch('e');
+    // putch('l');
+    // putch('l');
+    // putch('o');
+    // putch('\n');
+
+	simpleserial_init();
+    #if SS_VER == SS_VER_2_1
+    simpleserial_addcmd(0x01, 16, aes);
+    #else
+    simpleserial_addcmd('k', 16, get_key);
+    simpleserial_addcmd('p', 16,  get_pt);
+    simpleserial_addcmd('x',  0,   reset);
+    simpleserial_addcmd_flags('m', 18, get_mask, CMD_FLAG_LEN);
+    simpleserial_addcmd('s', 2, enc_multi_setnum);
+    simpleserial_addcmd('f', 16, enc_multi_getpt);
+    #endif
+    while(1)
+        simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-aes/simpleserial-aes.cpp
+++ b/hardware/victims/firmware/numicro8051/simpleserial-aes/simpleserial-aes.cpp
@@ -1,0 +1,168 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2017 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+extern "C" {
+    #include "aes-independant.h"
+    #include "hal.h"
+    #include "simpleserial.h"
+    #include <stdint.h>
+    #include <stdlib.h>
+}
+
+uint8_t get_mask(uint8_t* m, uint8_t len)
+{
+  aes_indep_mask(m, len);
+  return 0x00;
+}
+
+uint8_t get_key(uint8_t* k, uint8_t len)
+{
+	aes_indep_key(k);
+	return 0x00;
+}
+
+uint8_t get_pt(uint8_t* pt, uint8_t len)
+{
+    aes_indep_enc_pretrigger(pt);
+
+	trigger_high();
+
+  #ifdef ADD_JITTER
+  for (volatile uint8_t k = 0; k < (*pt & 0x0F); k++);
+  #endif
+
+	aes_indep_enc(pt); /* encrypting the data block */
+	trigger_low();
+
+    aes_indep_enc_posttrigger(pt);
+
+	simpleserial_put('r', 16, pt);
+	return 0x00;
+}
+
+uint8_t reset(uint8_t* x, uint8_t len)
+{
+    // Reset key here if needed
+	return 0x00;
+}
+
+static uint16_t num_encryption_rounds = 10;
+
+uint8_t enc_multi_getpt(uint8_t* pt, uint8_t len)
+{
+    aes_indep_enc_pretrigger(pt);
+
+    for(unsigned int i = 0; i < num_encryption_rounds; i++){
+        trigger_high();
+        aes_indep_enc(pt);
+        trigger_low();
+    }
+
+    aes_indep_enc_posttrigger(pt);
+	simpleserial_put('r', 16, pt);
+    return 0;
+}
+
+uint8_t enc_multi_setnum(uint8_t* t, uint8_t len)
+{
+    //Assumes user entered a number like [0, 200] to mean "200"
+    //which is most sane looking for humans I think
+    num_encryption_rounds = t[1];
+    num_encryption_rounds |= t[0] << 8;
+    return 0;
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t aes(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf)
+{
+    uint8_t req_len = 0;
+    uint8_t err = 0;
+    uint8_t mask_len = 0;
+    if (scmd & 0x04) {
+        // Mask has variable length. First byte encodes the length
+        mask_len = buf[req_len];
+        req_len += 1 + mask_len;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_mask(buf + req_len - mask_len, mask_len);
+        if (err)
+            return err;
+    }
+
+    if (scmd & 0x02) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_key(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+    if (scmd & 0x01) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_pt(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+
+    if (len != req_len) {
+        return SS_ERR_LEN;
+    }
+
+    return 0x00;
+
+}
+#endif
+
+int main(void)
+{
+	uint8_t tmp[KEY_LENGTH] = {DEFAULT_KEY};
+
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+	aes_indep_init();
+	aes_indep_key(tmp);
+
+    /* Uncomment this to get a HELLO message for debug */
+
+    // putch('h');
+    // putch('e');
+    // putch('l');
+    // putch('l');
+    // putch('o');
+    // putch('\n');
+
+	simpleserial_init();
+    #if SS_VER == SS_VER_2_1
+    simpleserial_addcmd(0x01, 16, aes);
+    #else
+    simpleserial_addcmd('k', 16, get_key);
+    simpleserial_addcmd('p', 16,  get_pt);
+    simpleserial_addcmd('x',  0,   reset);
+    simpleserial_addcmd_flags('m', 18, get_mask, CMD_FLAG_LEN);
+    simpleserial_addcmd('s', 2, enc_multi_setnum);
+    simpleserial_addcmd('f', 16, enc_multi_getpt);
+    #endif
+    while(1)
+        simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-base/makefile
+++ b/hardware/victims/firmware/numicro8051/simpleserial-base/makefile
@@ -1,0 +1,50 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = simpleserial-base
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += simpleserial-base.c
+
+# -----------------------------------------------------------------------------
+
+ifeq ($(CRYPTO_OPTIONS),)
+CRYPTO_OPTIONS = AES128C
+endif
+
+#Add simpleserial project to build
+include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/simpleserial-base/simpleserial-base.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-base/simpleserial-base.c
@@ -1,0 +1,117 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2017 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "simpleserial.h"
+
+uint8_t get_key(uint8_t* k, uint8_t len) __reentrant
+{
+	// Load key here
+	return 0x00;
+}
+
+uint8_t get_pt(uint8_t* pt, uint8_t len) __reentrant
+{
+	/**********************************
+	* Start user-specific code here. */
+	trigger_high();
+
+	//16 hex bytes held in 'pt' were sent
+	//from the computer. Store your response
+	//back into 'pt', which will send 16 bytes
+	//back to computer. Can ignore of course if
+	//not needed
+
+	trigger_low();
+	/* End user-specific code here. *
+	********************************/
+	simpleserial_put('r', 16, pt);
+	return 0x00;
+}
+
+uint8_t reset(uint8_t* x, uint8_t len) __reentrant
+{
+	// Reset key here if needed
+	return 0x00;
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t aes(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf) __reentrant
+{
+    uint8_t req_len = 0;
+    uint8_t err = 0;
+
+    if (scmd & 0x02) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_key(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+    if (scmd & 0x01) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_pt(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+
+    if (len != req_len) {
+        return SS_ERR_LEN;
+    }
+
+    return 0x00;
+
+}
+#endif
+
+int main(void)
+{
+    platform_init();
+	init_uart();
+	trigger_setup();
+
+ 	/* Uncomment this to get a HELLO message for debug */
+	/*
+	putch('h');
+	putch('e');
+	putch('l');
+	putch('l');
+	putch('o');
+	putch('\n');
+	*/
+
+	simpleserial_init();
+#if SS_VER != SS_VER_2_1
+	simpleserial_addcmd('p', 16, get_pt);
+	simpleserial_addcmd('k', 16, get_key);
+	simpleserial_addcmd('x', 0, reset);
+#else
+    simpleserial_addcmd(0x01, 16, aes);
+
+#endif
+	while(1)
+		simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-glitch/Makefile
+++ b/hardware/victims/firmware/numicro8051/simpleserial-glitch/Makefile
@@ -1,0 +1,48 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = simpleserial-glitch
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += simpleserial-glitch.c
+
+# -----------------------------------------------------------------------------
+
+CRYPTO_TARGET=NONE
+
+#Add simpleserial project to build
+include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/simpleserial-glitch/simpleserial-glitch.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-glitch/simpleserial-glitch.c
@@ -1,0 +1,185 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2020 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "simpleserial.h"
+
+//uint8_t infinite_loop(uint8_t* in);
+//uint8_t glitch_loop(uint8_t* in);
+//uint8_t password(uint8_t* pw);
+
+// Make sure no optimization happens for demo glitch logic.
+// #pragma GCC push_options
+// #pragma GCC optimize ("O0")
+
+#if SS_VER == SS_VER_2_1
+uint8_t glitch_loop(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t glitch_loop(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    volatile uint16_t i, j;
+    volatile uint32_t cnt;
+    cnt = 0;
+    trigger_high();
+    for(i=0; i<50; i++){
+        for(j=0; j<50; j++){
+            cnt++;
+        }
+    }
+    trigger_low();
+    simpleserial_put('r', 4, (uint8_t*)&cnt);
+#if SS_VER == SS_VER_2_1
+    return (cnt != 2500) ? 0x10 : 0x00;
+#else
+    return (cnt != 2500);
+#endif
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t glitch_comparison(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t glitch_comparison(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    uint8_t ok = 5;
+    trigger_high();
+    if (*in == 0xA2){
+        ok = 1;
+    } else {
+        ok = 0;
+    }
+    trigger_low();
+    simpleserial_put('r', 1, (uint8_t*)&ok);
+    return 0x00;
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t password(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* pw) __reentrant
+#else
+uint8_t password(uint8_t* pw, uint8_t len) __reentrant
+#endif
+{
+    char passwd[] = "touch";
+    char passok = 1;
+    int cnt;
+
+    trigger_high();
+
+    //Simple test - doesn't check for too-long password!
+    for(cnt = 0; cnt < 5; cnt++){
+        if (pw[cnt] != passwd[cnt]){
+            passok = 0;
+        }
+    }
+
+    trigger_low();
+
+    simpleserial_put('r', 1, (uint8_t*)&passok);
+    return 0x00;
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t infinite_loop(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t infinite_loop(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    led_ok(1);
+    led_error(0);
+
+    //Some fake variable
+    volatile uint8_t a = 0;
+
+    //External trigger logic
+    trigger_high();
+    trigger_low();
+
+    //Should be an infinite loop
+    while(a != 2){
+    ;
+    }
+
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+
+    putch('r');
+    putch('B');
+    putch('R');
+    putch('E');
+    putch('A');
+    putch('K');
+    putch('O');
+    putch('U');
+    putch('T');
+    putch('\n');
+
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+    led_error(1);
+
+    return 0;
+}
+
+// #pragma GCC pop_options
+
+int main(void)
+{
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+    /* Device reset detected */
+    putch('r');
+    putch('R');
+    putch('E');
+    putch('S');
+    putch('E');
+    putch('T');
+    putch(' ');
+    putch(' ');
+    putch(' ');
+    putch('\n');
+
+    simpleserial_init();
+    simpleserial_addcmd('g', 0, glitch_loop);
+    simpleserial_addcmd('c', 1, glitch_comparison);
+    #if SS_VER == SS_VER_2_1
+    simpleserial_addcmd(0x01, 5, password);
+    #else
+    simpleserial_addcmd('p', 5, password);
+    #endif
+    simpleserial_addcmd('i', 0, infinite_loop);
+    while(1)
+        simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-n76-test/Makefile
+++ b/hardware/victims/firmware/numicro8051/simpleserial-n76-test/Makefile
@@ -1,0 +1,48 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = simpleserial-n76-test
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += simpleserial-n76-test.c
+
+# -----------------------------------------------------------------------------
+
+CRYPTO_TARGET=NONE
+
+#Add simpleserial project to build
+include ../simpleserial/Makefile.simpleserial
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc
+

--- a/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
@@ -178,5 +178,6 @@ int main(void)
     simpleserial_addcmd('x', 0, get_rc_trim_values);
     simpleserial_addcmd('y', 0, echo);
     simpleserial_addcmd('b', 0, blink_forever);
-    simpleserial_get();
+    while(1)
+        simpleserial_get();
 }

--- a/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
@@ -1,0 +1,182 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2020 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include "Common.h"
+#include "isp_uart0.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+
+#include "simpleserial.h"
+
+//uint8_t infinite_loop(uint8_t* in);
+//uint8_t glitch_loop(uint8_t* in);
+//uint8_t password(uint8_t* pw);
+
+// Make sure no optimization happens for demo glitch logic.
+// #pragma GCC push_options
+// #pragma GCC optimize ("O0")
+
+void BYTE_READ_FUNC(uint8_t cmd, uint16_t start, uint8_t len, uint8_t *buf)
+{
+  uint8_t i;
+  set_IAPEN;
+  IAPCN = cmd;
+  IAPAH = (start >> 8) & 0xFF;
+  IAPAL = start & 0xFF;
+  for (i = 0; i < len - 1; i++)
+  {
+    set_IAPGO;
+    buf[i] = IAPFD;
+    IAPAL++;
+  }
+  // get the last one
+  set_IAPGO;
+  buf[i] = IAPFD;
+  clr_IAPEN;
+}
+
+#if SS_VER == SS_VER_2_1
+/**
+ * @brief      Get the RC trim values (i.e. the internal clock calibration values)
+*/
+uint8_t get_rc_trim_values(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t get_rc_trim_values(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    static uint8_t __data hircmap[12];
+    hircmap[0] = RCTRIM0;
+    hircmap[1] = RCTRIM1;
+    BYTE_READ_FUNC(READ_UID, 0x30, 10, &hircmap[2]);
+    simpleserial_put('r', 12, hircmap);
+    return 0x00;
+}
+
+
+static uint8_t ROM_DATA[128];
+#if SS_VER == SS_VER_2_1
+/**
+ * @brief      Get various rom data (e.g. CID, UID, etc.)
+ * Expects 8-bit command, 16-bit start address (little endian), 8-bit length in input buffer
+ * Commands are in isp_uart0.h
+*/
+uint8_t get_data(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t get_data(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    if (len < 4) {
+        return SS_ERR_LEN;
+    }
+    volatile uint8_t IAPcmd = in[0];
+    // check to make sure the cmd isn't a program or erase command
+    if (IAPcmd & 0x20) {
+        return 0x18;
+    }
+    // little-endian
+    volatile uint16_t start = in[1] | (((uint16_t)in[2]) << 8);
+    volatile uint8_t length = in[3];
+    if (length > 128) {
+        return 0x17;
+    }
+    
+
+    BYTE_READ_FUNC(IAPcmd, start, length, ROM_DATA);
+
+    simpleserial_put('r', length, ROM_DATA);
+    return 0x00;
+}
+
+
+#if SS_VER == SS_VER_2_1
+// Just echos back the input data
+uint8_t echo(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *in) __reentrant
+#else
+uint8_t echo(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    simpleserial_put('r', len, in);
+    return SS_ERR_OK;
+}
+
+#define TIMER_DIV12_VALUE_10ms_FOSC_160000			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
+// the idea is that the device will blink at different intervals depending on the clock speed
+void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
+{
+    clr_T1M;      // T1M=0, Timer1 Clock = Fsys/12
+    TMOD |= 0x10; // Timer1 is 16-bit mode
+    set_TR1;      // Start Timer1
+    while (u32CNT != 0)
+    {
+        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000);
+        while (TF1 != 1)
+            ; // Check Timer1 Time-Out Flag
+        clr_TF1;
+        u32CNT--;
+    }
+    clr_TR1; // Stop Timer1
+}
+
+#define BLINK_DELAY 50
+
+#if SS_VER == SS_VER_2_1
+uint8_t blink_forever(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t* in) __reentrant
+#else
+uint8_t blink_forever(uint8_t* in, uint8_t len) __reentrant
+#endif
+{
+    #ifdef FOSC_240000
+    led_error(1);
+    #endif
+    while(1)
+    {
+        led_ok(1);
+        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+        led_ok(0);
+        Timer1_Delay10ms_16mhz_vals(BLINK_DELAY);
+    }
+}
+
+int main(void)
+{
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+    /* Device reset detected */
+    putch('r');
+    putch('R');
+    putch('E');
+    putch('S');
+    putch('E');
+    putch('T');
+    putch(' ');
+    putch(' ');
+    putch(' ');
+    putch('\n');
+
+    simpleserial_init();
+    simpleserial_addcmd('n', 4, get_data);
+    simpleserial_addcmd('x', 0, get_rc_trim_values);
+    simpleserial_addcmd('y', 0, echo);
+    simpleserial_addcmd('b', 0, blink_forever);
+    simpleserial_get();
+}

--- a/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial-n76-test/simpleserial-n76-test.c
@@ -116,7 +116,7 @@ uint8_t echo(uint8_t* in, uint8_t len) __reentrant
     return SS_ERR_OK;
 }
 
-#define TIMER_DIV12_VALUE_10ms_FOSC_160000			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
+#define TIMER_DIV12_VALUE_10ms_16MHZ			65536-13334	//13334*12/16000000 = 10 mS 		// Timer divider = 12 
 // the idea is that the device will blink at different intervals depending on the clock speed
 void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
 {
@@ -125,8 +125,8 @@ void Timer1_Delay10ms_16mhz_vals(UINT32 u32CNT)
     set_TR1;      // Start Timer1
     while (u32CNT != 0)
     {
-        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000); // Find  define in "Function_define.h" "TIMER VALUE"
-        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_FOSC_160000);
+        TL1 = LOBYTE(TIMER_DIV12_VALUE_10ms_16MHZ); // Find  define in "Function_define.h" "TIMER VALUE"
+        TH1 = HIBYTE(TIMER_DIV12_VALUE_10ms_16MHZ);
         while (TF1 != 1)
             ; // Check Timer1 Time-Out Flag
         clr_TF1;

--- a/hardware/victims/firmware/numicro8051/simpleserial/Makefile.simpleserial
+++ b/hardware/victims/firmware/numicro8051/simpleserial/Makefile.simpleserial
@@ -1,0 +1,29 @@
+SRC += simpleserial.c
+VPATH += :$(FIRMWAREPATH)/simpleserial/
+EXTRAINCDIRS += $(FIRMWAREPATH)/simpleserial/
+
+SS_VERS_ALLOWED = SS_VER_1_0 SS_VER_1_1 SS_VER_2_0 SS_VER_2_1
+
+define SS_VERS_LIST
+
+  +---------+--------------+
+  | Version | SS_VER value |
+  +---------+--------------+
+  | V1.0    | SS_VER_1_0   |
+  | V1.1    | SS_VER_1_1   |
+  | V2.1    | SS_VER_2_1   |
+  +---------+--------------+
+
+endef
+
+# SimpleSerial version
+# To change this, define SS_VER before including this file
+ifeq ($(SS_VER),)
+  SS_VER = SS_VER_1_1
+else ifeq ($(filter $(SS_VER),$(SS_VERS_ALLOWED)),)
+  $(error Invalid SimpleSerial version: $(SS_VER); allowed verions: $(SS_VERS_LIST))
+endif
+
+${info SS_VER set to $(SS_VER)}
+
+CDEFS += -DSS_VER=$(SS_VER)

--- a/hardware/victims/firmware/numicro8051/simpleserial/simpleserial.c
+++ b/hardware/victims/firmware/numicro8051/simpleserial/simpleserial.c
@@ -1,0 +1,440 @@
+// simpleserial.c
+
+#include "simpleserial.h"
+#include <stdint.h>
+#include "hal.h"
+
+
+#define MAX_SS_CMDS 16
+static int num_commands = 0;
+
+#define MAX_SS_LEN 136 // 128 + 8 padding - max length of return for any current simpleserial command
+
+//#define SS_VER_1_0 0
+//#define SS_VER_1_1 1
+//#define SS_VER_2_0 2
+
+
+// 0xA6 formerly 
+#define CW_CRC 0x4D 
+uint8_t ss_crc(uint8_t *buf, uint8_t len)
+{
+	unsigned int k = 0;
+	uint8_t crc = 0x00;
+	while (len--) {
+		crc ^= *buf++;
+		for (k = 0; k < 8; k++) {
+			crc = crc & 0x80 ? (crc << 1) ^ CW_CRC: crc << 1;
+		}
+	}
+	return crc;
+
+}
+
+// [B_STUFF, CMD, SCMD, LEN, B_STUFF, DATA..., CRC, TERM]
+
+//#define SS_VER SS_VER_2_0
+#if SS_VER == SS_VER_2_0
+#error "SS_VER_2_0 is deprecated! Use SS_VER_2_1 instead."
+#elif SS_VER == SS_VER_2_1
+
+int hex_decode(int len, char* ascii_buf, uint8_t* data_buf)
+{
+	for(int i = 0; i < len; i++)
+	{
+		char n_hi = ascii_buf[2*i];
+		char n_lo = ascii_buf[2*i+1];
+
+		if(n_lo >= '0' && n_lo <= '9')
+			data_buf[i] = n_lo - '0';
+		else if(n_lo >= 'A' && n_lo <= 'F')
+			data_buf[i] = n_lo - 'A' + 10;
+		else if(n_lo >= 'a' && n_lo <= 'f')
+			data_buf[i] = n_lo - 'a' + 10;
+		else
+			return 1;
+
+		if(n_hi >= '0' && n_hi <= '9')
+			data_buf[i] |= (n_hi - '0') << 4;
+		else if(n_hi >= 'A' && n_hi <= 'F')
+			data_buf[i] |= (n_hi - 'A' + 10) << 4;
+		else if(n_hi >= 'a' && n_hi <= 'f')
+			data_buf[i] |= (n_hi - 'a' + 10) << 4;
+		else
+			return 1;
+	}
+
+	return 0;
+}
+
+typedef struct ss_cmd
+{
+	char c;
+	uint8_t len;
+	uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t *) __reentrant;
+} ss_cmd;
+static ss_cmd __xdata commands[MAX_SS_CMDS];
+
+void ss_puts(char *x)
+{
+	do {
+		putch(*x);
+	} while (*++x);
+}
+
+#define FRAME_BYTE 0x00
+
+uint8_t check_version(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *data) __reentrant
+{
+	uint8_t ver = SS_VER;
+	simpleserial_put('r', 1, &ver);
+	return SS_ERR_OK;
+}
+
+uint8_t ss_get_commands(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *data) __reentrant
+{
+    uint8_t cmd_chars[MAX_SS_CMDS];
+    for (uint8_t i = 0; i < (num_commands & 0xFF); i++) {
+        cmd_chars[i] = commands[i].c;
+    }
+
+    simpleserial_put('r', num_commands & 0xFF, (void *)cmd_chars);
+    return 0x00;
+
+}
+
+uint8_t stuff_data(uint8_t *buf, uint8_t len)
+{
+	uint8_t i = 1;
+	uint8_t last = 0;
+	for (; i < len; i++) {
+		if (buf[i] == FRAME_BYTE) {
+			buf[last] = i - last;
+			last = i;
+		}
+	}
+	return 0x00;
+}
+
+uint8_t unstuff_data(uint8_t *buf, uint8_t len)
+{
+	uint8_t next = buf[0];
+	buf[0] = 0x00;
+	//len -= 1;
+	uint8_t tmp = next;
+	while ((next < len) && tmp != 0) {
+		tmp = buf[next];
+		buf[next] = FRAME_BYTE;
+		next += tmp;
+	}
+	return next;
+}
+
+// Set up the SimpleSerial module by preparing internal commands
+// This just adds the "v" command for now...
+void simpleserial_init()
+{
+	simpleserial_addcmd('v', 0, check_version);
+    simpleserial_addcmd('w', 0, ss_get_commands);
+}
+
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t*) __reentrant)
+{
+	if(num_commands >= MAX_SS_CMDS) {
+		putch('a');
+		return 1;
+	}
+
+	if(len >= MAX_SS_LEN) {
+		putch('b');
+		return 1;
+	}
+
+	commands[num_commands].c   = c;
+	commands[num_commands].len = len;
+	commands[num_commands].fp  = fp;
+	num_commands++;
+
+	return 0;
+}
+
+void simpleserial_get(void)
+{
+    static uint8_t __xdata data_buf[MAX_SS_LEN];
+	uint8_t err = 0;
+
+	for (int i = 0; i < 4; i++) {
+		data_buf[i] = getch(); //PTR, cmd, scmd, len
+		if (data_buf[i] == FRAME_BYTE) {
+			err = SS_ERR_FRAME_BYTE;
+			goto ERROR;
+		}
+	}
+	uint8_t next_frame = unstuff_data(data_buf, 4);
+
+	// check for valid command
+	uint8_t c = 0;
+	for(c = 0; c < num_commands; c++)
+	{
+		if(commands[c].c == data_buf[1])
+			break;
+	}
+
+	if (c == num_commands) {
+		err = SS_ERR_CMD;
+		goto ERROR;
+	}
+
+	//check that next frame not beyond end of message
+	// account for cmd, scmd, len, data, crc, end of frame
+	if ((data_buf[3] + 5) < next_frame) {
+		err = SS_ERR_LEN;
+		goto ERROR;
+	}
+
+	// read in data
+	// eq to len + crc + frame end
+	int i = 4;
+	for (; i < data_buf[3] + 5; i++) {
+		data_buf[i] = getch();
+		if (data_buf[i] == FRAME_BYTE) {
+			err = SS_ERR_FRAME_BYTE;
+			goto ERROR;
+		}
+	}
+
+	//check that final byte is the FRAME_BYTE
+	data_buf[i] = getch();
+	if (data_buf[i] != FRAME_BYTE) {
+		err = SS_ERR_LEN;
+		goto ERROR;
+	}
+
+	//fully unstuff data now
+	unstuff_data(data_buf + next_frame, i - next_frame + 1);
+
+	//calc crc excluding original frame offset and frame end and crc
+	uint8_t crc = ss_crc(data_buf+1, i-2);
+	if (crc != data_buf[i-1]) {
+		err = SS_ERR_CRC;
+		goto ERROR;
+	}
+
+	err = commands[c].fp(data_buf[1], data_buf[2], data_buf[3], data_buf+4);
+
+ERROR:
+	simpleserial_put('e', 0x01, &err);
+	return;
+}
+
+void simpleserial_put(char c, uint8_t size, uint8_t* output)
+{
+	static uint8_t __xdata data_buf[MAX_SS_LEN];
+	data_buf[0] = 0x00;
+	data_buf[1] = c;
+	data_buf[2] = size;
+	int i = 0;
+	for (; i < size; i++) {
+		data_buf[i + 3] = output[i];
+	}
+	data_buf[i + 3] = ss_crc(data_buf+1, size+2);
+	data_buf[i + 4] = 0x00;
+	stuff_data(data_buf, i + 5);
+	for (int i = 0; i < size + 5; i++) {
+		putch(data_buf[i]);
+	}
+}
+
+
+#else
+
+typedef struct ss_cmd
+{
+	char c;
+	uint8_t len;
+	uint8_t (*fp)(uint8_t*, uint8_t) __reentrant;
+	uint8_t flags;
+} ss_cmd;
+static ss_cmd __xdata commands[MAX_SS_CMDS];
+// Callback function for "v" command.
+// This can exist in v1.0 as long as we don't actually send back an ack ("z")
+uint8_t check_version(uint8_t *v, uint8_t len)
+{
+	return SS_VER;
+}
+
+uint8_t ss_num_commands(uint8_t *x, uint8_t len)
+{
+    uint8_t ncmds = num_commands & 0xFF;
+    simpleserial_put('r', 0x01, &ncmds);
+    return 0x00;
+}
+
+typedef struct ss_cmd_repr {
+    uint8_t c;
+    uint8_t len;
+    uint8_t flags;
+} ss_cmd_repr;
+
+uint8_t ss_get_commands(uint8_t *x, uint8_t len)
+{
+    ss_cmd_repr __xdata repr_cmd_buf[MAX_SS_CMDS];
+    for (uint8_t i = 0; i < (num_commands & 0xFF); i++) {
+        repr_cmd_buf[i].c = commands[i].c;
+        repr_cmd_buf[i].len = commands[i].len;
+        repr_cmd_buf[i].flags = commands[i].flags;
+    }
+
+    simpleserial_put('r', num_commands * 0x03, (void *) repr_cmd_buf);
+    return 0x00;
+}
+
+static char hex_lookup[16] =
+{
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
+
+int hex_decode(int len, char* ascii_buf, uint8_t* data_buf)
+{
+	for(int i = 0; i < len; i++)
+	{
+		char n_hi = ascii_buf[2*i];
+		char n_lo = ascii_buf[2*i+1];
+
+		if(n_lo >= '0' && n_lo <= '9')
+			data_buf[i] = n_lo - '0';
+		else if(n_lo >= 'A' && n_lo <= 'F')
+			data_buf[i] = n_lo - 'A' + 10;
+		else if(n_lo >= 'a' && n_lo <= 'f')
+			data_buf[i] = n_lo - 'a' + 10;
+		else
+			return 1;
+
+		if(n_hi >= '0' && n_hi <= '9')
+			data_buf[i] |= (n_hi - '0') << 4;
+		else if(n_hi >= 'A' && n_hi <= 'F')
+			data_buf[i] |= (n_hi - 'A' + 10) << 4;
+		else if(n_hi >= 'a' && n_hi <= 'f')
+			data_buf[i] |= (n_hi - 'a' + 10) << 4;
+		else
+			return 1;
+	}
+
+	return 0;
+}
+
+
+
+// Set up the SimpleSerial module by preparing internal commands
+// This just adds the "v" command for now...
+void simpleserial_init()
+{
+	simpleserial_addcmd('v', 0, check_version);
+    simpleserial_addcmd('w', 0, ss_get_commands);
+    simpleserial_addcmd('y', 0, ss_num_commands);
+}
+
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t) __reentrant)
+{
+	return simpleserial_addcmd_flags(c, len, fp, CMD_FLAG_NONE);
+}
+
+int simpleserial_addcmd_flags(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t) __reentrant, uint8_t fl)
+{
+	if(num_commands >= MAX_SS_CMDS)
+		return 1;
+
+	if(len >= MAX_SS_LEN)
+		return 1;
+
+	commands[num_commands].c   = c;
+	commands[num_commands].len = len;
+	commands[num_commands].fp  = fp;
+	commands[num_commands].flags = fl;
+	num_commands++;
+
+	return 0;
+}
+
+void simpleserial_get(void)
+{
+	char __xdata ascii_buf[2*MAX_SS_LEN];
+	uint8_t __xdata data_buf[MAX_SS_LEN];
+	char c;
+
+	// Find which command we're receiving
+	c = getch();
+
+	int cmd;
+	for(cmd = 0; cmd < num_commands; cmd++)
+	{
+		if(commands[cmd].c == c)
+			break;
+	}
+
+	// If we didn't find a match, give up right away
+	if(cmd == num_commands)
+		return;
+
+	// If flag CMD_FLAG_LEN is set, the next byte indicates the sent length
+	if ((commands[cmd].flags & CMD_FLAG_LEN) != 0)
+	{
+		uint8_t l = 0;
+		char buff[2];
+		buff[0] = getch();
+		buff[1] = getch();
+		if (hex_decode(1, buff, &l))
+			return;
+		commands[cmd].len = l;
+	}
+
+	// Receive characters until we fill the ASCII buffer
+	for(int i = 0; i < 2*commands[cmd].len; i++)
+	{
+		c = getch();
+
+		// Check for early \n
+		if(c == '\n' || c == '\r')
+			return;
+
+		ascii_buf[i] = c;
+	}
+
+	// Assert that last character is \n or \r
+	c = getch();
+	if(c != '\n' && c != '\r')
+		return;
+
+	// ASCII buffer is full: convert to bytes
+	// Check for illegal characters here
+	if(hex_decode(commands[cmd].len, ascii_buf, data_buf))
+		return;
+
+	// Callback
+	uint8_t ret[1];
+	ret[0] = commands[cmd].fp(data_buf, commands[cmd].len);
+
+	// Acknowledge (if version is 1.1)
+#if SS_VER == SS_VER_1_1
+	simpleserial_put('z', 1, ret);
+#endif
+}
+
+void simpleserial_put(char c, uint8_t size, uint8_t* output)
+{
+	// Write first character
+	putch(c);
+
+	// Write each byte as two nibbles
+	for(int i = 0; i < size; i++)
+	{
+		putch(hex_lookup[output[i] >> 4 ]);
+		putch(hex_lookup[output[i] & 0xF]);
+	}
+
+	// Write trailing '\n'
+	putch('\n');
+}
+
+#endif

--- a/hardware/victims/firmware/numicro8051/simpleserial/simpleserial.h
+++ b/hardware/victims/firmware/numicro8051/simpleserial/simpleserial.h
@@ -1,0 +1,74 @@
+// simpleserial.h
+// Generic module for interpreting SimpleSerial commands
+
+#ifndef SIMPLESERIAL_H
+#define SIMPLESERIAL_H
+
+#include <stdint.h>
+
+#define SS_VER_1_0 0
+#define SS_VER_1_1 1
+#define SS_VER_2_0 2
+#define SS_VER_2_1 3
+
+#ifndef SS_VER
+	#define SS_VER SS_VER_1_1
+	#warning "SS_VER undefined! Setting SS_VER=SS_VER_1_1"
+#endif
+
+// Set up the SimpleSerial module
+// This prepares any internal commands
+void simpleserial_init(void);
+
+// Add a command to the SimpleSerial module
+// Args:
+// - c:   The character designating this command
+// - len: The number of bytes expected
+// - fp:  A pointer to a callback, which is called after receiving data
+// - fl:  Bitwise OR'd CMD_FLAG_* values. Defaults to CMD_FLAG_NONE when
+//        calling simpleserial_addcmd()
+// Example: simpleserial_addcmd('p', 16, encrypt_text)
+// - Calls encrypt_text() with a 16 byte array after receiving a line
+//   like p00112233445566778899AABBCCDDEEFF\n
+// Notes:
+// - Maximum of 10 active commands
+// - Maximum length of 64 bytes
+// - Returns 1 if either of these fail; otherwise 0
+// - The callback function returns a number in [0x00, 0xFF] as a status code;
+//   in protocol v1.1, this status code is returned through a "z" message
+#if SS_VER == SS_VER_2_1
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t*) __reentrant);
+#else
+
+#define CMD_FLAG_NONE	0x00
+// If this flag is set, the command supports variable length payload.
+// The first byte (hex-encoded) indicates the length.
+#define CMD_FLAG_LEN	0x01
+
+int simpleserial_addcmd_flags(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t) __reentrant, uint8_t);
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t) __reentrant);
+#endif
+
+// Attempt to process a command
+// If a full string is found, the relevant callback function is called
+// Might return without calling a callback for several reasons:
+// - First character didn't match any known commands
+// - One of the characters wasn't in [0-9|A-F|a-f]
+// - Data was too short or too long
+void simpleserial_get(void);
+
+// Write some data to the serial port
+// Prepends the character c to the start of the line
+// Example: simpleserial_put('r', 16, ciphertext)
+void simpleserial_put(char c, uint8_t size, uint8_t* output);
+
+typedef enum ss_err_cmd {
+	SS_ERR_OK,
+	SS_ERR_CMD,
+	SS_ERR_CRC,
+	SS_ERR_TIMEOUT,
+    SS_ERR_LEN,
+    SS_ERR_FRAME_BYTE
+} ss_err_cmd;
+
+#endif // SIMPLESERIAL_H

--- a/hardware/victims/firmware/numicro8051/tools/peep.def
+++ b/hardware/victims/firmware/numicro8051/tools/peep.def
@@ -1,0 +1,7 @@
+replace {
+	mov	%1,%2
+	orl	a%1,%3
+	mov	%2,%1
+} by {
+	orl	%2,%3
+}


### PR DESCRIPTION
This is the first in a series of PRs to land support for the N76E003 (and other NuMicro 8051 CPUs)

I have the programmer working on the CW-lite, but that's going to be a separate PR since it relies on naeusb being updated as well.

I have a repo with instructions and a bunch of examples of how to use it here: https://github.com/nikitalita/n76e003-cw-firmware

## Implementation

`hal` has the necessary functions for the examples, `commonlib` has the common platform functions (setting internal/external cpu, delay, etc.), `inc` contains the platform support headers.

This compiles using SDCC. I managed to port simpleserial and most of the mainline examples to the N76E003. I ended up having to making relatively few modifications; most of these were simply putting the appropriate attributes (`__data`, `__xdata`, etc.) in places such that the SDCC memory allocator was able to cope. Additionally, all functions that were added to simpleserial via `simpleserial_add_cmd()` had to be labelled as `__reentrant` because SDCC would not allocate their parameters on the stack otherwise, which became a problem when the function was called. I would have used `--stack-auto`, but I have never been able to get any program functioning correctly with that enabled on this target.

I had considered simply putting the SDCC attributes directly into the mainline examples and then just `#define`ing them blank, but seeing that nearly every other specialized target gets their own copies of the examples in your stack, I decided to do it that way too.

The biggest changes have mostly to do with the fact that the N76E003 only has 1k of ram in total:
- The max length of the tx/rx buffer in simpleserial was reduced from 255 to 136 (128 was the longest that any current simpleserial command uses, + 8 bytes of padding).
- The only crypto target supported is TINYAES128C, so no `simpleserial-ecc`, `simpleserial-tea`, etc.
- SS_VER_1_x is only supported when there is no crypto target; There isn't enough memory to support it

Since the device definition headers were nearly 1:1 across the NuMicro 8051 line, and many of these chips were pin-for-pin compatible (MS51FB9AE,  MS51FC0AE, and N76S003), I decided to implement support for those as well, since it took so little time. However, I have not tested any of these targets, since I don't have any of those chips.

## Use

I attempted to make this as close to your current build system as I could to make it as painless as possible to integrate into your jupyter examples; all that should be required is changing the parent directory and setting the appropriate clkgen.

`F_CPU=7372800` does work with this, but only when using the external clock. The only supported values when using the internal clock are 16Mhz and 16.6Mhz; the internal oscillator is not designed to support other values and the chip becomes unstable as a result. Additionally, the N76E003 does not function at rates > 16.6Mhz.
