### PR TITLE
New feature: stm32f3 enable clock cycle count

### DIFF
--- a/firmware/mcu/cpu-cycle/cpu-cycle.c
+++ b/firmware/mcu/cpu-cycle/cpu-cycle.c
@@ -1,0 +1,66 @@
+#include "hal.h"
+
+void hal_send_str(const char *in)
+{
+	const char *cur = in;
+	while (*cur)
+		putch(*(cur++));
+}
+
+void hal_send_unsignedll(const char *s, unsigned long long c)
+{
+	int i = 0;
+	char outs[21] = { 0 };
+	if (c < 10) {
+		outs[0] = '0' + c;
+	} else {
+		i = 19;
+		while (c != 0) {
+			/* Method adapted from ""hackers delight":
+			   Creates an approximation of q = (8/10) */
+			unsigned long long q = (c >> 1) + (c >> 2);
+			q = q + (q >> 4);
+			q = q + (q >> 8);
+			q = q + (q >> 16);
+			q = q + (q >> 32);
+			/* Now q = (1/10) */
+			q = q >> 3;
+			/* Since q contains an error due to the bits shifted
+			   out of the value, we only use it to determine the
+			   remainder.  */
+			unsigned long long r = c - ((q << 3) + (q << 1));
+			c = q;
+			/* The remainder might be off by 10, so q may be off by 1 */
+			if (r > 9) {
+				c += 1;
+				r -= 10;
+			}
+			outs[i] = '0' + (unsigned)r;
+			i -= 1;
+		}
+		i += 1;
+	}
+	hal_send_str(s);
+	hal_send_str(outs + i);
+	hal_send_str("\n");
+}
+
+int main(void)
+{
+	platform_init();
+	init_uart();
+	trigger_setup();
+
+	unsigned long long t0, t1;
+	unsigned a = 1;
+	hal_send_str("Hello world\n");
+	for (int i = 0; i < 10; i++) {
+		t0 = hal_get_time();
+		// Do something
+		a *= 2;
+		t1 = hal_get_time();
+		hal_send_unsignedll("Time taken: ", t1-t0);
+	}
+	hal_send_str("Bye world\n");
+	return 0;
+}

--- a/firmware/mcu/cpu-cycle/makefile
+++ b/firmware/mcu/cpu-cycle/makefile
@@ -1,0 +1,42 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+#
+# Makefile for ChipWhisperer SimpleSerial-AES Program
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+# This is the name of the compiled .hex file.
+TARGET = cpu-cycle
+
+# List C source files here.
+# Header files (.h) are automatically pulled in.
+SRC += cpu-cycle.c
+
+# -----------------------------------------------------------------------------
+
+FIRMWAREPATH = ../.
+include $(FIRMWAREPATH)/Makefile.inc

--- a/firmware/mcu/hal/hal.h
+++ b/firmware/mcu/hal/hal.h
@@ -199,5 +199,6 @@ void platform_init(void);
 
 void led_ok(unsigned int status);
 void led_error(unsigned int status);
+uint64_t hal_get_time(void);
 
 #endif //HAL_H_

--- a/firmware/mcu/hal/stm32f3/Makefile.stm32f3
+++ b/firmware/mcu/hal/stm32f3/Makefile.stm32f3
@@ -30,6 +30,7 @@ CPPFLAGS += -mthumb -mfloat-abi=soft -fmessage-length=0 -ffunction-sections
 ASFLAGS += -mthumb -mfloat-abi=soft -fmessage-length=0 -ffunction-sections
 
 CDEFS += -DSTM32F303xC -DSTM32F3 -DSTM32 -DDEBUG
+CDEFS += -DARM_MATH_CM4
 CPPDEFS += -DSTM32F303xC -DSTM32F3 -DSTM32 -DDEBUG
 
 LDFLAGS += --specs=nano.specs --specs=nosys.specs -T $(HALPATH)/stm32f3/LinkerScript.ld -Wl,--gc-sections -lm

--- a/firmware/mcu/hal/stm32f3/stm32f3_hal.c
+++ b/firmware/mcu/hal/stm32f3/stm32f3_hal.c
@@ -153,3 +153,22 @@ void change_ok_led(int x)
 {
 }
 #endif //PLATFORM==CWLITEARM
+
+static volatile unsigned long long overflowcnt = 0;
+
+/* SysTick Interrupt */
+void SysTick_Handler(void)
+{
+	  ++overflowcnt;
+}
+
+uint64_t hal_get_time(void)
+{
+  while (1) {
+    unsigned long long before = overflowcnt;
+    unsigned long long result = (before + 1) * 16777216llu - SysTick->VAL;
+    if (overflowcnt == before) {
+      return result;
+    }
+  }
+}

--- a/firmware/mcu/hal/stm32f3/stm32f3_hal_lowlevel.c
+++ b/firmware/mcu/hal/stm32f3/stm32f3_hal_lowlevel.c
@@ -43,6 +43,7 @@
 #include "stm32f3xx_hal_uart.h"
 #include "stm32f3xx_hal_flash.h"
 #include "stm32f3xx_hal_cortex.h"
+#include "arm_const_structs.h"
 
 #define assert_param(expr) ((void)0U)
 uint32_t hal_sys_tick = 0;
@@ -613,7 +614,8 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
 
   /* Configure the source of time base considering new system clocks settings*/
   //HAL_InitTick (TICK_INT_PRIORITY);
-  
+  SysTick_Config(1 << 24);
+
   return HAL_OK;
 }
 


### PR DESCRIPTION
Counting CPU clock cycles is an important benchmark in cryptoanalysis, but the CW project has not been implemented completely. So I made this PR as a test feature.

========

The starting point is these KWs: SysTick, SysTick_Handler, SystemInit, sysclk

Notice that
  arm_math.h \u2190 arm_const_struct.h
and core_cm{7,4,3,0,0plus}.h contains SysTick_Config, the same code as that in SystemInit in mps2_halc, which will enable clock cycle count, so include arm_math.h at the beginning.

However, we must define the macro ARM_MATH_CM{7,4,3,0,0PLUS} (in arm_math.h) to let core_cm{7,4,3,0,0plus}.h be included, so do -DARM_MATH_CM4 (stm32f3 is CM4)

Then we can use SysTick_Config, SysTick_Handler, etc, the code from mps2_hal.c, to define hal_get_time.

Also, add a test case for `cpu-cycle`.

==========

Remarks on the incomplete CW's CPU cycle count impl:  There are `HAL_Init()`, `HAL_GetTick()`,  commented `HAL_InitTick (TICK_INT_PRIORITY);` in `HAL_RCC_ClockConfig` in the stm32f3 codes, and I tried to enable it to test whether it works, but it did not. (Also similar case on STM32F4 board)

I only test it on STM32F3 & STM32F405 boards. For STM32F4x, things are almost the same, so shall test STM32F3 first.

The submitted code snippets can serve as an additional feature and perhaps require some time to elaborate on it. I believe that this is a highly demanded feature for the people who doing crypto in EE.