### PR TITLE
Update Makefile.inc

### DIFF
--- a/firmware/mcu/Makefile.inc
+++ b/firmware/mcu/Makefile.inc
@@ -281,6 +281,7 @@ LDFLAGS += $(EXTMEMOPTS)
 LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
 LDFLAGS += $(MATH_LIB)
 LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB)
+LDFLAGS += -Wl,--print-memory-usage
 #LDFLAGS += -T linker_script.x
 
 


### PR DESCRIPTION
Show memory usage after linking, useful when creating own targets

Will create a message like below during building
```
LINKING:
-en     simpleserial-aes-CW308_SAM4S.elf ...
Memory region         Used Size  Region Size  %age Used
             rom:        7380 B       128 KB      5.63%
             ram:       78728 B       160 KB     48.05%
```