### PR TITLE
fw/mcu/xmega: Fix HAL compilation in gcc 14.2

### DIFF
--- a/firmware/mcu/hal/Makefile.hal
+++ b/firmware/mcu/hal/Makefile.hal
@@ -311,6 +311,7 @@ endif
     endif
   endif
 
+  SRC += hal.c
   include $(HALPATH)/$(HAL)/Makefile.$(HAL)
   CDEFS += -DHAL_TYPE=HAL_$(HAL) -DPLATFORM=$(PLATFORM)
 #endif

--- a/firmware/mcu/hal/hal.c
+++ b/firmware/mcu/hal/hal.c
@@ -16,25 +16,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef XMEGA_HAL_H_
-#define XMEGA_HAL_H_
+#include "hal.h"
 
-//Generic Platform
-#include "uart.h"
+__attribute__((weak)) void led_ok(unsigned int status)
+{
+}
 
-//We want to use the AVR ADC-pins, since they have a seperate power rail
-#define trigger_setup() PORTA.DIRSET = PIN0_bm
-#define trigger_high()  PORTA.OUTSET = PIN0_bm
-#define trigger_low()   PORTA.OUTCLR = PIN0_bm
-
-#define init_uart init_uart0
-#define putch output_ch_0
-#define getch input_ch_0
-
-void HW_AES128_Init(void);
-void HW_AES128_LoadKey(uint8_t * key);
-void HW_AES128_Enc(uint8_t * pt);
-
-#endif //AVR_HAL_H_
-
-   
+__attribute__((weak)) void led_error(unsigned int status)
+{
+}

--- a/firmware/mcu/hal/hal.h
+++ b/firmware/mcu/hal/hal.h
@@ -197,12 +197,7 @@ void platform_init(void);
     
 #endif
 
-__attribute__((weak)) void led_ok(unsigned int status)
-{
-}
-
-__attribute__((weak)) void led_error(unsigned int status)
-{
-}
+void led_ok(unsigned int status);
+void led_error(unsigned int status);
 
 #endif //HAL_H_

--- a/firmware/mcu/hal/xmega/xmega_hal.c
+++ b/firmware/mcu/hal/xmega/xmega_hal.c
@@ -40,6 +40,26 @@ void platform_init(void)
  #endif
 }
 
+#if PLATFORM == CW303
+void led_error(unsigned int status)
+{
+    if (status) {
+        PORTA.OUTCLR = PIN6_bm;
+    } else {
+        PORTA.OUTSET = PIN6_bm;
+    }
+}
+
+void led_ok(unsigned int status)
+{
+    if(status) {
+        PORTA.OUTCLR = PIN5_bm;
+    } else {
+        PORTA.OUTSET = PIN5_bm;
+    }
+}
+#endif
+
 #if HWCRYPTO
 #include "XMEGA_AES_driver.h"
 static uint8_t enckey[16];


### PR DESCRIPTION
So, GCC is getting more and more picky...

A summary of the changes:
1. Do not define weak implementations in include files. They end up in multiple object files and gcc complains about what to do...
2. Create a default dummy implementation of `led_ok` and `led_error` as weak functions inside a `hal.c` file.
3. Instruct hal makefile to compile `hal.c`.
4. Avoid using macros to shadow the weakly defined functions. This is a shadowing problem and it may lead to compilation errors if headers are not very well placed. Instead, hard define those functions in a C file to overwrite the weak implementations.
