### PR TITLE
Fix docs for updating firmware: udev rules file has been moved to root folder

### DIFF
--- a/docs/firmware.rst
+++ b/docs/firmware.rst
@@ -40,13 +40,8 @@ shown at :ref:`windows-change-drivers`.
 Linux Prerequisites
 =====================
 
-If you are running natively on Linux, you will need to 
-ensure you have access to the serial ports. As of
-ChipWhisperer 5.6, a rule in :code:`chipwhisperer/hardware/50-newae.rules`
-will give serial port access to the current user
-
-Older versions do not include this rule, so it is recommended to replace :code:`/etc/udev/rules.d/50-newae.rules`
-with ChipWhisperer 5.6's :code:`chipwhisperer/hardware/50-newae.rules`, then run :code:`$ sudo udevadm control --reload-rules`
+If you are running on Linux, you will need to ensure you have access to the serial ports and USB devices.
+Instructions on how to install the udev rules can be found in the :ref:`linux install guide <linux-install>`.
 
 =================
 Mac Prerequisites


### PR DESCRIPTION
The file of the udev rules has been moved to the root folder of the repository.
See #512 #513
Since the instructions involve multiple steps (copy file, create group, join group, restart), I think it is best to just reference the instructions from the install guide.