### PR TITLE
Skip Github actions that have no meaning for a fork or clone of the repo

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
     build-n-publish:
+      if: github.repository == 'newaetech/chipwhisperer'
       name: Build/pub python to testpypi
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/update_minimal.yml
+++ b/.github/workflows/update_minimal.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update_minimal:
+    if: github.repository == 'newaetech/chipwhisperer'
     name: Update minimal
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_private.yml
+++ b/.github/workflows/update_private.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   trigger_action:
+    if: github.repository == 'newaetech/chipwhisperer'
     name: Push dispatch
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Although workflows are disabled by default on forks, some users may wish to enable them either for checking, or because they created a detached fork (i.e., create repo, git push, without using a fork, such as with a locally hosted Github instance). In this case, the publish actions, or those requiring secrets, should not be run.