### PR TITLE
Bugfix SimpleSerial2.py

### DIFF
--- a/software/chipwhisperer/capture/targets/SimpleSerial2.py
+++ b/software/chipwhisperer/capture/targets/SimpleSerial2.py
@@ -571,7 +571,7 @@ class SimpleSerial2(TargetTemplate):
             return None
 
         if ord(x[-1]) != 0x00:
-            target_logger.error("Missing frame byte at end of packet {}".format(hex(ord[x[-1]])))
+            target_logger.error("Missing frame byte at end of packet {}".format(hex(ord(x[-1]))))
 
         target_logger.debug("2nd read: {}".format(bytearray(x.encode('latin-1'))))
 


### PR DESCRIPTION
Fixed `TypeError: 'builtin_function_or_method' object is not subscriptable` error.