### PR TITLE
Add missing comma and trailing newline to udev rules

### DIFF
--- a/50-newae.rules
+++ b/50-newae.rules
@@ -13,7 +13,7 @@
 # Match all CW devices and serial ports
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", TAG+="uaccess"
 #   SUBSYSTEM=="tty", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", TAG+="uaccess", SYMLINK+="cw_serial%n"
-#   SUBSYSTEM=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124" TAG+="uaccess", SYMLINK+="cw_bootloader%n"
+#   SUBSYSTEM=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", SYMLINK+="cw_bootloader%n"
 
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", MODE="0664", GROUP="chipwhisperer"
 SUBSYSTEM=="tty", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", MODE="0664", GROUP="chipwhisperer", SYMLINK+="cw_serial%n"


### PR DESCRIPTION
Both of these are recommended for udev rule files.

See [here](https://www.clearpathrobotics.com/assets/guides/melodic/ros/Udev%20Rules.html#things-to-keep-in-mind), bullets 3 & 4, for a (non-authoritative) source.