### PR TITLE
Update SimpleSerial2.py

### DIFF
--- a/software/chipwhisperer/capture/targets/SimpleSerial2.py
+++ b/software/chipwhisperer/capture/targets/SimpleSerial2.py
@@ -788,7 +788,7 @@ class SimpleSerial2(TargetTemplate):
         return self.ser.currently_xoff
 
     def __repr__(self):
-        ret = "SimpleSerial Settings ="
+        ret = "SimpleSerial2 Settings ="
         for line in dict_to_str(self._dict_repr()).split("\n"):
             ret += "\n\t" + line
         return ret
@@ -801,8 +801,8 @@ class SimpleSerial2(TargetTemplate):
         rtn['output_len'] = self.output_len
 
         rtn['baud']     = self.baud
-        rtn['simpleserial_last_read'] = self.simpleserial_last_read
-        rtn['simpleserial_last_sent'] = self.simpleserial_last_sent
+        # rtn['simpleserial_last_read'] = self.simpleserial_last_read
+        # rtn['simpleserial_last_sent'] = self.simpleserial_last_sent
         rtn['xonxoff'] = self.xonxoff
         rtn['currently_xoff'] = self.currently_xoff
         rtn['parity'] = self.parity


### PR DESCRIPTION
The `last_read` `last_write` components are not implemented for SimpleSerialv2 and prevent printing the state of a simpleserial2 target. (As one does during debugging with both the `scope` and `target`.) 

Re-adding the storage of the last received and sent data is a bit more difficult now with the addition of `simpleserial_read_witherrors` as it has many control flow paths. As such taking it out is the easiest way to make the code work again.

This is mostly just a small functionality fix to make expected functionality work again but feature parity between simpleserial and simpleserial2 is to be achieved later.