### PR TITLE
Specify behaviour of `'v'` SimpleSerial command in the documentation

### DIFF
--- a/docs/source/simpleserial.rst
+++ b/docs/source/simpleserial.rst
@@ -240,6 +240,15 @@ Capture->Target communication:
 
 ``'e'`` is reserved for Target->Capture communication.
 
+The output of the ``'v'`` command is a single number between `0x00` and `0x03` mapped to the SimpleSerial versions in ascending order:
+
+.. code::
+
+    0x00 - Version 1.0
+    0x01 - Version 1.1
+    0x02 - Version 2.0
+    0x03 - Version 2.1
+
 Reserved Errors
 -----------------
 

--- a/docs/source/simpleserial.rst
+++ b/docs/source/simpleserial.rst
@@ -240,7 +240,9 @@ Capture->Target communication:
 
 ``'e'`` is reserved for Target->Capture communication.
 
-The output of the ``'v'`` command is a single number between `0x00` and `0x03` mapped to the SimpleSerial versions in ascending order:
+In both SimpleSerial versions, the output of the ``'v'`` command
+is a single number between `0x00` and `0x03` mapped to
+the SimpleSerial versions in ascending order:
 
 .. code::
 

--- a/docs/source/simpleserial.rst
+++ b/docs/source/simpleserial.rst
@@ -241,7 +241,7 @@ Capture->Target communication:
 ``'e'`` is reserved for Target->Capture communication.
 
 In both SimpleSerial versions, the output of the ``'v'`` command
-is a single number between `0x00` and `0x03` mapped to
+is a single number between ``0x00`` and ``0x03`` mapped to
 the SimpleSerial versions in ascending order:
 
 .. code::


### PR DESCRIPTION
As discussed in [this](https://github.com/newaetech/chipwhisperer/issues/555) issue, this simply adds a short explanation about the response of the `'v'` command in the SimpleSerial documentation, in the section on reserved commands.