### PR TITLE
Improve Husky segmented capture API

### DIFF
--- a/software/chipwhisperer/capture/scopes/OpenADC.py
+++ b/software/chipwhisperer/capture/scopes/OpenADC.py
@@ -981,9 +981,13 @@ class OpenADC(util.DisableNewAttr, ChipWhispererCommonInterface):
             return timeout or timeout2
 
     def get_last_trace_segmented(self):
-        """Return last trace assuming it was captued with segmented mode.
+        """Return last trace assuming it was captured with segmented mode.
 
-        NOTE: The length of each returned trace is 1 less sample than requested.
+        For CW-Lite/Pro (fifo_fill_mode="segment"), the trigger occupies one
+        sample slot per segment, so each returned segment is 1 sample shorter
+        than the requested sample count.
+
+        For CW-Husky, segments use the full requested sample count.
 
         Returns:
             2-D numpy array of the last captured traces.
@@ -992,7 +996,10 @@ class OpenADC(util.DisableNewAttr, ChipWhispererCommonInterface):
             Added segmented capture (requires custom bitstream)
         """
 
-        seg_len = self.adc.samples-1
+        if self._is_husky:
+            seg_len = self.adc.samples
+        else:
+            seg_len = self.adc.samples - 1
         num_seg = int(len(self.data_points) / seg_len)
 
         return np.reshape(self.data_points[:num_seg*seg_len], (num_seg, seg_len))

--- a/software/chipwhisperer/capture/scopes/_OpenADCInterface.py
+++ b/software/chipwhisperer/capture/scopes/_OpenADCInterface.py
@@ -1841,6 +1841,10 @@ class TriggerSettings(util.DisableNewAttr):
         if mode not in known_modes:
             raise ValueError("Invalid fill mode %s. Valid modes: %s" % (mode, known_modes), mode)
 
+        if mode == "segment" and self._is_husky:
+            raise ValueError("fifo_fill_mode 'segment' is not supported on CW-Husky. "
+                             "Use scope.adc.segments instead.")
+
         self._set_fifo_fill_mode(mode)
 
         # Segment mode requires samples have an odd divisability to work


### PR DESCRIPTION
## Summary

Two improvements for CW-Husky segmented capture:

### 1. Correct `get_last_trace_segmented()` segment length on Husky

On CW-Husky, segments use the full requested sample count (no trigger slot stolen). Previously this function unconditionally used `samples - 1`, causing progressive misalignment on Husky. Now uses the correct length per platform.

### 2. Reject `fifo_fill_mode = "segment"` on Husky

Setting this mode on Husky is a silent misconfiguration. Now raises `ValueError` directing users to `scope.adc.segments`.